### PR TITLE
Harden MiniMax Telegram output filtering

### DIFF
--- a/agent/lib/telegram-progress.test.ts
+++ b/agent/lib/telegram-progress.test.ts
@@ -3,7 +3,7 @@
  *
  * Constructs covered:
  * - `completedTelegramMessage`: keeps concise model-authored progress before tool calls.
- * - MiniMax thinking tags never cross the user-visible Telegram boundary.
+ * - Plain and namespaced MiniMax thinking tags never cross the Telegram boundary.
  * - Empty model steps remain invisible to avoid technical Telegram noise.
  */
 import { describe, expect, it } from "vitest";
@@ -39,5 +39,36 @@ describe("completedTelegramMessage", () => {
         message: "<think>Незавершённое внутреннее рассуждение",
       }),
     ).toBeNull();
+  });
+
+  it("removes every namespaced MiniMax thinking block embedded between visible text", () => {
+    expect(
+      completedTelegramMessage({
+        finishReason: "stop",
+        message: [
+          "<mm:think>Первое внутреннее рассуждение</mm:think>",
+          "Промежуточный результат",
+          "<mm:think>Второе внутреннее рассуждение</mm:think>",
+          "Готовый ответ",
+        ].join("\n"),
+      }),
+    ).toBe("Промежуточный результат\n\nГотовый ответ");
+
+    expect(
+      completedTelegramMessage({
+        finishReason: "length",
+        message: "<mm:think>Незавершённое внутреннее рассуждение",
+      }),
+    ).toBeNull();
+  });
+
+  it("removes reasoning before MiniMax's orphan namespaced closing marker", () => {
+    expect(
+      completedTelegramMessage({
+        finishReason: "stop",
+        message:
+          "Пользователь спрашивает о Telegram API.</mm:think>\n\nПонял вопрос. Вот готовый ответ.",
+      }),
+    ).toBe("Понял вопрос. Вот готовый ответ.");
   });
 });

--- a/agent/lib/telegram-progress.ts
+++ b/agent/lib/telegram-progress.ts
@@ -3,27 +3,31 @@
  *
  * Exports:
  * - `completedTelegramMessage`: keeps meaningful final or pre-tool model text and hides empty steps.
- * - `visibleTelegramModelText`: removes provider-embedded thinking from Telegram output.
+ * - `visibleTelegramModelText`: removes plain and namespaced MiniMax thinking from Telegram output.
  */
 const COMPLETE_THINKING_BLOCK_PATTERN =
-  /<think(?:\s[^>]*)?>[\s\S]*?<\/think\s*>/giu;
-const UNCLOSED_THINKING_BLOCK_PATTERN = /<think(?:\s[^>]*)?(?:>|$)[\s\S]*$/iu;
-const STRAY_THINKING_CLOSE_PATTERN = /<\/think\s*>/giu;
-const THINKING_OPEN_PREFIX = "<think";
+  /<(mm:)?think(?:\s[^>]*)?>[\s\S]*?<\/\1think\s*>/giu;
+const UNCLOSED_THINKING_BLOCK_PATTERN =
+  /<(?:mm:)?think(?:\s[^>]*)?(?:>|$)[\s\S]*$/iu;
+const CONTENT_THROUGH_LAST_THINKING_CLOSE_PATTERN =
+  /^[\s\S]*<\/(?:mm:)?think\s*>/iu;
+const THINKING_OPEN_PREFIXES = ["<mm:think", "<think"] as const;
 
 export function visibleTelegramModelText(message: string): string {
-  // MiniMax emits reasoning inside ordinary content, so remove complete and still-streaming blocks.
+  // MiniMax emits reasoning inside ordinary content, sometimes with only a closing boundary.
   let visible = message
     .replace(COMPLETE_THINKING_BLOCK_PATTERN, "")
     .replace(UNCLOSED_THINKING_BLOCK_PATTERN, "")
-    .replace(STRAY_THINKING_CLOSE_PATTERN, "");
+    .replace(CONTENT_THROUGH_LAST_THINKING_CLOSE_PATTERN, "");
 
-  // Cumulative Eve drafts can end in a split opening tag such as `<thi`; keep it private too.
+  // Cumulative Eve drafts can end in a split plain or namespaced opening tag.
   const normalized = visible.toLowerCase();
-  for (let length = THINKING_OPEN_PREFIX.length - 1; length > 0; length -= 1) {
-    if (!normalized.endsWith(THINKING_OPEN_PREFIX.slice(0, length))) continue;
-    visible = visible.slice(0, -length);
-    break;
+  for (const prefix of THINKING_OPEN_PREFIXES) {
+    for (let length = prefix.length - 1; length > 0; length -= 1) {
+      if (!normalized.endsWith(prefix.slice(0, length))) continue;
+      visible = visible.slice(0, -length);
+      return visible.trim();
+    }
   }
   return visible.trim();
 }

--- a/agent/lib/telegram-rich-markdown.test.ts
+++ b/agent/lib/telegram-rich-markdown.test.ts
@@ -3,6 +3,7 @@
  *
  * Constructs covered:
  * - Supported text-rich Markdown and a narrow inline HTML allowlist survive sanitization.
+ * - Malformed allowed HTML is rendered inert instead of blocking final delivery.
  * - Model-authored media, Telegram service tags, and unsafe links are rendered inert.
  * - Final rich messages split only between complete blocks at Telegram's length limit.
  * - The permanent prompt teaches semantic rich formatting without exposing transport control.
@@ -62,6 +63,16 @@ describe("sanitizeTelegramRichMarkdown", () => {
     expect(() => sanitizeTelegramRichMarkdown(row)).toThrow(
       "AGENT_TELEGRAM_RICH_TABLE_TOO_WIDE",
     );
+  });
+
+  it("neutralizes unclosed allowed HTML instead of blocking final delivery", () => {
+    expect(
+      formatTelegramRichMessages(
+        "<details><summary>Результат</summary>\n\nОтвет без закрывающего details",
+      ),
+    ).toEqual([
+      "&lt;details&gt;&lt;summary&gt;Результат&lt;/summary&gt;\n\nОтвет без закрывающего details",
+    ]);
   });
 });
 

