### PR TITLE
Release v0.2.6 after production preflight cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/groq": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- bump the immutable release version to `0.2.6` after `v0.2.5` correctly failed the pre-migration backup-space preflight
- application and deployment bytes are unchanged from the fully verified `v0.2.5` release
- reclaim unused production Docker build cache so backup preflight has 6.9 GB available

## Verification
- `npm run typecheck`
- `npx vitest run production-release-contract.test.ts` (15 passed)
- prior full Docker Compose release suite (516 passed)
- production current remains healthy on `v0.2.4`; failed deployment did not begin migration