### PR TITLE
Release v0.2.17: fix Telegram forum replies

### DIFF
--- a/agent/lib/sessions/session-context.test.ts
+++ b/agent/lib/sessions/session-context.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Telegram application session re-keying tests.
+ *
+ * Constructs covered:
+ * - `rekeyTelegramSession`: restores a verified forum topic when Eve channel state omits it.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+const registerRoute = vi.hoisted(() => vi.fn());
+
+vi.mock("./session-repository.js", () => ({
+  sessionRepository: { registerRoute },
+}));
+
+import { rekeyTelegramSession } from "./session-context.js";
+
+describe("rekeyTelegramSession", () => {
+  it("registers the outgoing bot anchor in the verified forum topic", async () => {
+    registerRoute.mockResolvedValue("-1001:278:279");
+    const setContinuationToken = vi.fn();
+    const channel = {
+      setContinuationToken,
+      state: {
+        chatId: "-1001",
+        chatType: "supergroup",
+        conversationId: "279",
+        messageThreadId: null,
+      },
+    };
+    const ctx = {
+      session: {
+        auth: {
+          current: {
+            attributes: {
+              applicationSessionId: "session-1",
+              telegramMessageThreadId: "278",
+            },
+          },
+        },
+      },
+    };
+
+    await rekeyTelegramSession(channel as never, ctx as never);
+
+    expect(registerRoute).toHaveBeenCalledWith("session-1", "-1001:278:279");
+    expect(setContinuationToken).toHaveBeenCalledWith("-1001:278:279");
+  });
+});

--- a/agent/lib/sessions/session-context.ts
+++ b/agent/lib/sessions/session-context.ts
@@ -36,6 +36,23 @@ export function sandboxSessionId(ctx: Pick<SessionContext, "session">): string {
   return id;
 }
 
+function telegramMessageThreadId(
+  stateThreadId: number | null,
+  ctx: Pick<SessionContext, "session">,
+): number | undefined {
+  if (stateThreadId !== null) return stateThreadId;
+  const verifiedThreadId = ctx.session.auth.current?.attributes.telegramMessageThreadId;
+  if (verifiedThreadId === undefined) return undefined;
+  const parsed = Number(verifiedThreadId);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new AppError(
+      "AGENT_SESSION_ROUTE_INVALID",
+      "Не удалось определить тему Telegram для продолжения контекста",
+    );
+  }
+  return parsed;
+}
+
 export async function rekeyTelegramSession(
   channel: TelegramEventContext,
   ctx: Pick<SessionContext, "session">,
@@ -46,12 +63,13 @@ export async function rekeyTelegramSession(
   }
 
   // The Telegram adapter can change the group anchor after every outbound message.
+  const messageThreadId = telegramMessageThreadId(state.messageThreadId, ctx);
   const baseToken = telegramContinuationToken({
     chatId: state.chatId,
     ...(state.chatType === "private" || state.conversationId === null
       ? {}
       : { conversationId: state.conversationId }),
-    ...(state.messageThreadId === null ? {} : { messageThreadId: state.messageThreadId }),
+    ...(messageThreadId === undefined ? {} : { messageThreadId }),
   });
   const sessionId = applicationSessionId(ctx);
   const token = await sessionRepository.registerRoute(sessionId, baseToken);

--- a/agent/lib/telegram-on-message-reply-routing.test.ts
+++ b/agent/lib/telegram-on-message-reply-routing.test.ts
@@ -88,6 +88,43 @@ describe("createTelegramMessageHandler reply routing", () => {
     expect(result).not.toBeNull();
   });
 
+  it("continues a forum reply through a persisted pre-fix threadless route", async () => {
+    const repository = familyGroupRepository();
+    repository.telegram.findIdentity.mockResolvedValue({
+      familyId: "family-1",
+      role: "member",
+      userId: "user-1",
+    });
+    repository.session.hasRoute
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const handler = createTelegramMessageHandler(repository);
+
+    const result = await handler(telegramContext().context, {
+      ...groupMessage("как дела?"),
+      messageId: "280",
+      messageThreadId: 278,
+      replyToMessage: {
+        chat: { id: "group-101", type: "supergroup" },
+        from: {
+          firstName: "Osinara",
+          id: "bot-1",
+          isBot: true,
+          username: "osinara_bot",
+        },
+        messageId: "279",
+        messageThreadId: 278,
+      },
+    });
+
+    expect(repository.session.hasRoute).toHaveBeenNthCalledWith(1, "group-101:278:279");
+    expect(repository.session.hasRoute).toHaveBeenNthCalledWith(2, "group-101::279");
+    expect(repository.session.prepareTurn).toHaveBeenCalledWith(expect.objectContaining({
+      baseContinuationToken: "group-101::279",
+    }));
+    expect(result).not.toBeNull();
+  });
+
   it("ignores a username-less reply to an unknown bot message route", async () => {
     const repository = familyGroupRepository();
     repository.session.hasRoute.mockResolvedValue(false);

--- a/agent/lib/telegram-on-message.ts
+++ b/agent/lib/telegram-on-message.ts
@@ -152,15 +152,21 @@ function baseContinuationToken(
   });
 }
 
-function replyContinuationToken(message: TelegramMessage): string | null {
+function replyContinuationTokens(message: TelegramMessage): string[] {
   const reply = message.replyToMessage;
-  if (!reply) return null;
+  if (!reply) return [];
   const messageThreadId = reply.messageThreadId ?? message.messageThreadId;
-  return telegramContinuationToken({
+  const exact = telegramContinuationToken({
     chatId: message.chat.id,
     conversationId: reply.messageId,
     ...(messageThreadId === undefined ? {} : { messageThreadId }),
   });
+  if (messageThreadId === undefined) return [exact];
+  // Releases before v0.2.17 could persist a group reply anchor without its verified forum topic.
+  return [exact, telegramContinuationToken({
+    chatId: message.chat.id,
+    conversationId: reply.messageId,
+  })];
 }
 
 function repliesToBotMessage(message: TelegramMessage): boolean {
@@ -245,13 +251,15 @@ export function createTelegramMessageHandler(repositories: TelegramMessageReposi
         }
         if (recordResult === "mode_disabled") journalEnabled = false;
       }
-      if (!addressed && message.replyToMessage) {
+      if (message.replyToMessage) {
         // Telegram may omit the sender entirely from a compact Rich Message reply reference.
         // The exact persisted chat/topic/message route proves that the anchor belongs to Osinara.
-        const candidateRoute = replyContinuationToken(message);
-        if (candidateRoute && await repositories.session.hasRoute(candidateRoute)) {
-          addressed = true;
-          verifiedReplyRoute = candidateRoute;
+        for (const candidateRoute of replyContinuationTokens(message)) {
+          if (await repositories.session.hasRoute(candidateRoute)) {
+            addressed = true;
+            verifiedReplyRoute = candidateRoute;
+            break;
+          }
         }
       }
       // Authorized family attachment references are retained without waking the model.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/groq": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Root cause
Production update 57047652 replied to bot message 279 in forum topic 278. The bot anchor had been persisted as a threadless route, so Eve could not find the target session for continuation token -1003567628736:278:279.

## Fix
- restore the verified forum topic from session auth when re-keying outbound bot anchors
- prefer the exact topic route for replies
- retain a narrow threadless fallback for anchors persisted before v0.2.17
- release version 0.2.17

## Verification
- npm test (476 passed, 81 database integration tests skipped locally)
- npm run typecheck
- npm run build