### PR TITLE
Hide MiniMax reasoning from Telegram

### DIFF
--- a/agent/lib/telegram-progress.test.ts
+++ b/agent/lib/telegram-progress.test.ts
@@ -3,6 +3,7 @@
  *
  * Constructs covered:
  * - `completedTelegramMessage`: keeps concise model-authored progress before tool calls.
+ * - MiniMax thinking tags never cross the user-visible Telegram boundary.
  * - Empty model steps remain invisible to avoid technical Telegram noise.
  */
 import { describe, expect, it } from "vitest";
@@ -11,13 +12,32 @@ import { completedTelegramMessage } from "./telegram-progress.js";
 
 describe("completedTelegramMessage", () => {
   it("delivers model-authored progress before a long tool step", () => {
-    expect(completedTelegramMessage({
-      finishReason: "tool-calls",
-      message: "Собрал информацию. Теперь формирую документ.",
-    })).toBe("Собрал информацию. Теперь формирую документ.");
+    expect(
+      completedTelegramMessage({
+        finishReason: "tool-calls",
+        message: "Собрал информацию. Теперь формирую документ.",
+      }),
+    ).toBe("Собрал информацию. Теперь формирую документ.");
   });
 
   it("does not expose an empty technical tool step", () => {
-    expect(completedTelegramMessage({ finishReason: "tool-calls", message: "   " })).toBeNull();
+    expect(
+      completedTelegramMessage({ finishReason: "tool-calls", message: "   " }),
+    ).toBeNull();
+  });
+
+  it("removes complete and unclosed MiniMax thinking blocks", () => {
+    expect(
+      completedTelegramMessage({
+        finishReason: "stop",
+        message: "<think>Внутреннее рассуждение</think>\n\nГотовый ответ",
+      }),
+    ).toBe("Готовый ответ");
+    expect(
+      completedTelegramMessage({
+        finishReason: "length",
+        message: "<think>Незавершённое внутреннее рассуждение",
+      }),
+    ).toBeNull();
   });
 });

--- a/agent/lib/telegram-progress.ts
+++ b/agent/lib/telegram-progress.ts
@@ -1,13 +1,40 @@
 /**
  * Telegram delivery policy for completed model messages.
  *
- * Export:
+ * Exports:
  * - `completedTelegramMessage`: keeps meaningful final or pre-tool model text and hides empty steps.
+ * - `visibleTelegramModelText`: removes provider-embedded thinking from Telegram output.
  */
+const COMPLETE_THINKING_BLOCK_PATTERN =
+  /<think(?:\s[^>]*)?>[\s\S]*?<\/think\s*>/giu;
+const UNCLOSED_THINKING_BLOCK_PATTERN = /<think(?:\s[^>]*)?(?:>|$)[\s\S]*$/iu;
+const STRAY_THINKING_CLOSE_PATTERN = /<\/think\s*>/giu;
+const THINKING_OPEN_PREFIX = "<think";
+
+export function visibleTelegramModelText(message: string): string {
+  // MiniMax emits reasoning inside ordinary content, so remove complete and still-streaming blocks.
+  let visible = message
+    .replace(COMPLETE_THINKING_BLOCK_PATTERN, "")
+    .replace(UNCLOSED_THINKING_BLOCK_PATTERN, "")
+    .replace(STRAY_THINKING_CLOSE_PATTERN, "");
+
+  // Cumulative Eve drafts can end in a split opening tag such as `<thi`; keep it private too.
+  const normalized = visible.toLowerCase();
+  for (let length = THINKING_OPEN_PREFIX.length - 1; length > 0; length -= 1) {
+    if (!normalized.endsWith(THINKING_OPEN_PREFIX.slice(0, length))) continue;
+    visible = visible.slice(0, -length);
+    break;
+  }
+  return visible.trim();
+}
+
 export function completedTelegramMessage(data: {
   finishReason: string;
   message?: string | null;
 }): string | null {
-  const message = data.message?.trim();
+  const message =
+    data.message === undefined || data.message === null
+      ? ""
+      : visibleTelegramModelText(data.message);
   return message ? message : null;
 }

