### PR TITLE
Release version 0.2.13

### DIFF
--- a/agent/lib/google-workspace/google-workspace-profile-store.test.ts
+++ b/agent/lib/google-workspace/google-workspace-profile-store.test.ts
@@ -3,7 +3,7 @@
  *
  * Constructs covered:
  * - Credentials are atomically materialized in the exact workspace directory with private modes.
- * - Removing one profile cannot affect a sibling workspace profile.
+ * - Removing one profile cannot affect sibling profiles or active workspace directory mounts.
  */
 import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -46,7 +46,7 @@ describe("Google Workspace profile store", () => {
     expect((await stat(credentials)).mode & 0o777).toBe(0o600);
   });
 
-  it("removes only the selected workspace profile", async () => {
+  it("removes only credentials while preserving the workspace directory mount target", async () => {
     const root = await mkdtemp(join(tmpdir(), "osinara-gws-profiles-"));
     roots.push(root);
     const store = createGoogleWorkspaceProfileStore(root);
@@ -58,11 +58,28 @@ describe("Google Workspace profile store", () => {
     };
     await store.write(PERSONAL_WORKSPACE_ID, credentials);
     await store.write(FAMILY_WORKSPACE_ID, credentials);
+    const personalDirectory = join(root, PERSONAL_WORKSPACE_ID);
+    const personalCredentials = join(personalDirectory, "credentials.json");
+    const directoryBeforeRemove = await stat(personalDirectory);
 
     await store.remove(PERSONAL_WORKSPACE_ID);
 
-    await expect(stat(join(root, PERSONAL_WORKSPACE_ID))).rejects.toMatchObject({ code: "ENOENT" });
+    // Active sandbox containers bind-mount this directory, so its inode must remain stable.
+    const directoryAfterRemove = await stat(personalDirectory);
+    expect(directoryAfterRemove.ino).toBe(directoryBeforeRemove.ino);
+    await expect(stat(personalCredentials)).rejects.toMatchObject({ code: "ENOENT" });
     await expect(stat(join(root, FAMILY_WORKSPACE_ID, "credentials.json"))).resolves.toBeDefined();
+
+    await store.write(PERSONAL_WORKSPACE_ID, {
+      ...credentials,
+      refresh_token: "next-refresh-secret",
+    });
+
+    const directoryAfterReconnect = await stat(personalDirectory);
+    expect(directoryAfterReconnect.ino).toBe(directoryBeforeRemove.ino);
+    expect(JSON.parse(await readFile(personalCredentials, "utf8"))).toEqual(expect.objectContaining({
+      refresh_token: "next-refresh-secret",
+    }));
   });
 
   it("rejects an untrusted workspace path before filesystem access", async () => {

--- a/agent/lib/google-workspace/google-workspace-profile-store.ts
+++ b/agent/lib/google-workspace/google-workspace-profile-store.ts
@@ -3,17 +3,21 @@
  *
  * Exports:
  * - `GoogleWorkspaceAuthorizedUserCredentials`: exact gws authorized-user credential contract.
- * - `createGoogleWorkspaceProfileStore`: atomic workspace-profile writer/remover.
+ * - `createGoogleWorkspaceProfileStore`: atomic mount-safe workspace-profile writer/remover.
  * - `googleWorkspaceProfileStore`: production store backed by its dedicated Docker volume.
  */
 import { randomUUID } from "node:crypto";
-import { chmod, mkdir, rename, rm, writeFile } from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import { chmod, mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
 import { z } from "zod";
 
 const DIRECTORY_MODE = 0o700;
 const CREDENTIAL_MODE = 0o600;
+const CREDENTIAL_FILE_NAME = "credentials.json";
+const TEMPORARY_CREDENTIAL_PREFIX = ".credentials-";
+const TEMPORARY_CREDENTIAL_SUFFIX = ".tmp";
 const workspaceIdSchema = z.uuid();
 
 export interface GoogleWorkspaceAuthorizedUserCredentials {
@@ -27,10 +31,32 @@ function workspaceDirectory(root: string, workspaceId: string): string {
   return join(root, workspaceIdSchema.parse(workspaceId));
 }
 
+function isErrnoException(error: unknown, code: string): boolean {
+  return error instanceof Error && "code" in error && error.code === code;
+}
+
+function isCredentialStoreEntry(entry: Dirent): boolean {
+  return entry.name === CREDENTIAL_FILE_NAME ||
+    (entry.name.startsWith(TEMPORARY_CREDENTIAL_PREFIX) &&
+      entry.name.endsWith(TEMPORARY_CREDENTIAL_SUFFIX));
+}
+
 export function createGoogleWorkspaceProfileStore(root: string) {
   return {
     async remove(workspaceId: string): Promise<void> {
-      await rm(workspaceDirectory(root, workspaceId), { force: true, recursive: true });
+      const directory = workspaceDirectory(root, workspaceId);
+      let entries: Dirent[];
+      try {
+        entries = await readdir(directory, { withFileTypes: true });
+      } catch (error) {
+        if (isErrnoException(error, "ENOENT")) return;
+        throw error;
+      }
+
+      // Keep the directory itself stable because active sandboxes bind-mount this exact inode.
+      await Promise.all(entries.filter(isCredentialStoreEntry).map((entry) =>
+        rm(join(directory, entry.name), { force: true })
+      ));
     },
 
     async write(
@@ -42,8 +68,11 @@ export function createGoogleWorkspaceProfileStore(root: string) {
       await chmod(directory, DIRECTORY_MODE);
 
       // A same-volume rename ensures gws never observes a partially written refresh token.
-      const destination = join(directory, "credentials.json");
-      const temporary = join(directory, `.credentials-${randomUUID()}.tmp`);
+      const destination = join(directory, CREDENTIAL_FILE_NAME);
+      const temporary = join(
+        directory,
+        `${TEMPORARY_CREDENTIAL_PREFIX}${randomUUID()}${TEMPORARY_CREDENTIAL_SUFFIX}`,
+      );
       try {
         await writeFile(temporary, `${JSON.stringify(credentials, null, 2)}\n`, {
           flag: "wx",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/groq": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "private": true,
   "type": "module",
   "imports": {

--- a/services/sandbox-runner/docker-sandbox-engine.test.ts
+++ b/services/sandbox-runner/docker-sandbox-engine.test.ts
@@ -89,7 +89,7 @@ describe("buildSandboxContainerOptions", () => {
       SecurityOpt: ["no-new-privileges:true"],
     });
     expect(options.Labels).toMatchObject({
-      "dev.osinara.sandbox.policy-version": "5",
+      "dev.osinara.sandbox.policy-version": "6",
       "dev.osinara.sandbox.project": "osinara",
       "dev.osinara.sandbox.session-id": SANDBOX_SESSION_ID,
     });

--- a/services/sandbox-runner/docker-sandbox-options.ts
+++ b/services/sandbox-runner/docker-sandbox-options.ts
@@ -23,7 +23,7 @@ export interface SandboxDockerRuntime {
   workspaceVolume: string;
 }
 
-export const SANDBOX_CONTAINER_POLICY_VERSION = "5";
+export const SANDBOX_CONTAINER_POLICY_VERSION = "6";
 
 const AGENT_BROWSER_SESSION_NAME = "osinara";
 const AGENT_BROWSER_RESTORE_SAVE_POLICY = "auto";


### PR DESCRIPTION
## Summary
- preserve Google Workspace credential workspace directories when removing credentials so active sandbox bind mounts are not invalidated
- bump sandbox container policy version to recreate stale containers after deploy
- bump release version to 0.2.13

## Verification
- npm run typecheck
- npm test
- npm run build
- npm run build:runtime
- docker compose -f compose.test.yaml up --build --abort-on-container-exit --exit-code-from tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Резюме

- Выпущена версия 0.2.13.
- Удаление Google Workspace-учётных данных теперь сохраняет каталог рабочей области и его inode, предотвращая повреждение активных bind-mount песочниц.
- Удаляются только релевантные файлы учётных данных; добавлены проверки повторной записи и сохранения `refresh_token`.
- Версия политики sandbox-контейнеров увеличена с 5 до 6 для пересоздания устаревших контейнеров.
- Обновлены соответствующие тесты.

Проверки включают проверку типов, тесты, сборки и интеграционные тесты Docker Compose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->