### PR TITLE
Release v0.2.10 after disk preflight cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/groq": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- bump the already-tested CA root hotfix from 0.2.9 to 0.2.10
- v0.2.9 correctly failed before backup/migrations because production free-space preflight found only 1.4 GB
- unused Docker images were removed; production now has 15 GB free

## Verification
- npm run typecheck
- compose-runtime.test.ts
- production-release-contract.test.ts
- v0.2.9 full Docker suite: 521 tests
- v0.2.9 built runtime successfully fetched Gmail Discovery schema over TLS