### PR TITLE
Preserve text split by MiniMax reasoning

### DIFF
--- a/agent/lib/telegram-progress.test.ts
+++ b/agent/lib/telegram-progress.test.ts
@@ -71,4 +71,19 @@ describe("completedTelegramMessage", () => {
       }),
     ).toBe("Понял вопрос. Вот готовый ответ.");
   });
+
+  it("rejoins visible text split by duplicated reasoning and orphan closing markers", () => {
+    expect(
+      completedTelegramMessage({
+        finishReason: "stop",
+        message: [
+          "<think>Пользователь спрашивает, как у меня дела.</think>",
+          "В",
+          "</think>",
+          " у меня дела. Это повтор внутреннего рассуждения.",
+          "</think>сё отлично, готов помогать!",
+        ].join("\n"),
+      }),
+    ).toBe("Всё отлично, готов помогать!");
+  });
 });

--- a/agent/lib/telegram-progress.ts
+++ b/agent/lib/telegram-progress.ts
@@ -9,16 +9,29 @@ const COMPLETE_THINKING_BLOCK_PATTERN =
   /<(mm:)?think(?:\s[^>]*)?>[\s\S]*?<\/\1think\s*>/giu;
 const UNCLOSED_THINKING_BLOCK_PATTERN =
   /<(?:mm:)?think(?:\s[^>]*)?(?:>|$)[\s\S]*$/iu;
-const CONTENT_THROUGH_LAST_THINKING_CLOSE_PATTERN =
-  /^[\s\S]*<\/(?:mm:)?think\s*>/iu;
+const THINKING_CLOSE_PATTERN = /<\/(?:mm:)?think\s*>/giu;
 const THINKING_OPEN_PREFIXES = ["<mm:think", "<think"] as const;
 
 export function visibleTelegramModelText(message: string): string {
-  // MiniMax emits reasoning inside ordinary content, sometimes with only a closing boundary.
+  // MiniMax emits reasoning inside ordinary content and can duplicate stream boundaries.
+  let removedCompleteBlock = false;
   let visible = message
-    .replace(COMPLETE_THINKING_BLOCK_PATTERN, "")
-    .replace(UNCLOSED_THINKING_BLOCK_PATTERN, "")
-    .replace(CONTENT_THROUGH_LAST_THINKING_CLOSE_PATTERN, "");
+    .replace(COMPLETE_THINKING_BLOCK_PATTERN, () => {
+      removedCompleteBlock = true;
+      return "";
+    })
+    .replace(UNCLOSED_THINKING_BLOCK_PATTERN, "");
+
+  // A corrupted stream can inject duplicated reasoning between visible token fragments.
+  const closingMarkers = [...visible.matchAll(THINKING_CLOSE_PATTERN)];
+  if (closingMarkers.length > 0) {
+    const first = closingMarkers[0]!;
+    const last = closingMarkers[closingMarkers.length - 1]!;
+    const suffix = visible.slice(last.index + last[0].length).trimStart();
+    visible = removedCompleteBlock
+      ? `${visible.slice(0, first.index).trimEnd()}${suffix}`
+      : suffix;
+  }
 
   // Cumulative Eve drafts can end in a split plain or namespaced opening tag.
   const normalized = visible.toLowerCase();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/groq": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- preserve visible token fragments split by duplicated MiniMax reasoning boundaries
- discard the duplicated reasoning injected between orphan closing markers
- add the exact production failure shape as a regression test
- bump the immutable patch release to 0.2.3

## Verification
- Docker Compose suite: 105 files, 484 tests passed
- npm run typecheck
- npm run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Что изменилось

- Исправлена обработка MiniMax reasoning-блоков: теперь сохраняются видимые фрагменты текста, разделённые дублирующимися `<think>...</think>` и сиротскими `</think>`-маркерами.
- Добавлен регрессионный тест для production-сценария.
- Версия пакета обновлена с `0.2.2` до `0.2.3`.

## Проверка

- 484 теста успешно пройдены в 105 файлах.
- Выполнены проверка типов и сборка.
- `git diff --check` завершился без ошибок.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->