### PR TITLE
Reply to triggering Telegram group messages

### DIFF
--- a/agent/channels/telegram.ts
+++ b/agent/channels/telegram.ts
@@ -7,6 +7,7 @@
  * - Durable identity-bound HITL callbacks and replies.
  * - Validated attachment persistence with model-safe workspace references.
  * - Native RichBlockThinking, chat-scoped streaming, and completed Rich Message delivery.
+ * - Verified group replies anchored to the triggering member message.
  */
 import { telegramChannel } from "eve/channels/telegram";
 
@@ -29,6 +30,7 @@ import { authorizeTelegramHitlCallback } from "../lib/telegram-hitl/callback-aut
 import { handleTelegramInputRequested } from "../lib/telegram-hitl/input-request.js";
 import { telegramHitlApprovalRepository } from "../lib/telegram-hitl/approval-repository.js";
 import { handleTelegramSessionFailure } from "../lib/telegram-session-failure.js";
+import { telegramTurnReplyParameters } from "../lib/telegram-reply.js";
 
 export default telegramChannel({
   botUsername: process.env.TELEGRAM_BOT_USERNAME as string,
@@ -51,7 +53,12 @@ export default telegramChannel({
       if (!message) return;
       const sessionId = applicationSessionId(ctx);
       if (!await sessionRepository.isCurrentEveSession(sessionId, ctx.session.id)) return;
-      await postTelegramRichMessage(message, channel.telegram, channel.state);
+      await postTelegramRichMessage(
+        message,
+        channel.telegram,
+        channel.state,
+        telegramTurnReplyParameters(channel.state, ctx),
+      );
       await rekeyTelegramSession(channel, ctx);
     },
     async "message.appended"(data, channel, ctx) {
@@ -66,7 +73,11 @@ export default telegramChannel({
     async "turn.failed"(data, channel, ctx) {
       const sessionId = applicationSessionId(ctx);
       // Eve's Telegram post helper updates both state and the durable continuation token.
-      await channel.telegram.post(formatTelegramTurnFailure(data));
+      const replyParameters = telegramTurnReplyParameters(channel.state, ctx);
+      await channel.telegram.post({
+        ...(replyParameters === undefined ? {} : { reply_parameters: replyParameters }),
+        text: formatTelegramTurnFailure(data),
+      });
       await sessionRepository.recordTurnFailed(sessionId, ctx.session.id);
       await telegramHitlApprovalRepository.clearForEveSession(sessionId, ctx.session.id);
       await rekeyTelegramSession(channel, ctx);

--- a/agent/lib/telegram-hitl/input-request.test.ts
+++ b/agent/lib/telegram-hitl/input-request.test.ts
@@ -44,6 +44,9 @@ describe("createTelegramInputRequestHandler", () => {
           current: {
             attributes: {
               applicationSessionId: "app-session-1",
+              telegramChatId: "-1001",
+              telegramChatType: "supergroup",
+              telegramReplyToMessageId: "77",
               telegramUserId: "101",
             },
             authenticator: "telegram",
@@ -77,6 +80,7 @@ describe("createTelegramInputRequestHandler", () => {
 
     expect(markPendingOperation).toHaveBeenCalledWith("app-session-1", true);
     expect(post).toHaveBeenCalledWith(expect.objectContaining({
+      reply_parameters: { allow_sending_without_reply: true, message_id: 77 },
       text: "Подготавливаю безопасный запрос подтверждения.",
     }));
     expect(post.mock.calls[0]?.[0]).not.toHaveProperty("reply_markup");

--- a/agent/lib/telegram-hitl/input-request.ts
+++ b/agent/lib/telegram-hitl/input-request.ts
@@ -20,6 +20,7 @@ import {
 import { AppError } from "../app-error.js";
 import { applicationSessionId, rekeyTelegramSession } from "../sessions/session-context.js";
 import { sessionRepository } from "../sessions/session-repository.js";
+import { telegramTurnReplyParameters } from "../telegram-reply.js";
 import {
   telegramHitlApprovalRepository,
   type TelegramHitlApprovalRepository,
@@ -106,10 +107,12 @@ export function createTelegramInputRequestHandler(dependencies: InputRequestDepe
       const rendered = renderTelegramInputRequest(localizedRequest, channel.state);
       const replyMarkup = localizeTelegramReplyMarkup(rendered.replyMarkup);
       const callbacks = callbackData(replyMarkup);
+      const replyParameters = telegramTurnReplyParameters(channel.state, ctx);
 
       // The actionable prompt is revealed only after both the route and approver binding are durable.
       const sent = await channel.telegram.post({
         ...(callbacks.length === 0 ? { reply_markup: replyMarkup } : {}),
+        ...(replyParameters === undefined ? {} : { reply_parameters: replyParameters }),
         text: HITL_PREPARING_MESSAGE,
       });
       if (!sent.id) {

--- a/agent/lib/telegram-on-message.test.ts
+++ b/agent/lib/telegram-on-message.test.ts
@@ -269,6 +269,7 @@ describe("createTelegramMessageHandler", () => {
         groupType: "family_private",
         memoryScopes: ["family"],
         sandboxSessionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        telegramReplyToMessageId: "1",
       },
     });
   });

--- a/agent/lib/telegram-on-message.ts
+++ b/agent/lib/telegram-on-message.ts
@@ -315,6 +315,9 @@ export function createTelegramMessageHandler(repositories: TelegramMessageReposi
           telegramChatId: message.chat.id,
           telegramChatType: message.chat.type,
           telegramMessageId: message.messageId,
+          ...(message.chat.type === "private"
+            ? {}
+            : { telegramReplyToMessageId: message.messageId }),
           ...(message.messageThreadId === undefined
             ? {}
             : { telegramMessageThreadId: String(message.messageThreadId) }),

--- a/agent/lib/telegram-reply.test.ts
+++ b/agent/lib/telegram-reply.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Telegram reply-target policy tests.
+ *
+ * Constructs covered:
+ * - `telegramTurnReplyParameters`: binds group output to the verified triggering message.
+ * - Private and non-message turns remain unthreaded.
+ * - Mismatched channel/auth state fails closed.
+ */
+import type { TelegramChannelState } from "eve/channels/telegram";
+import type { SessionContext } from "eve/context";
+import { describe, expect, it } from "vitest";
+
+import { telegramTurnReplyParameters } from "./telegram-reply.js";
+
+function state(chatType: "private" | "supergroup" = "supergroup") {
+  return {
+    chatId: chatType === "private" ? "101" : "-1001",
+    chatType,
+  } as TelegramChannelState;
+}
+
+function context(attributes: Record<string, unknown>) {
+  return {
+    session: {
+      auth: {
+        current: {
+          attributes,
+          authenticator: "telegram",
+          principalId: "user-1",
+          principalType: "user",
+        },
+      },
+    },
+  } as unknown as SessionContext;
+}
+
+describe("telegramTurnReplyParameters", () => {
+  it("replies to the verified message that triggered a group turn", () => {
+    expect(telegramTurnReplyParameters(state(), context({
+      telegramChatId: "-1001",
+      telegramChatType: "supergroup",
+      telegramReplyToMessageId: "77",
+    }))).toEqual({ allow_sending_without_reply: true, message_id: 77 });
+  });
+
+  it("does not add reply metadata to private or callback-originated turns", () => {
+    expect(telegramTurnReplyParameters(state("private"), context({
+      telegramChatId: "101",
+      telegramChatType: "private",
+      telegramReplyToMessageId: "77",
+    }))).toBeUndefined();
+    expect(telegramTurnReplyParameters(state(), context({
+      telegramChatId: "-1001",
+      telegramChatType: "supergroup",
+    }))).toBeUndefined();
+  });
+
+  it("rejects a reply target copied from another Telegram chat", () => {
+    expect(() => telegramTurnReplyParameters(state(), context({
+      telegramChatId: "-1002",
+      telegramChatType: "supergroup",
+      telegramReplyToMessageId: "77",
+    }))).toThrow("AGENT_TELEGRAM_REPLY_CONTEXT_INVALID");
+  });
+});

--- a/agent/lib/telegram-reply.ts
+++ b/agent/lib/telegram-reply.ts
@@ -1,0 +1,52 @@
+/**
+ * Trusted Telegram reply-target policy.
+ *
+ * Exports:
+ * - `TelegramReplyParameters`: Bot API payload for one verified message reply.
+ * - `telegramTurnReplyParameters`: resolves a group reply from current session auth.
+ */
+import type { TelegramChannelState } from "eve/channels/telegram";
+import type { SessionContext } from "eve/context";
+
+import { AppError } from "./app-error.js";
+
+const POSITIVE_MESSAGE_ID_PATTERN = /^[1-9]\d*$/u;
+
+export interface TelegramReplyParameters {
+  readonly [key: string]: boolean | number;
+  readonly allow_sending_without_reply: true;
+  readonly message_id: number;
+}
+
+export function telegramTurnReplyParameters(
+  state: Pick<TelegramChannelState, "chatId" | "chatType">,
+  ctx: Pick<SessionContext, "session">,
+): TelegramReplyParameters | undefined {
+  // Private chats are already one-to-one; callback turns intentionally omit the message-origin key.
+  if (state.chatType !== "group" && state.chatType !== "supergroup") return undefined;
+  const auth = ctx.session.auth.current;
+  const replyToMessageId = auth?.attributes.telegramReplyToMessageId;
+  if (!auth || replyToMessageId === undefined) return undefined;
+
+  // Reply metadata may only cross the channel boundary when it belongs to this exact verified chat.
+  if (
+    auth.authenticator !== "telegram" ||
+    auth.attributes.telegramChatId !== state.chatId ||
+    auth.attributes.telegramChatType !== state.chatType ||
+    typeof replyToMessageId !== "string" ||
+    !POSITIVE_MESSAGE_ID_PATTERN.test(replyToMessageId)
+  ) {
+    throw new AppError(
+      "AGENT_TELEGRAM_REPLY_CONTEXT_INVALID",
+      "Не удалось безопасно привязать ответ к сообщению Telegram",
+    );
+  }
+  const numericMessageId = Number(replyToMessageId);
+  if (!Number.isSafeInteger(numericMessageId)) {
+    throw new AppError(
+      "AGENT_TELEGRAM_REPLY_CONTEXT_INVALID",
+      "Не удалось безопасно привязать ответ к сообщению Telegram",
+    );
+  }
+  return { allow_sending_without_reply: true, message_id: numericMessageId };
+}

--- a/agent/lib/telegram-rich-messages.test.ts
+++ b/agent/lib/telegram-rich-messages.test.ts
@@ -4,6 +4,7 @@
  * Constructs covered:
  * - RichBlockThinking and text updates reuse one draft per private chat/topic.
  * - Completed output is persisted with sendRichMessage and anchors group conversations.
+ * - The first chunk of a group response replies to the verified triggering message.
  * - Telegram rejection and ambiguous transport failures remain fail-fast without retries.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -144,6 +145,28 @@ describe("postTelegramRichMessage", () => {
       rich_message: { markdown: expect.stringContaining("| Шаг | Статус |") },
     });
     expect(state.conversationId).toBe("73");
+  });
+
+  it("replies only the first group chunk to the triggering user message", async () => {
+    const telegramFetch = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () => telegramResponse({ chat: { type: "supergroup" }, message_id: 73 }),
+    );
+
+    await postTelegramRichMessage(
+      Array.from(
+        { length: 300 },
+        (_, index) => `Абзац ${index}: ${"длинный текст ".repeat(20)}`,
+      ).join("\n\n"),
+      telegramTarget({ chatId: "-100123", chatType: "supergroup" }),
+      undefined,
+      { allow_sending_without_reply: true, message_id: 55 },
+    );
+
+    expect(telegramFetch.mock.calls.length).toBeGreaterThan(1);
+    expect(requestBody(telegramFetch, 0)).toMatchObject({
+      reply_parameters: { allow_sending_without_reply: true, message_id: 55 },
+    });
+    expect(requestBody(telegramFetch, 1)).not.toHaveProperty("reply_parameters");
   });
 
   it("does not retry an ambiguously failed final delivery", async () => {

--- a/agent/lib/telegram-rich-messages.ts
+++ b/agent/lib/telegram-rich-messages.ts
@@ -10,6 +10,7 @@
  * - One stable non-zero draft ID per private chat/topic across turns and model steps.
  * - Telegram Bot API 10.1 `sendRichMessageDraft` and `sendRichMessage` validation.
  * - Final-delivery ambiguity diagnostics without automatic retries.
+ * - First-chunk group replies anchored to a verified inbound message.
  */
 import { createHash } from "node:crypto";
 
@@ -23,6 +24,7 @@ import {
 
 import { TELEGRAM_API_REQUEST_TIMEOUT_MS } from "../config.js";
 import { AppError } from "./app-error.js";
+import type { TelegramReplyParameters } from "./telegram-reply.js";
 import {
   formatTelegramRichMessageDraft,
   formatTelegramRichMessages,
@@ -201,12 +203,14 @@ function richBody(
   target: TelegramRichTarget,
   richMessage: Readonly<{ html: string } | { markdown: string }>,
   privateOnly: boolean,
+  replyParameters?: TelegramReplyParameters,
 ): TelegramApiBody {
   return {
     chat_id: numericChatId(target, privateOnly),
     ...(target.messageThreadId === undefined
       ? {}
       : { message_thread_id: target.messageThreadId }),
+    ...(replyParameters === undefined ? {} : { reply_parameters: replyParameters }),
     rich_message: richMessage,
   };
 }
@@ -240,12 +244,13 @@ export async function postTelegramRichMessage(
   markdown: string,
   target: TelegramRichTarget,
   state?: TelegramRichAnchorState,
+  replyParameters?: TelegramReplyParameters,
 ): Promise<void> {
   const chunks = formatTelegramRichMessages(markdown);
-  for (const chunk of chunks) {
+  for (const [index, chunk] of chunks.entries()) {
     const response = await requestTelegramRichApi(
       "sendRichMessage",
-      richBody(target, { markdown: chunk }, false),
+      richBody(target, { markdown: chunk }, false, index === 0 ? replyParameters : undefined),
     );
     const sent = requireSentMessage(response);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/groq": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "imports": {

--- a/production-deploy-shell.test.ts
+++ b/production-deploy-shell.test.ts
@@ -5,8 +5,9 @@
  * - Stable SemVer comparison rejects equal and lower releases.
  * - Exported release image variables fail before Compose interpolation.
  * - `composeSha256` binds the exact released Compose bytes.
+ * - PostgreSQL command tags cannot masquerade as returned proposal rows.
  */
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
@@ -78,5 +79,14 @@ describe("production deploy shell policies", () => {
     expect(valid.status, valid.stderr).toBe(0);
     expect(invalid.status).toBe(1);
     expect(invalid.stderr).toContain("DEPLOY_COMPOSE_HASH_MISMATCH");
+  });
+
+  it("suppresses PostgreSQL command tags for no-row state transitions", () => {
+    const databaseScript = readFileSync(
+      join(projectRoot, "scripts/production-deploy/database.sh"),
+      "utf8",
+    );
+
+    expect(databaseScript).toContain("--quiet");
   });
 });

--- a/scripts/production-deploy/database.sh
+++ b/scripts/production-deploy/database.sh
@@ -6,7 +6,7 @@ readonly DEPLOYMENT_LEASE_INTERVAL="60 minutes"
 
 psql_current() {
   compose_current exec -T postgres psql -X --no-psqlrc --set ON_ERROR_STOP=1 \
-    --username osinara --dbname osinara --no-align --tuples-only "$@"
+    --username osinara --dbname osinara --no-align --tuples-only --quiet "$@"
 }
 
 reconcile_stale_deployments() {


### PR DESCRIPTION
## Changes
- reply to the verified message that triggered a group/supergroup turn
- keep private and callback-originated turns unchanged
- anchor only the first Rich Message chunk and preserve forum topics
- reply-anchor HITL prompts and turn failures
- include the validated deployment poll command-tag hotfix
- release as v0.1.2

## Verification
- 103 Docker test files and 468 tests passed with PostgreSQL integrations
- TypeScript typecheck passed
- Eve production build passed
- Telegram Bot API 10.1 sendRichMessage reply_parameters contract verified