### PR TITLE
Release v0.2.18: reject incomplete model output

### DIFF
--- a/agent/lib/minimax-inline-reasoning-parser.ts
+++ b/agent/lib/minimax-inline-reasoning-parser.ts
@@ -8,6 +8,7 @@
  * - `consumeInlineReasoning`: consumes text chunks while keeping possible tag prefixes buffered.
  * - `finalizeInlineReasoning`: closes or rejects unfinished hidden reasoning by finish reason.
  * - `emptyVisibleAnswerError`: stable failure for hidden-only model output.
+ * - `assertMiniMaxFinishReasonComplete`: rejects incomplete or filtered provider output.
  */
 import type { LanguageModelV4FinishReason } from "@ai-sdk/provider";
 
@@ -16,6 +17,9 @@ import { AppError } from "./app-error.js";
 const MINI_MAX_REASONING_TAGS = ["think", "mm:think", "thinking"] as const;
 const MINI_MAX_REASONING_TRUNCATED_CODE = "AGENT_MINIMAX_REASONING_TRUNCATED";
 const MINI_MAX_EMPTY_VISIBLE_ANSWER_CODE = "AGENT_MINIMAX_EMPTY_VISIBLE_ANSWER";
+const MINI_MAX_OUTPUT_INCOMPLETE_CODE = "AGENT_MINIMAX_OUTPUT_INCOMPLETE";
+const MINI_MAX_OUTPUT_TRUNCATED_CODE = "AGENT_MINIMAX_OUTPUT_TRUNCATED";
+const MINI_MAX_OUTPUT_FILTERED_CODE = "AGENT_MINIMAX_OUTPUT_FILTERED";
 
 export type InlineReasoningEvent =
   | { readonly text: string; readonly type: "text" }
@@ -47,6 +51,28 @@ export function emptyVisibleAnswerError(): AppError {
   return new AppError(
     MINI_MAX_EMPTY_VISIBLE_ANSWER_CODE,
     "Модель не вернула готовый ответ. Попробуйте повторить запрос или переформулировать его",
+  );
+}
+
+export function assertMiniMaxFinishReasonComplete(
+  finishReason: LanguageModelV4FinishReason,
+): void {
+  if (finishReason.unified === "stop" || finishReason.unified === "tool-calls") return;
+  if (finishReason.unified === "length") {
+    throw new AppError(
+      MINI_MAX_OUTPUT_TRUNCATED_CODE,
+      "Модель оборвала ответ из-за ограничения длины. Сократите запрос или попросите ответить частями",
+    );
+  }
+  if (finishReason.unified === "content-filter") {
+    throw new AppError(
+      MINI_MAX_OUTPUT_FILTERED_CODE,
+      "Модель остановила ответ из-за ограничений безопасности. Переформулируйте запрос",
+    );
+  }
+  throw new AppError(
+    MINI_MAX_OUTPUT_INCOMPLETE_CODE,
+    "Модель не завершила ответ. Попробуйте повторить запрос или сформулировать его иначе",
   );
 }
 

--- a/agent/lib/minimax-inline-reasoning.ts
+++ b/agent/lib/minimax-inline-reasoning.ts
@@ -18,6 +18,7 @@ import type {
 import type { LanguageModelMiddleware } from "ai";
 
 import {
+  assertMiniMaxFinishReasonComplete,
   consumeInlineReasoning,
   createInlineReasoningState,
   emptyVisibleAnswerError,
@@ -96,6 +97,7 @@ function normalizeGeneratedContent(
     }
   }
   assertGeneratedOutputHasDeliverable(normalized);
+  assertMiniMaxFinishReasonComplete(finishReason);
   return normalized;
 }
 
@@ -256,6 +258,7 @@ export function createMiniMaxInlineReasoningMiddleware(): LanguageModelMiddlewar
                 }
                 states.clear();
                 if (!hasDeliverableOutput) throw emptyVisibleAnswerError();
+                assertMiniMaxFinishReasonComplete(part.finishReason);
               }
               hasDeliverableOutput = isStreamDeliverable(part) || hasDeliverableOutput;
               controller.enqueue(part);

--- a/agent/lib/minimax-model.test.ts
+++ b/agent/lib/minimax-model.test.ts
@@ -407,6 +407,22 @@ describe("createMiniMaxCliProxyModel", () => {
     ).rejects.toThrow("AGENT_MINIMAX_EMPTY_VISIBLE_ANSWER");
   });
 