--- a/agent/lib/telegram-rich-markdown.ts
+++ b/agent/lib/telegram-rich-markdown.ts
@@ -8,7 +8,8 @@
  *
  * Key constructs:
  * - A narrow HTML allowlist for details and inline text formatting.
- * - Explicit rejection of over-wide tables, malformed allowed tags, and indivisible long blocks.
+ * - Inert rendering of malformed allowed tags without losing the model's answer.
+ * - Explicit rejection of over-wide tables, excessive nesting, and indivisible long blocks.
  */
 import { AppError } from "./app-error.js";
 
@@ -185,7 +186,19 @@ function sanitizeTelegramRichMarkdownInternal(
 }
 
 export function sanitizeTelegramRichMarkdown(markdown: string): string {
-  return sanitizeTelegramRichMarkdownInternal(markdown, true);
+  try {
+    return sanitizeTelegramRichMarkdownInternal(markdown, true);
+  } catch (error) {
+    if (
+      !(error instanceof AppError) ||
+      error.code !== "AGENT_TELEGRAM_RICH_HTML_INVALID"
+    ) {
+      throw error;
+    }
+
+    // Model-authored formatting must not suppress an otherwise valid answer.
+    return sanitizeTelegramRichMarkdownInternal(markdown, false);
+  }
 }
 
 export function formatTelegramRichMessages(markdown: string): string[] {
@@ -217,16 +230,7 @@ export function formatTelegramRichMessages(markdown: string): string[] {
 }
 
 export function formatTelegramRichMessageDraft(markdown: string): string | null {
-  let sanitized: string;
-  try {
-    sanitized = sanitizeTelegramRichMarkdown(markdown).trim();
-  } catch (error) {
-    if (!(error instanceof AppError) || error.code !== "AGENT_TELEGRAM_RICH_HTML_INVALID") {
-      throw error;
-    }
-    // Stream deltas can end midway through an allowed tag; show it inert until the block closes.
-    sanitized = sanitizeTelegramRichMarkdownInternal(markdown, false).trim();
-  }
+  const sanitized = sanitizeTelegramRichMarkdown(markdown).trim();
   if (!sanitized || characterLength(sanitized) > TELEGRAM_RICH_MESSAGE_MAX_CHARACTERS) return null;
   return sanitized;
 }

--- a/agent/lib/telegram-rich-messages.test.ts
+++ b/agent/lib/telegram-rich-messages.test.ts
@@ -115,6 +115,14 @@ describe("Telegram rich drafts", () => {
     );
     await streamTelegramRichMessageDraft(
       {
+        messageSoFar: "<mm:thi",
+        stepIndex: 0,
+        turnId: "turn_minimax",
+      },
+      target,
+    );
+    await streamTelegramRichMessageDraft(
+      {
         messageSoFar: "<think>Скрытое рассуждение</think>\n\nВидимый ответ",
         stepIndex: 0,
         turnId: "turn_minimax",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/groq": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- filter plain and namespaced MiniMax thinking blocks, including orphan closing boundaries and partial streamed tags
- render malformed allowed Rich HTML as inert text instead of dropping the completed Telegram response
- bump the immutable patch release to 0.2.2

## Verification
- Docker Compose suite: 105 files, 483 tests passed
- npm run typecheck
- npm run build
- git diff --check