### PR TITLE
Fix Eve production runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,8 @@ COPY --from=production-dependencies /app/node_modules ./node_modules
 COPY --from=build /app/.output ./.output
 COPY --from=build /app/.eve ./.eve
 COPY --from=build /app/.runtime ./.runtime
+# Eve 0.22.5 `start` serves `.output` but still bundles authored modules from this tree.
+COPY --from=build /app/agent ./agent
 COPY --from=build /app/migrations ./migrations
 COPY --from=build /app/resources ./resources
 COPY --from=build /app/package.json ./package.json

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -4,7 +4,7 @@
 
 GitHub-hosted CI runs the complete `compose.test.yaml` suite for pull requests and pushes to
 `develop` or `main`. A successful `main` run requires a new stable version in `package.json`,
-builds five source-free images, publishes immutable tags to GHCR, records artifact attestations,
+builds five container-only images, publishes immutable tags to GHCR, records artifact attestations,
 and prepares `vVERSION` as a draft. CI uploads and byte-verifies every asset before publishing the
 draft as the latest release. A failed rerun may resume only a draft whose tag still resolves to the
 same commit; a published release or unrelated tag requires a package version bump.
@@ -14,6 +14,10 @@ published releases whose API metadata does not report `immutable: true`.
 - `osinara-deployment.json` contains schema version 1, commit SHA, release version, the SHA-256 of
   the exact Compose bytes, and five exact `ghcr.io/nyxandro/...@sha256:...` references;
 - `compose.production.yaml` contains no build context or source bind mount.
+
+The app image contains the authored `agent/` tree because Eve `0.22.5` still bundles those modules
+when `eve start` serves the built `.output`. The server receives no checkout: the source is confined
+to the immutable app image selected by digest.
 
 GitHub Actions uses only the repository `GITHUB_TOKEN`. The workflow grants package, release,
 OIDC, and attestation writes only to the release job. This follows GitHub's current guidance for

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/groq": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "imports": {

--- a/production-release-contract.test.ts
+++ b/production-release-contract.test.ts
@@ -2,7 +2,7 @@
  * Production release and deployment contract tests.
  *
  * Constructs covered:
- * - Source-free first-party Docker targets and OCI provenance labels.
+ * - Container-only first-party Docker targets and OCI provenance labels.
  * - Digest-only production Compose wiring, migration ordering, and isolation boundaries.
  * - Main-only GHCR release workflow with pinned actions and artifact attestations.
  * - Server-only deployment locking, validation, backup, status, and notification flow.
@@ -40,7 +40,7 @@ function service(compose: string, name: string, nextName: string): string {
 }
 
 describe("production container contract", () => {
-  it("publishes five source-free first-party targets with OCI provenance", () => {
+  it("publishes five container-only first-party targets with OCI provenance", () => {
     const dockerfile = readProjectFile("Dockerfile");
     const entrypoint = readProjectFile("scripts/docker-entrypoint.sh");
 
@@ -67,10 +67,11 @@ describe("production container contract", () => {
       "FROM nginx:1.29-alpine@sha256:5616878291a2eed594aee8db4dade5878cf7edcb475e59193904b198d9b830de",
     );
 
-    // Production images receive emitted JavaScript/assets, never the TypeScript source tree.
+    // Eve 0.22.5 serves built output but still bundles authored modules during `eve start`.
     const runtime = dockerfile.slice(dockerfile.indexOf(" AS runtime"));
     expect(runtime).toContain("COPY --from=build /app/.runtime ./.runtime");
-    expect(runtime).not.toMatch(/COPY --from=build \/app\/(agent|scripts|services)\b/);
+    expect(runtime).toContain("COPY --from=build /app/agent ./agent");
+    expect(runtime).not.toMatch(/COPY --from=build \/app\/(scripts|services)\b/);
     expect(entrypoint).toContain("node .runtime/scripts/migrate.js");
     expect(entrypoint).not.toContain("npm run migrate");
   });


### PR DESCRIPTION
## Changes
- include the authored agent tree required by Eve 0.22.5 at startup
- keep host deployments checkout-free and digest-pinned
- bump the immutable release version to 0.1.1

## Verification
- production release contract tests
- TypeScript typecheck
- local runtime image build
- real container smoke test returned ready from /eve/v1/health

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Что изменено

- В production runtime-образ добавлен каталог `agent`, необходимый Eve 0.22.5 для запуска и бандлинга авторских модулей.
- Обновлена версия пакета с `0.1.0` до `0.1.1`.
- Скорректированы production-контрактные тесты: проверяется наличие `agent` и отсутствие `scripts`/`services` в runtime-образе.
- Сохранены checkout-free деплои и digest-pinned сборка.

## Проверка

- Контрактные тесты production-релиза.
- TypeScript typecheck.
- Локальная сборка runtime-образа.
- Smoke-тест готовности контейнера через `/eve/v1/health`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->