+  it("rejects visible generated text when MiniMax reports an abnormal finish reason", async () => {
+    const model = createMiniMaxCliProxyModel({
+      apiKey: "proxy-key",
+      baseURL: "http://cli-proxy-api:8317/v1",
+      fetch: async () => jsonResponse(completion({
+        content: "Оборванный видимый ответ",
+        role: "assistant",
+      }, "unexpected_provider_stop")),
+      modelId: "MiniMax-M3",
+    });
+
+    await expect(
+      model.doGenerate({ prompt: userPrompt() } as LanguageModelV4CallOptions),
+    ).rejects.toThrow("AGENT_MINIMAX_OUTPUT_INCOMPLETE");
+  });
+
   it("streams visible text when trailing reasoning is unterminated but complete", async () => {
     const eventStream = [
       `data: ${JSON.stringify({ choices: [{ delta: {
@@ -451,5 +467,29 @@ describe("createMiniMaxCliProxyModel", () => {
     await expect(
       streamText({ model, prompt: "Подготовь документ" }).text,
     ).rejects.toThrow("AGENT_MINIMAX_REASONING_TRUNCATED");
+  });
+
+  it("rejects streamed visible text when MiniMax reports an abnormal finish reason", async () => {
+    const eventStream = [
+      `data: ${JSON.stringify({ choices: [{
+        delta: { content: "Оборванный видимый ответ" },
+        finish_reason: "unexpected_provider_stop",
+        index: 0,
+      }] })}\n\n`,
+      "data: [DONE]\n\n",
+    ].join("");
+    const model = createMiniMaxCliProxyModel({
+      apiKey: "proxy-key",
+      baseURL: "http://cli-proxy-api:8317/v1",
+      fetch: async () => new Response(eventStream, {
+        headers: { "content-type": "text/event-stream" },
+        status: 200,
+      }),
+      modelId: "MiniMax-M3",
+    });
+
+    await expect(
+      streamText({ model, prompt: "Подготовь документ" }).text,
+    ).rejects.toThrow("AGENT_MINIMAX_OUTPUT_INCOMPLETE");
   });
 });

--- a/agent/lib/sessions/session-repository.integration.test.ts
+++ b/agent/lib/sessions/session-repository.integration.test.ts
@@ -69,6 +69,22 @@ describeWithDatabase("session repository", () => {
     await expect(sessionRepository.hasRoute("101:42:901")).resolves.toBe(false);
   });
 
+  it("does not treat an unbound route from a failed first turn as resumable", async () => {
+    const f = await fixture();
+    const current = await sessionRepository.prepareTurn({
+      baseContinuationToken: "101:42:900",
+      familyId: f.familyId,
+      groupId: null,
+      now: new Date("2026-07-12T12:00:00.000Z"),
+      scope: "personal",
+      userId: f.userId,
+    });
+
+    await expect(sessionRepository.hasRoute("101:42:900")).resolves.toBe(false);
+    await sessionRepository.bindEveSession(current.id, "wrun_bound_after_start");
+    await expect(sessionRepository.hasRoute("101:42:900")).resolves.toBe(true);
+  });
+
   it("defers a requested rotation until the pending operation completes", async () => {
     const f = await fixture();
     const current = await sessionRepository.prepareTurn({

--- a/agent/lib/sessions/session-repository.ts
+++ b/agent/lib/sessions/session-repository.ts
@@ -193,8 +193,11 @@ export const sessionRepository = {
   async hasRoute(baseContinuationToken: string): Promise<boolean> {
     const result = await database().query(
       `SELECT 1
-         FROM conversation_session_routes
-        WHERE base_continuation_token = $1
+         FROM conversation_session_routes route
+         JOIN conversation_sessions session ON session.id = route.session_id
+        WHERE route.base_continuation_token = $1
+          AND session.retired_at IS NULL
+          AND session.eve_session_id IS NOT NULL
         LIMIT 1`,
       [baseContinuationToken],
     );

--- a/agent/lib/telegram-interface.test.ts
+++ b/agent/lib/telegram-interface.test.ts
@@ -190,6 +190,7 @@ describe("Telegram interface localization", () => {
     });
 
     expect(turnMessage).toContain("Не удалось выполнить запрос");
+    expect(turnMessage).toContain("Модель не смогла сформировать завершённый ответ");
     expect(turnMessage).toContain("Код: MODEL_CALL_FAILED");
     expect(turnMessage).toContain("Номер ошибки: 8c4eebf2-a386-4dcb-913d-4b5a28edee2f");
     expect(turnMessage).not.toContain("AGENT_MINIMAX");

--- a/agent/lib/telegram-interface.ts
+++ b/agent/lib/telegram-interface.ts
@@ -163,6 +163,9 @@ function supportReference(details: FailureData["details"]): string | null {
 }
 
 function publicFailureExplanation(data: FailureData): string | null {
+  if (data.code === "MODEL_CALL_FAILED") {
+    return "Модель не смогла сформировать завершённый ответ.";
+  }
   // Validation errors are authored by application code and already contain safe Russian guidance.
   if (!data.code.endsWith("_INPUT_INVALID") || typeof data.message !== "string") return null;
   return data.message.replace(new RegExp(`^${data.code}:\\s*`, "u"), "");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/groq": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Production evidence
- one MiniMax turn completed with finishReason=other and only 404 visible characters; Telegram delivered it as if complete
- a simple follow-up failed because MiniMax returned hidden-only output (AGENT_MINIMAX_EMPTY_VISIBLE_ANSWER)
- a poisoned exact reply route from a failed first turn could shadow a resumable legacy route

## Fix
- accept only stop and tool-calls as successful MiniMax finish reasons
- reject length, content-filter, error, and other before Telegram final delivery
- localize MODEL_CALL_FAILED with a clear Russian explanation
- require an active bound Eve session when selecting a reply route
- release version 0.2.18

## Verification
- npm test (478 passed, 82 database integration tests skipped locally)
- npm run typecheck
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Что изменилось

- Добавена проверка завершённости ответов MiniMax: успешными считаются только `stop` и `tool-calls`.
- Ответы с причинами `length`, `content-filter`, `error`, `other` и неизвестными значениями отклоняются до отправки в Telegram.
- Для ошибки `MODEL_CALL_FAILED` добавлено понятное русскоязычное сообщение.
- Маршрут ответа теперь считается доступным только при наличии активной привязанной Eve-сессии.
- Добавлены unit- и интеграционные тесты для новых сценариев.
- Версия обновлена до `0.2.18`.

## Проверка

- `npm test`: 478 тестов пройдено, 82 интеграционных теста с БД пропущены локально.
- `npm run typecheck`
- `npm run build`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->