### PR TITLE
Add CA roots for Google Workspace CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,9 @@ USER node
 CMD ["node", ".runtime/services/sandbox-egress-proxy/main.js"]
 
 FROM first-party-node AS runtime
+RUN apt-get update \
+    && apt-get install --no-install-recommends --yes ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 ENV NODE_ENV=production
 COPY --from=production-dependencies /app/node_modules ./node_modules

--- a/compose-runtime.test.ts
+++ b/compose-runtime.test.ts
@@ -8,6 +8,7 @@
  * - PDF processing stays inside the normal sandbox instead of a parallel service.
  * - Docker socket, runner control plane, egress proxy, and tools volume remain isolated.
  * - Dynamic skill package assets are shipped in the production agent image.
+ * - Production agent runtime includes system CA roots for native integration binaries.
  * - Node application services explicitly select the production runtime image stage.
  * - Nginx re-resolves the agent service after Docker replaces its container IP.
  */
@@ -101,6 +102,18 @@ describe("Docker Compose runtime wiring", () => {
     const dockerfile = readFileSync(new URL("Dockerfile", projectRoot), "utf8");
 
     expect(dockerfile).toContain("COPY --from=build /app/resources ./resources\n");
+  });
+
+  it("installs system CA roots in the production agent runtime", () => {
+    const dockerfile = readFileSync(new URL("Dockerfile", projectRoot), "utf8");
+    const runtime = dockerfile.slice(
+      dockerfile.indexOf("FROM first-party-node AS runtime"),
+      dockerfile.indexOf("FROM nginx:", dockerfile.indexOf("FROM first-party-node AS runtime")),
+    );
+
+    // The native gws binary uses the OS trust store rather than Node's bundled root certificates.
+    expect(runtime).toContain("ca-certificates");
+    expect(runtime).toContain("rm -rf /var/lib/apt/lists/*");
   });
 
   it("builds every Node application service from the runtime stage", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/groq": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- install system CA certificates in the production agent runtime
- protect the native gws TLS dependency with an image-contract test
- bump release version to 0.2.9

## Root cause
The native gws binary failed while fetching Google Discovery documents with `invalid peer certificate: UnknownIssuer`; Node OAuth requests continued to work because Node uses its own root bundle.

## Verification
- npm run typecheck
- npm test (521 tests in Docker)
- npm run build
- npm run build:runtime
- Docker Compose runtime image build
- `gws schema gmail.users.messages.list` succeeds inside the built agent image