--- a/agent/lib/telegram-rich-messages.test.ts
+++ b/agent/lib/telegram-rich-messages.test.ts
@@ -21,11 +21,13 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-function telegramTarget(overrides: Partial<{
-  chatId: string;
-  chatType: "group" | "private" | "supergroup";
-  messageThreadId: number;
-}> = {}) {
+function telegramTarget(
+  overrides: Partial<{
+    chatId: string;
+    chatType: "group" | "private" | "supergroup";
+    messageThreadId: number;
+  }> = {},
+) {
   return {
     chatId: overrides.chatId ?? "123456789",
     chatType: overrides.chatType ?? "private",
@@ -41,14 +43,21 @@ function telegramResponse(result: unknown): Response {
 }
 
 function requestBody(fetchMock: ReturnType<typeof vi.spyOn>, index = 0) {
-  return JSON.parse(String(fetchMock.mock.calls[index]![1]?.body)) as Record<string, unknown>;
+  return JSON.parse(String(fetchMock.mock.calls[index]![1]?.body)) as Record<
+    string,
+    unknown
+  >;
 }
 
 describe("Telegram rich drafts", () => {
   it("starts a native RichBlockThinking draft in a private chat", async () => {
-    const telegramFetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(telegramResponse(true));
+    const telegramFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(telegramResponse(true));
 
-    await startTelegramRichThinkingDraft(telegramTarget({ messageThreadId: 42 }));
+    await startTelegramRichThinkingDraft(
+      telegramTarget({ messageThreadId: 42 }),
+    );
 
     expect(String(telegramFetch.mock.calls[0]![0])).toBe(
       "https://api.telegram.org/bottelegram-bot-secret/sendRichMessageDraft",
@@ -61,40 +70,84 @@ describe("Telegram rich drafts", () => {
   });
 
   it("reuses one draft for thinking, all steps, and later turns in the same chat", async () => {
-    const telegramFetch = vi.spyOn(globalThis, "fetch").mockImplementation(
-      async () => telegramResponse(true),
-    );
+    const telegramFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => telegramResponse(true));
     const target = telegramTarget();
 
     await startTelegramRichThinkingDraft(target);
-    await streamTelegramRichMessageDraft({
-      messageSoFar: "Первый шаг",
-      stepIndex: 0,
-      turnId: "turn_first",
-    }, target);
-    await streamTelegramRichMessageDraft({
-      messageSoFar: "Следующий ответ",
-      stepIndex: 2,
-      turnId: "turn_next",
-    }, target);
+    await streamTelegramRichMessageDraft(
+      {
+        messageSoFar: "Первый шаг",
+        stepIndex: 0,
+        turnId: "turn_first",
+      },
+      target,
+    );
+    await streamTelegramRichMessageDraft(
+      {
+        messageSoFar: "Следующий ответ",
+        stepIndex: 2,
+        turnId: "turn_next",
+      },
+      target,
+    );
 
-    const ids = telegramFetch.mock.calls.map((_call, index) => requestBody(telegramFetch, index).draft_id);
+    const ids = telegramFetch.mock.calls.map(
+      (_call, index) => requestBody(telegramFetch, index).draft_id,
+    );
     expect(new Set(ids).size).toBe(1);
   });
 
-  it("keeps independent drafts for different private topics", async () => {
-    const telegramFetch = vi.spyOn(globalThis, "fetch").mockImplementation(
-      async () => telegramResponse(true),
+  it("keeps partial MiniMax thinking private until visible answer text arrives", async () => {
+    const telegramFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(telegramResponse(true));
+    const target = telegramTarget();
+
+    await streamTelegramRichMessageDraft(
+      {
+        messageSoFar: "<thi",
+        stepIndex: 0,
+        turnId: "turn_minimax",
+      },
+      target,
+    );
+    await streamTelegramRichMessageDraft(
+      {
+        messageSoFar: "<think>Скрытое рассуждение</think>\n\nВидимый ответ",
+        stepIndex: 0,
+        turnId: "turn_minimax",
+      },
+      target,
     );
 
-    await startTelegramRichThinkingDraft(telegramTarget({ messageThreadId: 41 }));
-    await startTelegramRichThinkingDraft(telegramTarget({ messageThreadId: 42 }));
+    expect(telegramFetch).toHaveBeenCalledOnce();
+    const body = requestBody(telegramFetch);
+    expect(body.rich_message).toEqual({ markdown: "Видимый ответ" });
+  });
 
-    expect(requestBody(telegramFetch, 0).draft_id).not.toBe(requestBody(telegramFetch, 1).draft_id);
+  it("keeps independent drafts for different private topics", async () => {
+    const telegramFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => telegramResponse(true));
+
+    await startTelegramRichThinkingDraft(
+      telegramTarget({ messageThreadId: 41 }),
+    );
+    await startTelegramRichThinkingDraft(
+      telegramTarget({ messageThreadId: 42 }),
+    );
+
+    expect(requestBody(telegramFetch, 0).draft_id).not.toBe(
+      requestBody(telegramFetch, 1).draft_id,
+    );
   });
 
   it("does not create rich drafts outside private chats", async () => {
-    const telegramFetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(telegramResponse(true));
+    const telegramFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(telegramResponse(true));
 
     await startTelegramRichThinkingDraft(
       telegramTarget({ chatId: "-100123", chatType: "supergroup" }),
@@ -104,15 +157,21 @@ describe("Telegram rich drafts", () => {
   });
 
   it("does not retry a rejected thinking draft", async () => {
-    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    const telegramFetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(
-      JSON.stringify({ description: "Too Many Requests", ok: false }),
-      { headers: { "content-type": "application/json" }, status: 429 },
-    ));
+    const errorLog = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const telegramFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ description: "Too Many Requests", ok: false }),
+          { headers: { "content-type": "application/json" }, status: 429 },
+        ),
+      );
 
-    await expect(startTelegramRichThinkingDraft(telegramTarget())).rejects.toThrow(
-      "AGENT_TELEGRAM_RICH_DRAFT_DELIVERY_FAILED",
-    );
+    await expect(
+      startTelegramRichThinkingDraft(telegramTarget()),
+    ).rejects.toThrow("AGENT_TELEGRAM_RICH_DRAFT_DELIVERY_FAILED");
 
     expect(telegramFetch).toHaveBeenCalledTimes(1);
     expect(errorLog).toHaveBeenCalledOnce();
@@ -121,10 +180,12 @@ describe("Telegram rich drafts", () => {
 
 describe("postTelegramRichMessage", () => {
   it("persists completed Rich Markdown and records the returned group anchor", async () => {
-    const telegramFetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(telegramResponse({
-      chat: { id: -100123, type: "supergroup" },
-      message_id: 73,
-    }));
+    const telegramFetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      telegramResponse({
+        chat: { id: -100123, type: "supergroup" },
+        message_id: 73,
+      }),
+    );
     const state = {
       chatType: "supergroup" as const,
       conversationId: "55" as string | null,
@@ -132,7 +193,11 @@ describe("postTelegramRichMessage", () => {
 
     await postTelegramRichMessage(
       "## Итог\n\n| Шаг | Статус |\n| --- | --- |\n| 1 | Готово |",
-      telegramTarget({ chatId: "-100123", chatType: "supergroup", messageThreadId: 7 }),
+      telegramTarget({
+        chatId: "-100123",
+        chatType: "supergroup",
+        messageThreadId: 7,
+      }),
       state,
     );
 
@@ -148,9 +213,11 @@ describe("postTelegramRichMessage", () => {
   });
 
   it("replies only the first group chunk to the triggering user message", async () => {
-    const telegramFetch = vi.spyOn(globalThis, "fetch").mockImplementation(
-      async () => telegramResponse({ chat: { type: "supergroup" }, message_id: 73 }),
-    );
+    const telegramFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () =>
+        telegramResponse({ chat: { type: "supergroup" }, message_id: 73 }),
+      );
 
     await postTelegramRichMessage(
       Array.from(
@@ -166,36 +233,48 @@ describe("postTelegramRichMessage", () => {
     expect(requestBody(telegramFetch, 0)).toMatchObject({
       reply_parameters: { allow_sending_without_reply: true, message_id: 55 },
     });
-    expect(requestBody(telegramFetch, 1)).not.toHaveProperty("reply_parameters");
+    expect(requestBody(telegramFetch, 1)).not.toHaveProperty(
+      "reply_parameters",
+    );
   });
 
   it("does not retry an ambiguously failed final delivery", async () => {
-    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const errorLog = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
     const timeout = new DOMException("The operation timed out", "TimeoutError");
-    const telegramFetch = vi.spyOn(globalThis, "fetch").mockRejectedValue(timeout);
+    const telegramFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(timeout);
 
-    await expect(postTelegramRichMessage(
-      "Ответ",
-      telegramTarget(),
-    )).rejects.toBe(timeout);
+    await expect(
+      postTelegramRichMessage("Ответ", telegramTarget()),
+    ).rejects.toBe(timeout);
 
-    expect(timeout.message).toContain("AGENT_TELEGRAM_RICH_MESSAGE_DELIVERY_AMBIGUOUS");
+    expect(timeout.message).toContain(
+      "AGENT_TELEGRAM_RICH_MESSAGE_DELIVERY_AMBIGUOUS",
+    );
     expect(telegramFetch).toHaveBeenCalledTimes(1);
     expect(errorLog).toHaveBeenCalledOnce();
   });
 
   it("logs an ambiguous success envelope without exposing message content", async () => {
-    const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(telegramResponse({ unexpected: true }));
+    const errorLog = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      telegramResponse({ unexpected: true }),
+    );
 
-    await expect(postTelegramRichMessage(
-      "Чувствительный ответ",
-      telegramTarget(),
-    )).rejects.toThrow("AGENT_TELEGRAM_RICH_MESSAGE_DELIVERY_AMBIGUOUS");
+    await expect(
+      postTelegramRichMessage("Чувствительный ответ", telegramTarget()),
+    ).rejects.toThrow("AGENT_TELEGRAM_RICH_MESSAGE_DELIVERY_AMBIGUOUS");
 
-    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining(
-      "AGENT_TELEGRAM_RICH_MESSAGE_DELIVERY_AMBIGUOUS",
-    ));
-    expect(errorLog).not.toHaveBeenCalledWith(expect.stringContaining("Чувствительный ответ"));
+    expect(errorLog).toHaveBeenCalledWith(
+      expect.stringContaining("AGENT_TELEGRAM_RICH_MESSAGE_DELIVERY_AMBIGUOUS"),
+    );
+    expect(errorLog).not.toHaveBeenCalledWith(
+      expect.stringContaining("Чувствительный ответ"),
+    );
   });
 });

--- a/agent/lib/telegram-rich-messages.ts
+++ b/agent/lib/telegram-rich-messages.ts
@@ -24,6 +24,7 @@ import {
 
 import { TELEGRAM_API_REQUEST_TIMEOUT_MS } from "../config.js";
 import { AppError } from "./app-error.js";
+import { visibleTelegramModelText } from "./telegram-progress.js";
 import type { TelegramReplyParameters } from "./telegram-reply.js";
 import {
   formatTelegramRichMessageDraft,
@@ -32,8 +33,7 @@ import {
 
 const TELEGRAM_DRAFT_ID_MODULUS = 2_147_483_647;
 const TELEGRAM_THINKING_CUSTOM_EMOJI_ID = "5535034915403333642";
-const TELEGRAM_THINKING_HTML =
-  `<tg-thinking><tg-emoji emoji-id="${TELEGRAM_THINKING_CUSTOM_EMOJI_ID}"></tg-emoji> Думаю…</tg-thinking>`;
+const TELEGRAM_THINKING_HTML = `<tg-thinking><tg-emoji emoji-id="${TELEGRAM_THINKING_CUSTOM_EMOJI_ID}"></tg-emoji> Думаю…</tg-thinking>`;
 const TELEGRAM_CHAT_TYPES = new Set<TelegramChatType>([
   "channel",
   "group",
@@ -55,8 +55,13 @@ type TelegramRichTarget = Pick<
   "chatId" | "chatType" | "messageThreadId"
 >;
 
-type TelegramRichAnchorState = Pick<TelegramChannelState, "chatType" | "conversationId">;
-type TelegramApiBody = NonNullable<Parameters<typeof callTelegramApi>[0]["body"]>;
+type TelegramRichAnchorState = Pick<
+  TelegramChannelState,
+  "chatType" | "conversationId"
+>;
+type TelegramApiBody = NonNullable<
+  Parameters<typeof callTelegramApi>[0]["body"]
+>;
 
 interface SentTelegramMessage {
   readonly chatType: TelegramChatType;
@@ -64,7 +69,8 @@ interface SentTelegramMessage {
 }
 
 function draftId(target: TelegramRichTarget): number {
-  const thread = target.messageThreadId === undefined ? "" : String(target.messageThreadId);
+  const thread =
+    target.messageThreadId === undefined ? "" : String(target.messageThreadId);
   const digest = createHash("sha256")
     .update(target.chatId)
     .update(":")
@@ -84,9 +90,16 @@ function requireTelegramBotToken(): string {
   return botToken;
 }
 
-function numericChatId(target: TelegramRichTarget, privateOnly: boolean): number | string {
+function numericChatId(
+  target: TelegramRichTarget,
+  privateOnly: boolean,
+): number | string {
   const numeric = Number(target.chatId);
-  if (Number.isSafeInteger(numeric) && numeric !== 0 && (!privateOnly || numeric > 0)) {
+  if (
+    Number.isSafeInteger(numeric) &&
+    numeric !== 0 &&
+    (!privateOnly || numeric > 0)
+  ) {
     return numeric;
   }
   if (!privateOnly && /^@[A-Za-z][A-Za-z0-9_]{3,}$/u.test(target.chatId)) {
@@ -98,7 +111,10 @@ function numericChatId(target: TelegramRichTarget, privateOnly: boolean): number
   );
 }
 
-function telegramRichFetch(request: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+function telegramRichFetch(
+  request: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
   const timeoutSignal = AbortSignal.timeout(TELEGRAM_API_REQUEST_TIMEOUT_MS);
   const signal = init?.signal
     ? AbortSignal.any([init.signal, timeoutSignal])
@@ -119,9 +135,10 @@ async function requestTelegramRichApi(
   method: "sendRichMessage" | "sendRichMessageDraft",
   body: TelegramApiBody,
 ): Promise<TelegramApiResponse> {
-  const transportCode = method === "sendRichMessage"
-    ? "AGENT_TELEGRAM_RICH_MESSAGE_DELIVERY_AMBIGUOUS"
-    : "AGENT_TELEGRAM_RICH_DRAFT_DELIVERY_FAILED";
+  const transportCode =
+    method === "sendRichMessage"
+      ? "AGENT_TELEGRAM_RICH_MESSAGE_DELIVERY_AMBIGUOUS"
+      : "AGENT_TELEGRAM_RICH_DRAFT_DELIVERY_FAILED";
   let response: TelegramApiResponse;
   try {
     response = await callTelegramApi({
@@ -132,27 +149,37 @@ async function requestTelegramRichApi(
     });
   } catch (error) {
     // A final network failure is ambiguous because Telegram may have accepted the message.
-    console.error(JSON.stringify({
-      code: transportCode,
-      errorName: error instanceof Error ? error.name : "UnknownError",
-      method,
-    }));
+    console.error(
+      JSON.stringify({
+        code: transportCode,
+        errorName: error instanceof Error ? error.name : "UnknownError",
+        method,
+      }),
+    );
     if (error instanceof Error) addStableErrorCode(error, transportCode);
     throw error;
   }
 
-  if (response.ok && typeof response.body === "object" && response.body !== null &&
-    "ok" in response.body && response.body.ok === true) {
+  if (
+    response.ok &&
+    typeof response.body === "object" &&
+    response.body !== null &&
+    "ok" in response.body &&
+    response.body.ok === true
+  ) {
     return response;
   }
-  const rejectionCode = method === "sendRichMessage"
-    ? "AGENT_TELEGRAM_RICH_MESSAGE_DELIVERY_FAILED"
-    : "AGENT_TELEGRAM_RICH_DRAFT_DELIVERY_FAILED";
-  console.error(JSON.stringify({
-    code: rejectionCode,
-    method,
-    providerStatus: response.status,
-  }));
+  const rejectionCode =
+    method === "sendRichMessage"
+      ? "AGENT_TELEGRAM_RICH_MESSAGE_DELIVERY_FAILED"
+      : "AGENT_TELEGRAM_RICH_DRAFT_DELIVERY_FAILED";
+  console.error(
+    JSON.stringify({
+      code: rejectionCode,
+      method,
+      providerStatus: response.status,
+    }),
+  );
   throw new AppError(
     rejectionCode,
     method === "sendRichMessage"
@@ -164,18 +191,22 @@ async function requestTelegramRichApi(
 function requireDraftSuccess(response: TelegramApiResponse): void {
   const body = response.body as { result?: unknown };
   if (body.result === true) return;
-  console.error(JSON.stringify({
-    code: "AGENT_TELEGRAM_RICH_DRAFT_DELIVERY_FAILED",
-    method: "sendRichMessageDraft",
-    providerStatus: response.status,
-  }));
+  console.error(
+    JSON.stringify({
+      code: "AGENT_TELEGRAM_RICH_DRAFT_DELIVERY_FAILED",
+      method: "sendRichMessageDraft",
+      providerStatus: response.status,
+    }),
+  );
   throw new AppError(
     "AGENT_TELEGRAM_RICH_DRAFT_DELIVERY_FAILED",
     "Telegram вернул некорректное подтверждение потокового ответа",
   );
 }
 
-function requireSentMessage(response: TelegramApiResponse): SentTelegramMessage {
+function requireSentMessage(
+  response: TelegramApiResponse,
+): SentTelegramMessage {
   const body = response.body as {
     result?: {
       chat?: { type?: unknown };
@@ -184,15 +215,24 @@ function requireSentMessage(response: TelegramApiResponse): SentTelegramMessage 
   };
   const messageId = body.result?.message_id;
   const chatType = body.result?.chat?.type;
-  if (Number.isSafeInteger(messageId) && Number(messageId) > 0 &&
-    typeof chatType === "string" && TELEGRAM_CHAT_TYPES.has(chatType as TelegramChatType)) {
-    return { chatType: chatType as TelegramChatType, messageId: String(messageId) };
+  if (
+    Number.isSafeInteger(messageId) &&
+    Number(messageId) > 0 &&
+    typeof chatType === "string" &&
+    TELEGRAM_CHAT_TYPES.has(chatType as TelegramChatType)
+  ) {
+    return {
+      chatType: chatType as TelegramChatType,
+      messageId: String(messageId),
+    };
   }
-  console.error(JSON.stringify({
-    code: "AGENT_TELEGRAM_RICH_MESSAGE_DELIVERY_AMBIGUOUS",
-    method: "sendRichMessage",
-    providerStatus: response.status,
-  }));
+  console.error(
+    JSON.stringify({
+      code: "AGENT_TELEGRAM_RICH_MESSAGE_DELIVERY_AMBIGUOUS",
+      method: "sendRichMessage",
+      providerStatus: response.status,
+    }),
+  );
   throw new AppError(
     "AGENT_TELEGRAM_RICH_MESSAGE_DELIVERY_AMBIGUOUS",
     "Telegram принял запрос, но не подтвердил идентификатор отправленного сообщения",
@@ -210,7 +250,9 @@ function richBody(
     ...(target.messageThreadId === undefined
       ? {}
       : { message_thread_id: target.messageThreadId }),
-    ...(replyParameters === undefined ? {} : { reply_parameters: replyParameters }),
+    ...(replyParameters === undefined
+      ? {}
+      : { reply_parameters: replyParameters }),
     rich_message: richMessage,
   };
 }
@@ -231,7 +273,9 @@ export async function streamTelegramRichMessageDraft(
   target: TelegramRichTarget,
 ): Promise<void> {
   if (target.chatType !== "private") return;
-  const markdown = formatTelegramRichMessageDraft(event.messageSoFar);
+  const markdown = formatTelegramRichMessageDraft(
+    visibleTelegramModelText(event.messageSoFar),
+  );
   if (!markdown) return;
   const response = await requestTelegramRichApi("sendRichMessageDraft", {
     ...richBody(target, { markdown }, true),
@@ -250,7 +294,12 @@ export async function postTelegramRichMessage(
   for (const [index, chunk] of chunks.entries()) {
     const response = await requestTelegramRichApi(
       "sendRichMessage",
-      richBody(target, { markdown: chunk }, false, index === 0 ? replyParameters : undefined),
+      richBody(
+        target,
+        { markdown: chunk },
+        false,
+        index === 0 ? replyParameters : undefined,
+      ),
     );
     const sent = requireSentMessage(response);
 

--- a/cli-proxy-runtime.test.ts
+++ b/cli-proxy-runtime.test.ts
@@ -3,7 +3,7 @@
  *
  * Constructs covered:
  * - Runtime config rendering keeps client and upstream secrets out of source configuration.
- * - NeuralDeep-compatible models are exposed without retries or a management surface.
+ * - OpenAI-compatible models are exposed without retries or a management surface.
  * - Docker wiring keeps CLIProxyAPI internal and pins its canonical release image.
  */
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
@@ -23,7 +23,7 @@ afterEach(() => {
 });
 
 describe("CLIProxyAPI runtime", () => {
-  it("renders authenticated no-retry upstream config from server models and environment secrets", () => {
+  it("renders authenticated no-retry MiniMax config from server models and environment secrets", () => {
     const directory = mkdtempSync(join(tmpdir(), "osinara-cli-proxy-"));
     temporaryDirectories.push(directory);
     const target = join(directory, "config.json");
@@ -53,9 +53,9 @@ describe("CLIProxyAPI runtime", () => {
       "openai-compatibility": [
         {
           "api-key-entries": [{ "api-key": "upstream-test-key" }],
-          "base-url": "https://api.neuraldeep.ru/v1",
-          models: [{ alias: "qwen3.6-fp8", name: "qwen3.6-fp8" }],
-          name: "neuraldeep",
+          "base-url": "https://api.minimax.io/v1",
+          models: [{ alias: "MiniMax-M3", name: "MiniMax-M3" }],
+          name: "minimax",
         },
       ],
       "remote-management": {

--- a/config/model-providers.json
+++ b/config/model-providers.json
@@ -1,16 +1,16 @@
 {
   "schemaVersion": 1,
   "agent": {
-    "textModelId": "qwen3.6-fp8",
-    "visionModelId": "qwen3.6-fp8",
-    "contextWindowTokens": 262144,
+    "textModelId": "MiniMax-M3",
+    "visionModelId": "MiniMax-M3",
+    "contextWindowTokens": 1000000,
     "upstream": {
-      "name": "neuraldeep",
-      "baseUrl": "https://api.neuraldeep.ru/v1",
+      "name": "minimax",
+      "baseUrl": "https://api.minimax.io/v1",
       "models": [
         {
-          "name": "qwen3.6-fp8",
-          "alias": "qwen3.6-fp8",
+          "name": "MiniMax-M3",
+          "alias": "MiniMax-M3",
           "inputModalities": ["text", "image"],
           "outputModalities": ["text"]
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/groq": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- switch the canonical text and vision provider back to MiniMax M3
- remove provider-embedded think blocks from cumulative Telegram drafts and completed messages
- publish the change as version 0.2.1

## Verification
- npm test
- npm run typecheck
- npm run build
- npm run build:runtime
- docker compose -f compose.test.yaml up --build --abort-on-container-exit --exit-code-from tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Каноническим текстовым и vision-провайдером снова стал MiniMax M3.
- Обновлена конфигурация моделей: `MiniMax-M3`, контекстное окно увеличено до 1 000 000 токенов.
- Добавлена фильтрация `<think>...</think>` и незавершённых reasoning-блоков перед отправкой Telegram-сообщений и потоковых черновиков.
- Расширены тесты фильтрации и Telegram-доставки.
- Обновлены диагностические ошибки и структурированное логирование Telegram API.
- Версия пакета повышена с `0.2.0` до `0.2.1`.
- Обновлены CLI-тесты для MiniMax-конфигурации.

## Проверка

Проверки включают тесты, проверку типов, сборку, runtime-сборку и запуск Docker Compose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->