### PR TITLE
Preserve sessions for Telegram forum replies

### DIFF
--- a/agent/lib/telegram-on-message.test.ts
+++ b/agent/lib/telegram-on-message.test.ts
@@ -12,6 +12,7 @@
  * - Captionless photos retain a model-visible trusted workspace reference.
  * - External groups drop all inbound media before persistence, journaling, or model dispatch.
  * - Foreign replies to pending HITL prompts stop before Eve dispatch.
+ * - Forum replies inherit routing from the referenced bot message, not a newly assigned thread.
  */
 import type { TelegramMessage } from "eve/channels/telegram";
 import { describe, expect, it, vi } from "vitest";
@@ -294,10 +295,12 @@ describe("createTelegramMessageHandler", () => {
     const { context, sendMessage } = telegramContext();
     const message: TelegramMessage = {
       ...groupMessage("Подтвердить"),
+      chat: { id: "group-101", title: "Форум", type: "supergroup" },
       from: { firstName: "Борис", id: "telegram-202", isBot: false },
       messageId: "89",
+      messageThreadId: 88,
       replyToMessage: {
-        chat: { id: "group-101", type: "group" },
+        chat: { id: "group-101", type: "supergroup" },
         from: {
           firstName: "Osinara",
           id: "bot-1",

--- a/agent/lib/telegram-on-message.test.ts
+++ b/agent/lib/telegram-on-message.test.ts
@@ -320,6 +320,16 @@ describe("createTelegramMessageHandler", () => {
     });
     expect(sendMessage).toHaveBeenCalledWith(expect.stringContaining("AGENT_APPROVAL_FORBIDDEN"));
     expect(repository.session.prepareTurn).not.toHaveBeenCalled();
+
+    // Existing topics retain the referenced bot message's thread instead of the incoming value.
+    repository.hitl.authorizeReply.mockClear();
+    await handler(context, {
+      ...message,
+      replyToMessage: { ...message.replyToMessage!, messageThreadId: 42 },
+    });
+    expect(repository.hitl.authorizeReply).toHaveBeenCalledWith(expect.objectContaining({
+      baseContinuationToken: "group-101:42:88",
+    }));
   });
 
   it("does not journal an ordinary message in addressed-only mode", async () => {

--- a/agent/lib/telegram-on-message.ts
+++ b/agent/lib/telegram-on-message.ts
@@ -102,16 +102,20 @@ function formatStoredAttachments(attachments: readonly StoredTelegramAttachment[
 }
 
 function baseContinuationToken(message: TelegramMessage): string {
-  // This mirrors the reviewed Eve 0.22.5 Telegram state function exactly.
+  // A first reply in a forum can acquire a new thread ID; route by the referenced bot anchor.
+  const repliesToBot = message.replyToMessage?.from?.isBot === true;
   const conversationId = message.chat.type === "private"
     ? undefined
-    : message.replyToMessage?.from?.isBot === true
+    : repliesToBot
     ? message.replyToMessage.messageId
     : message.messageId;
+  const messageThreadId = repliesToBot
+    ? message.replyToMessage?.messageThreadId
+    : message.messageThreadId;
   return telegramContinuationToken({
     chatId: message.chat.id,
     ...(conversationId === undefined ? {} : { conversationId }),
-    ...(message.messageThreadId === undefined ? {} : { messageThreadId: message.messageThreadId }),
+    ...(messageThreadId === undefined ? {} : { messageThreadId }),
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/groq": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Changes
- route a reply through the referenced bot message's forum topic identity
- avoid treating Telegram's newly assigned first-reply thread ID as a new Eve session
- add a regression test matching the production update shape
- release as v0.1.3

## Verification
- reproduced the production failure before the fix
- 103 Docker test files and 468 tests passed with PostgreSQL integrations
- TypeScript typecheck and Eve production build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Что изменено

- Исправлена маршрутизация ответов в Telegram-форумах: ответы на сообщения бота используют `messageThreadId` исходного сообщения, сохраняя сессию Eve.
- Добавлен регрессионный тест для соответствующей структуры Telegram update.
- Обновлена версия пакета до `0.1.3`.

## Проверка

- 468 тестов в 103 Docker-файлах с интеграциями PostgreSQL.
- TypeScript typecheck.
- Production-сборка Eve.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->