### PR TITLE
Handle MiniMax reasoning structurally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ FROM first-party-node AS dependencies
 WORKDIR /app
 COPY package.json package-lock.json ./
 COPY scripts/apply-eve-patches.ts ./scripts/apply-eve-patches.ts
+COPY scripts/apply-openai-compatible-patches.ts ./scripts/apply-openai-compatible-patches.ts
 RUN npm ci
 
 FROM dependencies AS build
@@ -33,6 +34,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 COPY package.json package-lock.json ./
 COPY scripts/apply-eve-patches.ts ./scripts/apply-eve-patches.ts
+COPY scripts/apply-openai-compatible-patches.ts ./scripts/apply-openai-compatible-patches.ts
 RUN npm ci --omit=dev
 
 FROM eceasy/cli-proxy-api@sha256:0b27437917e45a22612ff43ede0fd6baf077c1898c622037a24a79399a9b3d0c AS cli-proxy

--- a/agent/channels/telegram.ts
+++ b/agent/channels/telegram.ts
@@ -6,7 +6,7 @@
  * - Application-owned family/group authorization in `onMessage`.
  * - Durable identity-bound HITL callbacks and replies.
  * - Validated attachment persistence with model-safe workspace references.
- * - Native RichBlockThinking, chat-scoped streaming, and completed Rich Message delivery.
+ * - One native thinking draft per turn and completed Rich Message delivery.
  * - Verified group replies anchored to the triggering member message.
  */
 import { telegramChannel } from "eve/channels/telegram";
