### PR TITLE
Fix Google Workspace tool arguments

### DIFF
--- a/agent/lib/google-workspace/google-workspace-tool.test.ts
+++ b/agent/lib/google-workspace/google-workspace-tool.test.ts
@@ -2,10 +2,12 @@
  * Google Workspace model-facing tool policy tests.
  *
  * Constructs covered:
+ * - Provider-facing input JSON Schema is a flat object without root-level unions.
  * - OAuth initiation and known reads do not create redundant Eve approvals.
  * - Mutations, uploads, and unknown dynamic methods require HITL.
  */
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 
 import googleWorkspace from "../../tools/google_workspace.js";
 
@@ -17,6 +19,19 @@ function approvalFor(input: Record<string, unknown>) {
 }
 
 describe("google_workspace approval policy", () => {
+  it("publishes a provider-compatible flat input schema", () => {
+    const schema = z.toJSONSchema((googleWorkspace as unknown as {
+      inputSchema: Parameters<typeof z.toJSONSchema>[0];
+    }).inputSchema) as Record<string, unknown>;
+
+    expect(schema.type).toBe("object");
+    expect(schema).not.toHaveProperty("oneOf");
+    expect(schema).not.toHaveProperty("anyOf");
+    expect(schema.properties).toMatchObject({
+      action: { enum: ["connect", "execute"], type: "string" },
+    });
+  });
+
   it("requires approval for every possible external mutation", () => {
     expect(approvalFor({ action: "connect" })).toBe("not-applicable");
     expect(approvalFor({

--- a/agent/tools/google_workspace.ts
+++ b/agent/tools/google_workspace.ts
@@ -7,6 +7,7 @@
 import { defineTool } from "eve/tools";
 import { z } from "zod";
 
+import { AppError } from "../lib/app-error.js";
 import { requireGoogleWorkspaceAuthorization } from "../lib/google-workspace/google-workspace-context.js";
 import {
   googleWorkspaceCommandSchema,
@@ -19,22 +20,35 @@ const workspaceFileSchema = z.object({
   path: z.string().min(1).max(512),
   scope: z.enum(["personal", "family"]),
 }).strict();
-const googleWorkspaceToolSchema = z.discriminatedUnion("action", [
-  z.object({ action: z.literal("connect") }).strict(),
-  z.object({
-    action: z.literal("execute"),
-    command: googleWorkspaceCommandSchema.omit({ uploadContentType: true }),
-    output: workspaceFileSchema.optional(),
-    upload: workspaceFileSchema.extend({
-      contentType: z.string().min(1).max(200),
-    }).strict().optional(),
-  }).strict(),
-]);
+const googleWorkspaceExecuteSchema = z.object({
+  action: z.literal("execute"),
+  command: googleWorkspaceCommandSchema.omit({ uploadContentType: true }),
+  output: workspaceFileSchema.optional(),
+  upload: workspaceFileSchema.extend({
+    contentType: z.string().min(1).max(200),
+  }).strict().optional(),
+}).strict();
+
+// Root-level `oneOf` is not reliably supported by OpenAI-compatible function calling providers.
+const googleWorkspaceToolSchema = z.object({
+  action: z.enum(["connect", "execute"]),
+  command: googleWorkspaceExecuteSchema.shape.command.optional(),
+  output: workspaceFileSchema.optional(),
+  upload: googleWorkspaceExecuteSchema.shape.upload,
+}).strict();
+
+function invalidToolInput(): never {
+  throw new AppError(
+    "AGENT_GOOGLE_WORKSPACE_PARAMETERS_INVALID",
+    "Параметры Google Workspace не заполнены. Повторите запрос",
+  );
+}
 
 export default defineTool({
   approval: ({ toolInput }) => {
     if (toolInput?.action !== "execute") return "not-applicable";
     if (toolInput.upload) return "user-approval";
+    if (!toolInput.command) return "user-approval";
     return isGoogleWorkspaceReadOnlyCommand(toolInput.command)
       ? "not-applicable"
       : "user-approval";
@@ -45,8 +59,11 @@ export default defineTool({
   async execute(input, ctx) {
     const authorization = requireGoogleWorkspaceAuthorization(ctx);
     if (input.action === "connect") {
+      if (input.command || input.output || input.upload) invalidToolInput();
       return await startGoogleWorkspaceAuthorization(authorization);
     }
-    return await executeGoogleWorkspaceCommand(authorization, input, ctx.callId);
+    const execution = googleWorkspaceExecuteSchema.safeParse(input);
+    if (!execution.success) invalidToolInput();
+    return await executeGoogleWorkspaceCommand(authorization, execution.data, ctx.callId);
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/groq": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- replace the root-level discriminated `oneOf` tool contract with a provider-compatible flat object schema
- keep connect/execute invariants fail-closed inside the trusted tool boundary
- add a regression test for the exact compiled schema shape
- bump the immutable patch release to `0.2.7`

## Root cause
MiniMax/OpenAI-compatible function calling did not reliably populate arguments for a root-level `oneOf` schema, so Eve received `{}` and rejected the call before execution.

## Verification
- red/green provider-schema regression test
- `npm run typecheck`
- `npm test` (517 total)
- `npm run build` and compiled manifest assertion
- `npm run build:runtime`
- full Docker Compose suite (517 passed)