@@ -19,7 +19,6 @@ import { completedTelegramMessage } from "../lib/telegram-progress.js";
 import {
   postTelegramRichMessage,
   startTelegramRichThinkingDraft,
-  streamTelegramRichMessageDraft,
 } from "../lib/telegram-rich-messages.js";
 import {
   applicationSessionId,
@@ -39,13 +38,6 @@ export default telegramChannel({
   },
   drainRoute: "/eve/v1/telegram-drain",
   events: {
-    async "action.result"(_data, channel) {
-      // Refresh the same chat-scoped preview before the next model step.
-      await startTelegramRichThinkingDraft(channel.telegram);
-    },
-    async "actions.requested"(_data, channel) {
-      await startTelegramRichThinkingDraft(channel.telegram);
-    },
     "input.requested": handleTelegramInputRequested,
     async "message.completed"(data, channel, ctx) {
       // Model-authored pre-tool text is a user-visible progress update, not technical tool noise.
@@ -60,12 +52,6 @@ export default telegramChannel({
         telegramTurnReplyParameters(channel.state, ctx),
       );
       await rekeyTelegramSession(channel, ctx);
-    },
-    async "message.appended"(data, channel, ctx) {
-      // Every turn and tool-loop step updates one Telegram preview for this private chat/topic.
-      const sessionId = applicationSessionId(ctx);
-      if (!await sessionRepository.isCurrentEveSession(sessionId, ctx.session.id)) return;
-      await streamTelegramRichMessageDraft(data, channel.telegram);
     },
     async "session.failed"(data, channel) {
       await handleTelegramSessionFailure(data, channel, sessionRepository);

--- a/agent/lib/minimax-model.test.ts
+++ b/agent/lib/minimax-model.test.ts
@@ -1,0 +1,218 @@
+/**
+ * MiniMax OpenAI-compatible model boundary tests.
+ *
+ * Constructs covered:
+ * - `createMiniMaxCliProxyModel`: adds `reasoning_split` to every request.
+ * - MiniMax `reasoning_details` survives a complete assistant/tool round trip.
+ * - Streaming reasoning metadata remains attached to the AI SDK reasoning part.
+ * - Inline reasoning in text fails closed when the upstream contract is violated.
+ */
+import { describe, expect, it } from "vitest";
+import type {
+  LanguageModelV4CallOptions,
+  LanguageModelV4Content,
+  LanguageModelV4Prompt,
+  LanguageModelV4StreamPart,
+} from "@ai-sdk/provider";
+
+import { createMiniMaxCliProxyModel } from "./minimax-model.js";
+
+const REASONING_DETAILS = [{
+  format: "MiniMax-response-v1",
+  id: "reasoning-text-1",
+  index: 0,
+  text: "Проверяю погоду через инструмент.",
+  type: "reasoning.text",
+}] as const;
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+    status: 200,
+  });
+}
+
+function completion(message: Record<string, unknown>, finishReason: string) {
+  return {
+    choices: [{ finish_reason: finishReason, index: 0, message }],
+    created: 1,
+    id: "completion-1",
+    model: "MiniMax-M3",
+    object: "chat.completion",
+    usage: { completion_tokens: 10, prompt_tokens: 10, total_tokens: 20 },
+  };
+}
+
+function userPrompt(): LanguageModelV4Prompt {
+  return [{
+    content: [{ text: "Какая погода?", type: "text" }],
+    role: "user",
+  }];
+}
+
+function assistantPrompt(content: LanguageModelV4Content[]): LanguageModelV4Prompt[number] {
+  return {
+    content: content.map((part) => {
+      if (part.type === "reasoning") {
+        return {
+          providerOptions: part.providerMetadata,
+          text: part.text,
+          type: "reasoning" as const,
+        };
+      }
+      if (part.type === "tool-call") {
+        return {
+          input: JSON.parse(part.input) as Record<string, unknown>,
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          type: "tool-call" as const,
+        };
+      }
+      if (part.type === "text") {
+        return { text: part.text, type: "text" as const };
+      }
+      throw new Error(`Unexpected content part in test: ${part.type}`);
+    }),
+    role: "assistant",
+  };
+}
+
+function toolResultPrompt(): LanguageModelV4Prompt[number] {
+  return {
+    content: [{
+      output: { type: "text", value: "24 C, солнечно" },
+      toolCallId: "call-weather-1",
+      toolName: "get_weather",
+      type: "tool-result",
+    }],
+    role: "tool",
+  };
+}
+
+describe("createMiniMaxCliProxyModel", () => {
+  it("preserves exact reasoning_details through an assistant/tool round trip", async () => {
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const responses = [
+      completion({
+        content: "",
+        reasoning_content: REASONING_DETAILS[0].text,
+        reasoning_details: REASONING_DETAILS,
+        role: "assistant",
+        tool_calls: [{
+          function: { arguments: '{"location":"Москва"}', name: "get_weather" },
+          id: "call-weather-1",
+          type: "function",
+        }],
+      }, "tool_calls"),
+      completion({ content: "Сейчас солнечно.", role: "assistant" }, "stop"),
+    ];
+    const model = createMiniMaxCliProxyModel({
+      apiKey: "proxy-key",
+      baseURL: "http://cli-proxy-api:8317/v1",
+      fetch: async (_input, init) => {
+        requestBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return jsonResponse(responses.shift());
+      },
+      modelId: "MiniMax-M3",
+    });
+
+    const first = await model.doGenerate({ prompt: userPrompt() } as LanguageModelV4CallOptions);
+    const reasoning = first.content.find((part) => part.type === "reasoning");
+    expect(reasoning?.providerMetadata?.openaiCompatible?.reasoningDetails).toEqual(
+      REASONING_DETAILS,
+    );
+
+    await model.doGenerate({
+      prompt: [userPrompt()[0]!, assistantPrompt(first.content), toolResultPrompt()],
+    } as LanguageModelV4CallOptions);
+
+    expect(requestBodies[0]).toMatchObject({ reasoning_split: true });
+    expect(requestBodies[1]).toMatchObject({
+      messages: [
+        expect.any(Object),
+        expect.objectContaining({
+          reasoning_content: REASONING_DETAILS[0].text,
+          reasoning_details: REASONING_DETAILS,
+        }),
+        expect.any(Object),
+      ],
+      reasoning_split: true,
+    });
+  });
+
+  it("keeps streaming reasoning_details on the completed reasoning part", async () => {
+    const eventStream = [
+      `data: ${JSON.stringify({ choices: [{ delta: {
+        reasoning_content: REASONING_DETAILS[0].text,
+        reasoning_details: REASONING_DETAILS,
+      }, index: 0 }] })}\n\n`,
+      `data: ${JSON.stringify({ choices: [{ delta: { content: "Готовый ответ" }, finish_reason: "stop", index: 0 }] })}\n\n`,
+      "data: [DONE]\n\n",
+    ].join("");
+    const model = createMiniMaxCliProxyModel({
+      apiKey: "proxy-key",
+      baseURL: "http://cli-proxy-api:8317/v1",
+      fetch: async () => new Response(eventStream, {
+        headers: { "content-type": "text/event-stream" },
+        status: 200,
+      }),
+      modelId: "MiniMax-M3",
+    });
+
+    const { stream } = await model.doStream({ prompt: userPrompt() } as LanguageModelV4CallOptions);
+    const parts: LanguageModelV4StreamPart[] = [];
+    for await (const part of stream) parts.push(part);
+
+    expect(parts.find((part) => part.type === "reasoning-delta")).toMatchObject({
+      delta: REASONING_DETAILS[0].text,
+    });
+    expect(parts.find((part) => part.type === "reasoning-end")).toMatchObject({
+      providerMetadata: {
+        openaiCompatible: { reasoningDetails: REASONING_DETAILS },
+      },
+    });
+    expect(parts.find((part) => part.type === "text-delta")).toMatchObject({
+      delta: "Готовый ответ",
+    });
+  });
+
+  it("fails closed when case-variant inline reasoning appears in text", async () => {
+    const model = createMiniMaxCliProxyModel({
+      apiKey: "proxy-key",
+      baseURL: "http://cli-proxy-api:8317/v1",
+      fetch: async () => jsonResponse(completion({
+        content: "<THINK>Скрытое рассуждение</THINK>Ответ",
+        role: "assistant",
+      }, "stop")),
+      modelId: "MiniMax-M3",
+    });
+
+    await expect(
+      model.doGenerate({ prompt: userPrompt() } as LanguageModelV4CallOptions),
+    ).rejects.toThrow("AGENT_MINIMAX_REASONING_CONTRACT_VIOLATION");
+  });
+
+  it("fails closed when an inline boundary is split across stream chunks", async () => {
+    const eventStream = [
+      `data: ${JSON.stringify({ choices: [{ delta: { content: "<thi" }, index: 0 }] })}\n\n`,
+      `data: ${JSON.stringify({ choices: [{ delta: { content: "nk>Скрыто" }, index: 0 }] })}\n\n`,
+      "data: [DONE]\n\n",
+    ].join("");
+    const model = createMiniMaxCliProxyModel({
+      apiKey: "proxy-key",
+      baseURL: "http://cli-proxy-api:8317/v1",
+      fetch: async () => new Response(eventStream, {
+        headers: { "content-type": "text/event-stream" },
+        status: 200,
+      }),
+      modelId: "MiniMax-M3",
+    });
+
+    const { stream } = await model.doStream({ prompt: userPrompt() } as LanguageModelV4CallOptions);
+    await expect(async () => {
+      for await (const _part of stream) {
+        // Fully consume the provider stream so contract errors propagate.
+      }
+    }).rejects.toThrow("AGENT_MINIMAX_REASONING_CONTRACT_VIOLATION");
+  });
+});

--- a/agent/lib/minimax-model.test.ts
+++ b/agent/lib/minimax-model.test.ts
@@ -4,7 +4,8 @@
  * Constructs covered:
  * - `createMiniMaxCliProxyModel`: adds `reasoning_split` to every request.
  * - MiniMax `reasoning_details` survives a complete assistant/tool round trip.
- * - Streaming reasoning metadata remains attached to the AI SDK reasoning part.
+ * - Incremental streaming reasoning metadata is reconstructed on the AI SDK reasoning part.
+ * - Multiple reasoning history parts serialize one complete MiniMax details envelope.
  * - Inline reasoning in text fails closed when the upstream contract is violated.
  */
 import { describe, expect, it } from "vitest";
@@ -24,6 +25,14 @@ const REASONING_DETAILS = [{
   text: "Проверяю погоду через инструмент.",
   type: "reasoning.text",
 }] as const;
+const REASONING_DETAILS_FRAGMENT_ONE = [{
+  ...REASONING_DETAILS[0],
+  text: "Проверяю ",
+}];
+const REASONING_DETAILS_FRAGMENT_TWO = [{
+  ...REASONING_DETAILS[0],
+  text: "погоду через инструмент.",
+}];
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -143,8 +152,12 @@ describe("createMiniMaxCliProxyModel", () => {
   it("keeps streaming reasoning_details on the completed reasoning part", async () => {
     const eventStream = [
       `data: ${JSON.stringify({ choices: [{ delta: {
-        reasoning_content: REASONING_DETAILS[0].text,
-        reasoning_details: REASONING_DETAILS,
+        reasoning_content: REASONING_DETAILS_FRAGMENT_ONE[0].text,
+        reasoning_details: REASONING_DETAILS_FRAGMENT_ONE,
+      }, index: 0 }] })}\n\n`,
+      `data: ${JSON.stringify({ choices: [{ delta: {
+        reasoning_content: REASONING_DETAILS_FRAGMENT_TWO[0].text,
+        reasoning_details: REASONING_DETAILS_FRAGMENT_TWO,
       }, index: 0 }] })}\n\n`,
       `data: ${JSON.stringify({ choices: [{ delta: { content: "Готовый ответ" }, finish_reason: "stop", index: 0 }] })}\n\n`,
       "data: [DONE]\n\n",
@@ -164,7 +177,7 @@ describe("createMiniMaxCliProxyModel", () => {
     for await (const part of stream) parts.push(part);
 
     expect(parts.find((part) => part.type === "reasoning-delta")).toMatchObject({
-      delta: REASONING_DETAILS[0].text,
+      delta: REASONING_DETAILS_FRAGMENT_ONE[0].text,
     });
     expect(parts.find((part) => part.type === "reasoning-end")).toMatchObject({
       providerMetadata: {
@@ -173,6 +186,46 @@ describe("createMiniMaxCliProxyModel", () => {
     });
     expect(parts.find((part) => part.type === "text-delta")).toMatchObject({
       delta: "Готовый ответ",
+    });
+  });
+
+  it("combines incremental reasoning metadata from assistant history parts", async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const model = createMiniMaxCliProxyModel({
+      apiKey: "proxy-key",
+      baseURL: "http://cli-proxy-api:8317/v1",
+      fetch: async (_input, init) => {
+        requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return jsonResponse(completion({ content: "Готово.", role: "assistant" }, "stop"));
+      },
+      modelId: "MiniMax-M3",
+    });
+    const reasoningParts: LanguageModelV4Content[] = [
+      {
+        providerMetadata: {
+          openaiCompatible: { reasoningDetails: REASONING_DETAILS_FRAGMENT_ONE },
+        },
+        text: REASONING_DETAILS_FRAGMENT_ONE[0].text,
+        type: "reasoning",
+      },
+      {
+        providerMetadata: {
+          openaiCompatible: { reasoningDetails: REASONING_DETAILS_FRAGMENT_TWO },
+        },
+        text: REASONING_DETAILS_FRAGMENT_TWO[0].text,
+        type: "reasoning",
+      },
+    ];
+
+    await model.doGenerate({
+      prompt: [userPrompt()[0]!, assistantPrompt(reasoningParts)],
+    } as LanguageModelV4CallOptions);
+
+    expect(requestBody).toMatchObject({
+      messages: [
+        expect.any(Object),
+        expect.objectContaining({ reasoning_details: REASONING_DETAILS }),
+      ],
     });
   });
 

--- a/agent/lib/minimax-model.ts
+++ b/agent/lib/minimax-model.ts
@@ -1,0 +1,118 @@
+/**
+ * MiniMax model adapter for the internal OpenAI-compatible CLIProxy route.
+ *
+ * Exports:
+ * - `createMiniMaxCliProxyModel`: creates a MiniMax chat model with separated
+ *   reasoning and a fail-closed inline-reasoning contract validator.
+ *
+ * Key constructs:
+ * - `reasoning_split: true` is an integration invariant, not runtime configuration.
+ * - The patched OpenAI-compatible provider preserves exact `reasoning_details`
+ *   metadata through assistant/tool history for interleaved thinking.
+ * - Reserved reasoning boundaries in text fail the model call without rewriting it.
+ */
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import type {
+  LanguageModelV4Content,
+  LanguageModelV4StreamPart,
+} from "@ai-sdk/provider";
+import type { FetchFunction } from "@ai-sdk/provider-utils";
+import {
+  wrapLanguageModel,
+  type LanguageModelMiddleware,
+} from "ai";
+
+import { AppError } from "./app-error.js";
+
+const CLI_PROXY_PROVIDER_NAME = "cli-proxy-api";
+const MINI_MAX_REASONING_BOUNDARIES = [
+  "<think",
+  "</think",
+  "<mm:think",
+  "</mm:think",
+  "<thinking",
+  "</thinking",
+] as const;
+const MAX_REASONING_BOUNDARY_LENGTH = Math.max(
+  ...MINI_MAX_REASONING_BOUNDARIES.map((boundary) => boundary.length),
+);
+
+interface MiniMaxCliProxyModelOptions {
+  readonly apiKey: string;
+  readonly baseURL: string;
+  readonly fetch?: FetchFunction;
+  readonly modelId: string;
+}
+
+function reasoningContractError(): AppError {
+  return new AppError(
+    "AGENT_MINIMAX_REASONING_CONTRACT_VIOLATION",
+    "Модель вернула внутреннее рассуждение в тексте ответа. Попробуйте повторить запрос",
+  );
+}
+
+function containsReasoningBoundary(text: string): boolean {
+  const normalized = text.toLowerCase();
+  return MINI_MAX_REASONING_BOUNDARIES.some((boundary) => normalized.includes(boundary));
+}
+
+function assertSeparatedContent(content: readonly LanguageModelV4Content[]): void {
+  // `reasoning_split` guarantees that text parts contain only user-visible output.
+  for (const part of content) {
+    if (part.type === "text" && containsReasoningBoundary(part.text)) {
+      throw reasoningContractError();
+    }
+  }
+}
+
+function reasoningContractMiddleware(): LanguageModelMiddleware {
+  return {
+    specificationVersion: "v4",
+    async wrapGenerate({ doGenerate }) {
+      const result = await doGenerate();
+      assertSeparatedContent(result.content);
+      return result;
+    },
+    async wrapStream({ doStream }) {
+      const result = await doStream();
+      const suffixes = new Map<string, string>();
+      return {
+        ...result,
+        stream: result.stream.pipeThrough(
+          new TransformStream<LanguageModelV4StreamPart, LanguageModelV4StreamPart>({
+            transform(part, controller) {
+              if (part.type !== "text-delta") {
+                controller.enqueue(part);
+                return;
+              }
+
+              // Retain only enough prior text to detect an exact boundary split across chunks.
+              const combined = `${suffixes.get(part.id) ?? ""}${part.delta}`;
+              if (containsReasoningBoundary(combined)) {
+                controller.error(reasoningContractError());
+                return;
+              }
+              suffixes.set(part.id, combined.slice(-(MAX_REASONING_BOUNDARY_LENGTH - 1)));
+              controller.enqueue(part);
+            },
+          }),
+        ),
+      };
+    },
+  };
+}
+
+export function createMiniMaxCliProxyModel(options: MiniMaxCliProxyModelOptions) {
+  const provider = createOpenAICompatible({
+    apiKey: options.apiKey,
+    baseURL: options.baseURL,
+    ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+    name: CLI_PROXY_PROVIDER_NAME,
+    // MiniMax must return reasoning separately so Eve never receives it as message text.
+    transformRequestBody: (body) => ({ ...body, reasoning_split: true }),
+  });
+  return wrapLanguageModel({
+    middleware: reasoningContractMiddleware(),
+    model: provider.chatModel(options.modelId),
+  });
+}

--- a/agent/lib/model-registry.test.ts
+++ b/agent/lib/model-registry.test.ts
@@ -5,6 +5,7 @@
  * - `primaryModel`: server-configured CLIProxy text route for the Eve agent loop.
  * - `visionModel`: independently configured CLIProxy route for workspace images.
  * - `voiceTranscriptionModel`: explicit Groq Whisper transcription route.
+ * - MiniMax chat models keep their CLIProxy identity after contract wrapping.
  */
 import { describe, expect, it } from "vitest";
 

--- a/agent/lib/model-registry.test.ts
+++ b/agent/lib/model-registry.test.ts
@@ -18,6 +18,7 @@ import {
 
 describe("model registry", () => {
   it("selects the configured CLIProxy text model", () => {
+    expect(modelProviderConfig.agent.upstream.name).toBe("minimax");
     expect(primaryModel.modelId).toBe(modelProviderConfig.agent.textModelId);
     expect(primaryModel.provider).toBe("cli-proxy-api.chat");
   });

--- a/agent/lib/model-registry.ts
+++ b/agent/lib/model-registry.ts
@@ -5,11 +5,20 @@
  * - `primaryModel`: server-configured CLIProxy text model for the Eve agent loop.
  * - `visionModel`: independently selected CLIProxy vision model.
  * - `voiceTranscriptionModel`: server-configured Groq Whisper route for Telegram voice notes.
+ *
+ * Key constructs:
+ * - MiniMax routes use the dedicated adapter that preserves interleaved reasoning.
+ * - Other configured OpenAI-compatible upstreams retain the generic CLIProxy route.
  */
 import { createGroq } from "@ai-sdk/groq";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 
+import { AppError } from "./app-error.js";
+import { createMiniMaxCliProxyModel } from "./minimax-model.js";
 import { modelProviderConfig } from "./model-provider-config.js";
+
+const CLI_PROXY_PROVIDER_NAME = "cli-proxy-api";
+const MINIMAX_UPSTREAM_NAME = "minimax";
 
 const groq = createGroq({
   apiKey: process.env.GROQ_API_KEY as string,
@@ -18,12 +27,33 @@ const groq = createGroq({
 const cliProxyApi = createOpenAICompatible({
   apiKey: process.env.CLI_PROXY_API_KEY as string,
   baseURL: process.env.CLI_PROXY_BASE_URL as string,
-  name: "cli-proxy-api",
+  name: CLI_PROXY_PROVIDER_NAME,
 });
 
+function cliProxyChatModel(alias: string) {
+  // Keep an explicit registry guard even though startup config validation checks aliases.
+  const upstream = modelProviderConfig.agent.upstream.models.find(
+    (model) => model.alias === alias,
+  );
+  if (!upstream) {
+    throw new AppError(
+      "AGENT_MODEL_ALIAS_UNKNOWN",
+      `Модель «${alias}» отсутствует в конфигурации upstream-моделей`,
+    );
+  }
+  if (modelProviderConfig.agent.upstream.name === MINIMAX_UPSTREAM_NAME) {
+    return createMiniMaxCliProxyModel({
+      apiKey: process.env.CLI_PROXY_API_KEY as string,
+      baseURL: process.env.CLI_PROXY_BASE_URL as string,
+      modelId: alias,
+    });
+  }
+  return cliProxyApi.chatModel(alias);
+}
+
 // Text and vision selection are independent but share one explicit CLIProxy transport.
-export const primaryModel = cliProxyApi.chatModel(modelProviderConfig.agent.textModelId);
-export const visionModel = cliProxyApi.chatModel(modelProviderConfig.agent.visionModelId);
+export const primaryModel = cliProxyChatModel(modelProviderConfig.agent.textModelId);
+export const visionModel = cliProxyChatModel(modelProviderConfig.agent.visionModelId);
 
 // Voice remains isolated on Groq and never falls back to the agent provider.
 export const voiceTranscriptionModel = groq.transcription(

--- a/agent/lib/telegram-channel-draft-policy.test.ts
+++ b/agent/lib/telegram-channel-draft-policy.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Telegram channel draft-rate regression contract.
+ *
+ * Constructs covered:
+ * - The channel starts one native thinking draft at the turn boundary.
+ * - Token deltas and tool-loop events never trigger additional draft API calls.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const TELEGRAM_CHANNEL_PATH = new URL("../channels/telegram.ts", import.meta.url);
+
+describe("Telegram channel draft policy", () => {
+  it("does not bind high-frequency model or tool events to Telegram drafts", async () => {
+    const source = await readFile(TELEGRAM_CHANNEL_PATH, "utf8");
+
+    expect(source).toContain('async "turn.started"');
+    expect(source).not.toContain('"message.appended"');
+    expect(source).not.toContain('"action.result"');
+    expect(source).not.toContain('"actions.requested"');
+  });
+});

--- a/agent/lib/telegram-progress.test.ts
+++ b/agent/lib/telegram-progress.test.ts
@@ -3,7 +3,6 @@
  *
  * Constructs covered:
  * - `completedTelegramMessage`: keeps concise model-authored progress before tool calls.
- * - Plain and namespaced MiniMax thinking tags never cross the Telegram boundary.
  * - Empty model steps remain invisible to avoid technical Telegram noise.
  */
 import { describe, expect, it } from "vitest";
@@ -20,70 +19,18 @@ describe("completedTelegramMessage", () => {
     ).toBe("Собрал информацию. Теперь формирую документ.");
   });
 
-  it("does not expose an empty technical tool step", () => {
+  it("trims surrounding whitespace from a delivered message", () => {
     expect(
-      completedTelegramMessage({ finishReason: "tool-calls", message: "   " }),
-    ).toBeNull();
-  });
-
-  it("removes complete and unclosed MiniMax thinking blocks", () => {
-    expect(
-      completedTelegramMessage({
-        finishReason: "stop",
-        message: "<think>Внутреннее рассуждение</think>\n\nГотовый ответ",
-      }),
+      completedTelegramMessage({ finishReason: "stop", message: "\n\nГотовый ответ  " }),
     ).toBe("Готовый ответ");
-    expect(
-      completedTelegramMessage({
-        finishReason: "length",
-        message: "<think>Незавершённое внутреннее рассуждение",
-      }),
-    ).toBeNull();
   });
 
-  it("removes every namespaced MiniMax thinking block embedded between visible text", () => {
-    expect(
-      completedTelegramMessage({
-        finishReason: "stop",
-        message: [
-          "<mm:think>Первое внутреннее рассуждение</mm:think>",
-          "Промежуточный результат",
-          "<mm:think>Второе внутреннее рассуждение</mm:think>",
-          "Готовый ответ",
-        ].join("\n"),
-      }),
-    ).toBe("Промежуточный результат\n\nГотовый ответ");
-
-    expect(
-      completedTelegramMessage({
-        finishReason: "length",
-        message: "<mm:think>Незавершённое внутреннее рассуждение",
-      }),
-    ).toBeNull();
-  });
-
-  it("removes reasoning before MiniMax's orphan namespaced closing marker", () => {
-    expect(
-      completedTelegramMessage({
-        finishReason: "stop",
-        message:
-          "Пользователь спрашивает о Telegram API.</mm:think>\n\nПонял вопрос. Вот готовый ответ.",
-      }),
-    ).toBe("Понял вопрос. Вот готовый ответ.");
-  });
-
-  it("rejoins visible text split by duplicated reasoning and orphan closing markers", () => {
-    expect(
-      completedTelegramMessage({
-        finishReason: "stop",
-        message: [
-          "<think>Пользователь спрашивает, как у меня дела.</think>",
-          "В",
-          "</think>",
-          " у меня дела. Это повтор внутреннего рассуждения.",
-          "</think>сё отлично, готов помогать!",
-        ].join("\n"),
-      }),
-    ).toBe("Всё отлично, готов помогать!");
+  it.each([
+    { finishReason: "tool-calls", message: "   " },
+    { finishReason: "stop", message: "" },
+    { finishReason: "stop", message: null },
+    { finishReason: "stop" },
+  ])("does not expose an empty technical step %#", (data) => {
+    expect(completedTelegramMessage(data)).toBeNull();
   });
 });

--- a/agent/lib/telegram-progress.ts
+++ b/agent/lib/telegram-progress.ts
@@ -3,55 +3,15 @@
  *
  * Exports:
  * - `completedTelegramMessage`: keeps meaningful final or pre-tool model text and hides empty steps.
- * - `visibleTelegramModelText`: removes plain and namespaced MiniMax thinking from Telegram output.
+ *
+ * MiniMax reasoning is separated by `minimax-model.ts`; Eve routes reasoning parts
+ * to dedicated events that this delivery policy never receives.
  */
-const COMPLETE_THINKING_BLOCK_PATTERN =
-  /<(mm:)?think(?:\s[^>]*)?>[\s\S]*?<\/\1think\s*>/giu;
-const UNCLOSED_THINKING_BLOCK_PATTERN =
-  /<(?:mm:)?think(?:\s[^>]*)?(?:>|$)[\s\S]*$/iu;
-const THINKING_CLOSE_PATTERN = /<\/(?:mm:)?think\s*>/giu;
-const THINKING_OPEN_PREFIXES = ["<mm:think", "<think"] as const;
-
-export function visibleTelegramModelText(message: string): string {
-  // MiniMax emits reasoning inside ordinary content and can duplicate stream boundaries.
-  let removedCompleteBlock = false;
-  let visible = message
-    .replace(COMPLETE_THINKING_BLOCK_PATTERN, () => {
-      removedCompleteBlock = true;
-      return "";
-    })
-    .replace(UNCLOSED_THINKING_BLOCK_PATTERN, "");
-
-  // A corrupted stream can inject duplicated reasoning between visible token fragments.
-  const closingMarkers = [...visible.matchAll(THINKING_CLOSE_PATTERN)];
-  if (closingMarkers.length > 0) {
-    const first = closingMarkers[0]!;
-    const last = closingMarkers[closingMarkers.length - 1]!;
-    const suffix = visible.slice(last.index + last[0].length).trimStart();
-    visible = removedCompleteBlock
-      ? `${visible.slice(0, first.index).trimEnd()}${suffix}`
-      : suffix;
-  }
-
-  // Cumulative Eve drafts can end in a split plain or namespaced opening tag.
-  const normalized = visible.toLowerCase();
-  for (const prefix of THINKING_OPEN_PREFIXES) {
-    for (let length = prefix.length - 1; length > 0; length -= 1) {
-      if (!normalized.endsWith(prefix.slice(0, length))) continue;
-      visible = visible.slice(0, -length);
-      return visible.trim();
-    }
-  }
-  return visible.trim();
-}
-
 export function completedTelegramMessage(data: {
   finishReason: string;
   message?: string | null;
 }): string | null {
   const message =
-    data.message === undefined || data.message === null
-      ? ""
-      : visibleTelegramModelText(data.message);
+    data.message === undefined || data.message === null ? "" : data.message.trim();
   return message ? message : null;
 }

--- a/agent/lib/telegram-rich-markdown.test.ts
+++ b/agent/lib/telegram-rich-markdown.test.ts
@@ -13,7 +13,6 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
 import {
-  formatTelegramRichMessageDraft,
   formatTelegramRichMessages,
   sanitizeTelegramRichMarkdown,
 } from "./telegram-rich-markdown.js";
@@ -94,16 +93,6 @@ describe("formatTelegramRichMessages", () => {
     expect(chunks).toHaveLength(2);
     expect(chunks[0]).toBe(paragraph);
     expect(chunks[1]).toBe(code);
-  });
-
-  it("stops draft updates when the complete preview exceeds the rich limit", () => {
-    expect(formatTelegramRichMessageDraft("слово ".repeat(6_000))).toBeNull();
-  });
-
-  it("keeps an incomplete streamed HTML block inert until the model closes it", () => {
-    expect(formatTelegramRichMessageDraft("<details><summary>Пояснение")).toBe(
-      "&lt;details&gt;&lt;summary&gt;Пояснение",
-    );
   });
 
   it("fails explicitly when one indivisible block exceeds the rich limit", () => {

--- a/agent/lib/telegram-rich-markdown.ts
+++ b/agent/lib/telegram-rich-markdown.ts
@@ -4,7 +4,6 @@
  * Exports:
  * - `sanitizeTelegramRichMarkdown`: preserves text-rich structure and neutralizes active content.
  * - `formatTelegramRichMessages`: produces complete blocks within Telegram's rich text limit.
- * - `formatTelegramRichMessageDraft`: returns one valid ephemeral preview or `null` when too long.
  *
  * Key constructs:
  * - A narrow HTML allowlist for details and inline text formatting.
@@ -227,10 +226,4 @@ export function formatTelegramRichMessages(markdown: string): string[] {
   }
   if (chunk) chunks.push(chunk);
   return chunks;
-}
-
-export function formatTelegramRichMessageDraft(markdown: string): string | null {
-  const sanitized = sanitizeTelegramRichMarkdown(markdown).trim();
-  if (!sanitized || characterLength(sanitized) > TELEGRAM_RICH_MESSAGE_MAX_CHARACTERS) return null;
-  return sanitized;
 }

--- a/agent/lib/telegram-rich-messages.test.ts
+++ b/agent/lib/telegram-rich-messages.test.ts
@@ -2,7 +2,7 @@
  * Native Telegram Rich Message delivery tests.
  *
  * Constructs covered:
- * - RichBlockThinking and text updates reuse one draft per private chat/topic.
+ * - RichBlockThinking uses one stable draft per private chat/topic.
  * - Completed output is persisted with sendRichMessage and anchors group conversations.
  * - The first chunk of a group response replies to the verified triggering message.
  * - Telegram rejection and ambiguous transport failures remain fail-fast without retries.
@@ -12,7 +12,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   postTelegramRichMessage,
   startTelegramRichThinkingDraft,
-  streamTelegramRichMessageDraft,
 } from "./telegram-rich-messages.js";
 
 beforeEach(() => vi.stubEnv("TELEGRAM_BOT_TOKEN", "telegram-bot-secret"));
@@ -67,72 +66,6 @@ describe("Telegram rich drafts", () => {
       message_thread_id: 42,
       rich_message: { html: expect.stringContaining("<tg-thinking>") },
     });
-  });
-
-  it("reuses one draft for thinking, all steps, and later turns in the same chat", async () => {
-    const telegramFetch = vi
-      .spyOn(globalThis, "fetch")
-      .mockImplementation(async () => telegramResponse(true));
-    const target = telegramTarget();
-
-    await startTelegramRichThinkingDraft(target);
-    await streamTelegramRichMessageDraft(
-      {
-        messageSoFar: "Первый шаг",
-        stepIndex: 0,
-        turnId: "turn_first",
-      },
-      target,
-    );
-    await streamTelegramRichMessageDraft(
-      {
-        messageSoFar: "Следующий ответ",
-        stepIndex: 2,
-        turnId: "turn_next",
-      },
-      target,
-    );
-
-    const ids = telegramFetch.mock.calls.map(
-      (_call, index) => requestBody(telegramFetch, index).draft_id,
-    );
-    expect(new Set(ids).size).toBe(1);
-  });
-
-  it("keeps partial MiniMax thinking private until visible answer text arrives", async () => {
-    const telegramFetch = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(telegramResponse(true));
-    const target = telegramTarget();
-
-    await streamTelegramRichMessageDraft(
-      {
-        messageSoFar: "<thi",
-        stepIndex: 0,
-        turnId: "turn_minimax",
-      },
-      target,
-    );
-    await streamTelegramRichMessageDraft(
-      {
-        messageSoFar: "<mm:thi",
-        stepIndex: 0,
-        turnId: "turn_minimax",
-      },
-      target,
-    );
-    await streamTelegramRichMessageDraft(
-      {
-        messageSoFar: "<think>Скрытое рассуждение</think>\n\nВидимый ответ",
-        stepIndex: 0,
-        turnId: "turn_minimax",
-      },
-      target,
-    );
-
-    expect(telegramFetch).toHaveBeenCalledOnce();
-    const body = requestBody(telegramFetch);
-    expect(body.rich_message).toEqual({ markdown: "Видимый ответ" });
   });
 
   it("keeps independent drafts for different private topics", async () => {

--- a/agent/lib/telegram-rich-messages.ts
+++ b/agent/lib/telegram-rich-messages.ts
@@ -3,7 +3,6 @@
  *
  * Exports:
  * - `startTelegramRichThinkingDraft`: displays Telegram's native ephemeral thinking block.
- * - `streamTelegramRichMessageDraft`: updates the same chat-scoped draft with model output.
  * - `postTelegramRichMessage`: persists completed rich output and records group anchors.
  *
  * Key constructs:
@@ -24,12 +23,8 @@ import {
 
 import { TELEGRAM_API_REQUEST_TIMEOUT_MS } from "../config.js";
 import { AppError } from "./app-error.js";
-import { visibleTelegramModelText } from "./telegram-progress.js";
 import type { TelegramReplyParameters } from "./telegram-reply.js";
-import {
-  formatTelegramRichMessageDraft,
-  formatTelegramRichMessages,
-} from "./telegram-rich-markdown.js";
+import { formatTelegramRichMessages } from "./telegram-rich-markdown.js";
 
 const TELEGRAM_DRAFT_ID_MODULUS = 2_147_483_647;
 const TELEGRAM_THINKING_CUSTOM_EMOJI_ID = "5535034915403333642";
@@ -40,15 +35,6 @@ const TELEGRAM_CHAT_TYPES = new Set<TelegramChatType>([
   "private",
   "supergroup",
 ]);
-
-interface TelegramTurnEvent {
-  readonly turnId: string;
-}
-
-interface TelegramDraftEvent extends TelegramTurnEvent {
-  readonly messageSoFar: string;
-  readonly stepIndex: number;
-}
 
 type TelegramRichTarget = Pick<
   TelegramHandle,
@@ -263,22 +249,6 @@ export async function startTelegramRichThinkingDraft(
   if (target.chatType !== "private") return;
   const response = await requestTelegramRichApi("sendRichMessageDraft", {
     ...richBody(target, { html: TELEGRAM_THINKING_HTML }, true),
-    draft_id: draftId(target),
-  });
-  requireDraftSuccess(response);
-}
-
-export async function streamTelegramRichMessageDraft(
-  event: TelegramDraftEvent,
-  target: TelegramRichTarget,
-): Promise<void> {
-  if (target.chatType !== "private") return;
-  const markdown = formatTelegramRichMessageDraft(
-    visibleTelegramModelText(event.messageSoFar),
-  );
-  if (!markdown) return;
-  const response = await requestTelegramRichApi("sendRichMessageDraft", {
-    ...richBody(target, { markdown }, true),
     draft_id: draftId(target),
   });
   requireDraftSuccess(response);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/groq": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "imports": {
@@ -18,7 +18,7 @@
     "typecheck": "tsc",
     "migrate": "node --experimental-strip-types scripts/migrate.ts",
     "memory:reindex": "node --import tsx scripts/reindex-memory.ts",
-    "postinstall": "node --experimental-strip-types scripts/apply-eve-patches.ts"
+    "postinstall": "node --experimental-strip-types scripts/apply-eve-patches.ts && node --experimental-strip-types scripts/apply-openai-compatible-patches.ts"
   },
   "dependencies": {
     "@ai-sdk/groq": "4.0.7",

--- a/production-release-contract.test.ts
+++ b/production-release-contract.test.ts
@@ -78,6 +78,15 @@ describe("production container contract", () => {
     expect(entrypoint).not.toContain("npm run migrate");
   });
 
+  it("installs every version-pinned dependency patch in build and production stages", () => {
+    const dockerfile = readProjectFile("Dockerfile");
+
+    expect(dockerfile.match(/COPY scripts\/apply-eve-patches\.ts/g)).toHaveLength(2);
+    expect(
+      dockerfile.match(/COPY scripts\/apply-openai-compatible-patches\.ts/g),
+    ).toHaveLength(2);
+  });
+
   it("uses only required digest references and one shared app image", () => {
     const compose = readProjectFile("compose.production.yaml");
 

--- a/scripts/apply-openai-compatible-patches.ts
+++ b/scripts/apply-openai-compatible-patches.ts
@@ -60,6 +60,36 @@ if (packageJson.version !== EXPECTED_OPENAI_COMPATIBLE_VERSION) {
   );
 }
 
+// Merge incremental SSE fragments while also tolerating already-cumulative detail snapshots.
+await replaceOnce(
+  `function getOpenAIMetadata(message) {
+  var _a, _b;
+  return (_b = (_a = message == null ? void 0 : message.providerOptions) == null ? void 0 : _a.openaiCompatible) != null ? _b : {};
+}
+function getAudioFormat(mediaType) {`,
+  `function getOpenAIMetadata(message) {
+  var _a, _b;
+  return (_b = (_a = message == null ? void 0 : message.providerOptions) == null ? void 0 : _a.openaiCompatible) != null ? _b : {};
+}
+function mergeMiniMaxReasoningDetails(current, incoming) {
+  const merged = current == null ? [] : current.map((detail) => ({ ...detail }));
+  for (const detail of incoming) {
+    const existingIndex = merged.findIndex(
+      (candidate) => candidate.id === detail.id && candidate.index === detail.index
+    );
+    if (existingIndex < 0) {
+      merged.push({ ...detail });
+      continue;
+    }
+    const existing = merged[existingIndex];
+    const text = detail.text.startsWith(existing.text) ? detail.text : existing.text.startsWith(detail.text) ? existing.text : existing.text + detail.text;
+    merged[existingIndex] = { ...existing, ...detail, text };
+  }
+  return merged;
+}
+function getAudioFormat(mediaType) {`,
+);
+
 // Carry provider metadata from an AI SDK reasoning part back into assistant history.
 await replaceOnce(
   `        let reasoning = "";
@@ -76,7 +106,10 @@ await replaceOnce(
   `            case "reasoning": {
               reasoning += part.text;
               if (partMetadata.reasoningDetails !== void 0) {
-                reasoningDetails = partMetadata.reasoningDetails;
+                reasoningDetails = mergeMiniMaxReasoningDetails(
+                  reasoningDetails,
+                  partMetadata.reasoningDetails
+                );
               }
               break;
             }`,
@@ -134,7 +167,7 @@ await replaceOnce(
       });`,
 );
 
-// Keep the latest cumulative details and bind them to the streamed reasoning part.
+// Accumulate incremental details and bind the complete envelope to the reasoning part.
 await replaceOnce(
   `    let isActiveReasoning = false;
     let isActiveText = false;
@@ -152,7 +185,10 @@ await replaceOnce(
             const reasoningContent = (_b2 = delta.reasoning_content) != null ? _b2 : delta.reasoning;`,
   `            const delta = choice.delta;
             if (delta.reasoning_details != null) {
-              reasoningDetails = delta.reasoning_details;
+              reasoningDetails = mergeMiniMaxReasoningDetails(
+                reasoningDetails,
+                delta.reasoning_details
+              );
             }
             const reasoningContent = (_b2 = delta.reasoning_content) != null ? _b2 : delta.reasoning;`,
 );

--- a/scripts/apply-openai-compatible-patches.ts
+++ b/scripts/apply-openai-compatible-patches.ts
@@ -1,0 +1,178 @@
+/**
+ * Reproducible @ai-sdk/openai-compatible 3.0.7 MiniMax patch installer.
+ *
+ * Constructs:
+ * - Preserves MiniMax `reasoning_details` on generated and streamed reasoning parts.
+ * - Serializes the exact details back into assistant history for interleaved thinking.
+ * - Patches only the reviewed, version-pinned runtime artifact used by Node/Eve.
+ * - Is idempotent and fails installation when the upstream artifact no longer matches.
+ */
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const EXPECTED_OPENAI_COMPATIBLE_VERSION = "3.0.7";
+const runtimePath = resolve(
+  "node_modules/@ai-sdk/openai-compatible/dist/index.js",
+);
+
+async function replaceOnce(before: string, after: string): Promise<void> {
+  const source = await readFile(runtimePath, "utf8");
+  if (source.includes(after)) return;
+  const first = source.indexOf(before);
+  if (first < 0 || source.indexOf(before, first + before.length) >= 0) {
+    throw new Error(
+      `AGENT_OPENAI_COMPATIBLE_PATCH_MISMATCH: Не удалось однозначно применить проверенный патч к ${runtimePath}`,
+    );
+  }
+  await writeFile(runtimePath, source.replace(before, after), "utf8");
+}
+
+function occurrenceCount(source: string, value: string): number {
+  return source.split(value).length - 1;
+}
+
+async function replaceAllExact(
+  before: string,
+  after: string,
+  expectedOccurrences: number,
+): Promise<void> {
+  const source = await readFile(runtimePath, "utf8");
+  const beforeCount = occurrenceCount(source, before);
+  const afterCount = occurrenceCount(source, after);
+  if (beforeCount === 0 && afterCount === expectedOccurrences) return;
+  if (beforeCount !== expectedOccurrences || afterCount !== 0) {
+    throw new Error(
+      `AGENT_OPENAI_COMPATIBLE_PATCH_MISMATCH: Ожидалось ${expectedOccurrences} совпадений проверенного патча в ${runtimePath}, найдено ${beforeCount}`,
+    );
+  }
+  await writeFile(runtimePath, source.split(before).join(after), "utf8");
+}
+
+const packageJson = JSON.parse(
+  await readFile(
+    resolve("node_modules/@ai-sdk/openai-compatible/package.json"),
+    "utf8",
+  ),
+) as { version?: string };
+if (packageJson.version !== EXPECTED_OPENAI_COMPATIBLE_VERSION) {
+  throw new Error(
+    `AGENT_OPENAI_COMPATIBLE_PATCH_VERSION_UNSUPPORTED: Ожидалась @ai-sdk/openai-compatible ${EXPECTED_OPENAI_COMPATIBLE_VERSION}, установлена ${String(packageJson.version)}`,
+  );
+}
+
+// Carry provider metadata from an AI SDK reasoning part back into assistant history.
+await replaceOnce(
+  `        let reasoning = "";
+        const toolCalls = [];`,
+  `        let reasoning = "";
+        let reasoningDetails;
+        const toolCalls = [];`,
+);
+await replaceOnce(
+  `            case "reasoning": {
+              reasoning += part.text;
+              break;
+            }`,
+  `            case "reasoning": {
+              reasoning += part.text;
+              if (partMetadata.reasoningDetails !== void 0) {
+                reasoningDetails = partMetadata.reasoningDetails;
+              }
+              break;
+            }`,
+);
+await replaceOnce(
+  `          ...reasoning.length > 0 ? { reasoning_content: reasoning } : {},
+          tool_calls: toolCalls.length > 0 ? toolCalls : void 0,`,
+  `          ...reasoning.length > 0 ? { reasoning_content: reasoning } : {},
+          ...reasoningDetails === void 0 ? {} : { reasoning_details: reasoningDetails },
+          tool_calls: toolCalls.length > 0 ? toolCalls : void 0,`,
+);
+
+// Accept MiniMax's documented structured reasoning envelope in JSON and SSE responses.
+await replaceOnce(
+  `var OpenAICompatibleChatResponseSchema = z3.looseObject({`,
+  `var miniMaxReasoningDetailsSchema = z3.array(
+  z3.looseObject({
+    type: z3.string(),
+    id: z3.string(),
+    format: z3.string(),
+    index: z3.number(),
+    text: z3.string()
+  })
+).nullish();
+var OpenAICompatibleChatResponseSchema = z3.looseObject({`,
+);
+await replaceAllExact(
+  `        reasoning_content: z3.string().nullish(),
+        reasoning: z3.string().nullish(),
+        tool_calls: z3.array(`,
+  `        reasoning_content: z3.string().nullish(),
+        reasoning: z3.string().nullish(),
+        reasoning_details: miniMaxReasoningDetailsSchema,
+        tool_calls: z3.array(`,
+  2,
+);
+
+// Attach exact details to non-stream reasoning so AI SDK response history retains them.
+await replaceOnce(
+  `    const reasoning = (_c = choice.message.reasoning_content) != null ? _c : choice.message.reasoning;
+    if (reasoning != null && reasoning.length > 0) {
+      content.push({
+        type: "reasoning",
+        text: reasoning
+      });`,
+  `    const reasoningDetails = choice.message.reasoning_details ?? void 0;
+    const reasoning = choice.message.reasoning_content ?? choice.message.reasoning ?? reasoningDetails?.map((detail) => detail.text).join("\\n");
+    if (reasoning != null && reasoning.length > 0) {
+      content.push({
+        type: "reasoning",
+        text: reasoning,
+        ...reasoningDetails === void 0 ? {} : {
+          providerMetadata: { openaiCompatible: { reasoningDetails } }
+        }
+      });`,
+);
+
+// Keep the latest cumulative details and bind them to the streamed reasoning part.
+await replaceOnce(
+  `    let isActiveReasoning = false;
+    let isActiveText = false;
+    const convertUsage = (usage2) => this.convertUsage(usage2);`,
+  `    let isActiveReasoning = false;
+    let isActiveText = false;
+    let reasoningDetails;
+    const reasoningProviderMetadata = () => reasoningDetails == null ? void 0 : {
+      openaiCompatible: { reasoningDetails }
+    };
+    const convertUsage = (usage2) => this.convertUsage(usage2);`,
+);
+await replaceOnce(
+  `            const delta = choice.delta;
+            const reasoningContent = (_b2 = delta.reasoning_content) != null ? _b2 : delta.reasoning;`,
+  `            const delta = choice.delta;
+            if (delta.reasoning_details != null) {
+              reasoningDetails = delta.reasoning_details;
+            }
+            const reasoningContent = (_b2 = delta.reasoning_content) != null ? _b2 : delta.reasoning;`,
+);
+await replaceAllExact(
+  `                controller.enqueue({
+                  type: "reasoning-end",
+                  id: "reasoning-0"
+                });`,
+  `                controller.enqueue({
+                  type: "reasoning-end",
+                  id: "reasoning-0",
+                  providerMetadata: reasoningProviderMetadata()
+                });`,
+  2,
+);
+await replaceOnce(
+  `              controller.enqueue({ type: "reasoning-end", id: "reasoning-0" });`,
+  `              controller.enqueue({
+                type: "reasoning-end",
+                id: "reasoning-0",
+                providerMetadata: reasoningProviderMetadata()
+              });`,
+);


### PR DESCRIPTION
## Summary
- force MiniMax `reasoning_split` at the model adapter boundary and preserve exact `reasoning_details` through assistant/tool history
- fail closed if reasoning markers still appear in user-visible content
- remove Telegram regex rewriting and high-frequency rich-message draft updates
- add a version-pinned, idempotent OpenAI-compatible provider patch and bump the release to `0.2.4`

## Verification
- `npm ci`
- `npm run typecheck`
- `npm test` (408 passed, 78 skipped locally)
- `npm run build`
- `npm run build:runtime`
- `docker compose -f compose.test.yaml up --build --abort-on-container-exit --exit-code-from tests` (486 passed)
- production CLIProxy MiniMax two-step tool loop with preserved `reasoning_details`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Что изменилось

- Добавлена специализированная обработка MiniMax reasoning:
  - включается `reasoning_split: true`;
  - `reasoning_details` сохраняются в assistant/tool history и потоковых событиях;
  - добавлена fail-closed проверка inline reasoning-маркеров.
- Реализован версионно-закреплённый идемпотентный патч для `@ai-sdk/openai-compatible` версии `3.0.7`, подключённый к `postinstall` и Docker-сборке.
- Реестр моделей теперь выбирает MiniMax-адаптер для соответствующего upstream и экспортирует модель транскрибации Groq.
- Упрощена Telegram-доставка: удалены regex-обработка reasoning и частые обновления rich-message drafts; сохраняется один thinking draft на turn и публикация завершённого сообщения.
- Версия пакета повышена до `0.2.4`.
- Добавлены и обновлены тесты для reasoning-контрактов, сохранения метаданных, Telegram draft-политики и production Docker-контракта.

## Проверка

Покрыты type checking, тесты, сборка, Docker-тесты и production CLIProxy MiniMax двухшаговый tool loop с сохранением `reasoning_details`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->