### PR TITLE
Release v0.2.21: repair Telegram replies and MiniMax search

### DIFF
--- a/agent/lib/minimax-anthropic-compatibility.test.ts
+++ b/agent/lib/minimax-anthropic-compatibility.test.ts
@@ -1,0 +1,233 @@
+/**
+ * MiniMax Anthropic wire-compatibility tests.
+ *
+ * Constructs covered:
+ * - `createMiniMaxAnthropicCompatibilityFetch`: preserves web-search payload bytes bidirectionally.
+ * - Chunked SSE records are normalized without changing unrelated provider events.
+ * - JSON responses use the same narrow web-search result normalization.
+ * - The configured AI SDK transport consumes MiniMax provider-managed search and final text.
+ * - Malformed provider JSON fails with a stable boundary error.
+ */
+import { anthropic } from "@ai-sdk/anthropic";
+import type { FetchFunction } from "@ai-sdk/provider-utils";
+import { streamText } from "ai";
+import { describe, expect, it, vi } from "vitest";
+
+import { createConfiguredLanguageModel } from "./model-transport.js";
+import { createMiniMaxAnthropicCompatibilityFetch } from "./minimax-anthropic-compatibility.js";
+
+const RESULT = {
+  content: "Проверенный фрагмент страницы",
+  title: "Доставка еды",
+  type: "web_search_result",
+  url: "https://example.com/delivery",
+};
+
+function chunkedResponse(source: string, splitAt: number): Response {
+  const encoder = new TextEncoder();
+  return new Response(new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(source.slice(0, splitAt)));
+      controller.enqueue(encoder.encode(source.slice(splitAt)));
+      controller.close();
+    },
+  }), {
+    headers: { "content-type": "text/event-stream" },
+    status: 200,
+  });
+}
+
+function event(name: string, data: unknown): string {
+  return `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+describe("createMiniMaxAnthropicCompatibilityFetch", () => {
+  it("normalizes a chunked MiniMax web-search SSE result for the Anthropic SDK", async () => {
+    const event = {
+      content_block: {
+        content: [RESULT],
+        tool_use_id: "call-search-1",
+        type: "web_search_tool_result",
+      },
+      index: 3,
+      type: "content_block_start",
+    };
+    const source = `event: content_block_start\ndata: ${JSON.stringify(event)}\n\nevent: ping\ndata: {"type":"ping"}\n\n`;
+    const fetch = createMiniMaxAnthropicCompatibilityFetch(
+      vi.fn(async () => chunkedResponse(source, 47)) as FetchFunction,
+    );
+
+    const response = await fetch("https://api.minimax.io/anthropic/v1/messages", {
+      body: "{}",
+      method: "POST",
+    });
+    const normalized = await response.text();
+
+    expect(normalized).toContain(`"encrypted_content":"${RESULT.content}"`);
+    expect(normalized).not.toContain(`"content":"${RESULT.content}"`);
+    expect(normalized).toContain('data: {"type":"ping"}');
+  });
+
+  it("rejects malformed MiniMax search SSE with a stable error", async () => {
+    const source = "event: content_block_start\ndata: {\"type\":\"web_search_tool_result\"\n\n";
+    const fetch = createMiniMaxAnthropicCompatibilityFetch(
+      vi.fn(async () => chunkedResponse(source, 20)) as FetchFunction,
+    );
+    const response = await fetch("https://api.minimax.io/anthropic/v1/messages", {
+      body: "{}",
+      method: "POST",
+    });
+
+    await expect(response.text()).rejects.toThrow(
+      "AGENT_MINIMAX_ANTHROPIC_PAYLOAD_INVALID: MiniMax передал некорректный JSON",
+    );
+  });
+
+  it("restores the exact MiniMax content field when replaying assistant history", async () => {
+    let body: unknown;
+    const fetch = createMiniMaxAnthropicCompatibilityFetch(vi.fn(async (_input, init) => {
+      body = JSON.parse(String(init?.body));
+      return new Response("{}", {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      });
+    }) as FetchFunction);
+
+    await fetch("https://api.minimax.io/anthropic/v1/messages", {
+      body: JSON.stringify({
+        messages: [{
+          content: [{
+            content: [{
+              encrypted_content: RESULT.content,
+              title: RESULT.title,
+              type: RESULT.type,
+              url: RESULT.url,
+            }],
+            tool_use_id: "call-search-1",
+            type: "web_search_tool_result",
+          }],
+          role: "assistant",
+        }],
+      }),
+      method: "POST",
+    });
+
+    expect(body).toMatchObject({
+      messages: [{
+        content: [{
+          content: [RESULT],
+          type: "web_search_tool_result",
+        }],
+      }],
+    });
+  });
+
+  it("normalizes non-streaming MiniMax message content", async () => {
+    const fetch = createMiniMaxAnthropicCompatibilityFetch(vi.fn(async () =>
+      new Response(JSON.stringify({
+        content: [{
+          content: [RESULT],
+          tool_use_id: "call-search-1",
+          type: "web_search_tool_result",
+        }],
+        type: "message",
+      }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      })) as FetchFunction);
+
+    const response = await fetch("https://api.minimax.io/anthropic/v1/messages", {
+      body: "{}",
+      method: "POST",
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      content: [{
+        content: [{ encrypted_content: RESULT.content }],
+        type: "web_search_tool_result",
+      }],
+    });
+  });
+
+  it("lets the AI SDK consume MiniMax web search followed by final text", async () => {
+    const source = [
+      event("message_start", {
+        message: {
+          content: [],
+          id: "message-search-1",
+          model: "MiniMax-M3",
+          role: "assistant",
+          stop_reason: null,
+          stop_sequence: null,
+          type: "message",
+          usage: { input_tokens: 10, output_tokens: 0 },
+        },
+        type: "message_start",
+      }),
+      event("content_block_start", {
+        content_block: {
+          id: "call-search-1",
+          input: { query: "доставка еды" },
+          name: "web_search",
+          type: "server_tool_use",
+        },
+        index: 0,
+        type: "content_block_start",
+      }),
+      event("content_block_stop", { index: 0, type: "content_block_stop" }),
+      event("content_block_start", {
+        content_block: {
+          content: [RESULT],
+          tool_use_id: "call-search-1",
+          type: "web_search_tool_result",
+        },
+        index: 1,
+        type: "content_block_start",
+      }),
+      event("content_block_stop", { index: 1, type: "content_block_stop" }),
+      event("content_block_start", {
+        content_block: { text: "", type: "text" },
+        index: 2,
+        type: "content_block_start",
+      }),
+      event("content_block_delta", {
+        delta: { text: "Нашла доставку.", type: "text_delta" },
+        index: 2,
+        type: "content_block_delta",
+      }),
+      event("content_block_stop", { index: 2, type: "content_block_stop" }),
+      event("message_delta", {
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        type: "message_delta",
+        usage: { input_tokens: 10, output_tokens: 8 },
+      }),
+      event("message_stop", { type: "message_stop" }),
+    ].join("");
+    const model = createConfiguredLanguageModel({
+      apiKey: "model-secret",
+      fetch: vi.fn(async () => chunkedResponse(source, 137)) as FetchFunction,
+      maxOutputTokens: 128_000,
+      modelId: "MiniMax-M3",
+      transport: {
+        authentication: "bearer",
+        baseUrl: "https://api.minimax.io/anthropic/v1",
+        compatibility: "minimax-anthropic",
+        protocol: "anthropic-messages",
+        thinking: { type: "adaptive" },
+      },
+    });
+
+    const result = streamText({
+      maxRetries: 0,
+      model,
+      prompt: "Найди доставку еды",
+      // The provider package and root AI SDK resolve separate branded tool schema instances.
+      tools: { web_search: anthropic.tools.webSearch_20250305() as never },
+    });
+
+    await expect(result.text).resolves.toBe("Нашла доставку.");
+    await expect(result.sources).resolves.toEqual([
+      expect.objectContaining({ title: RESULT.title, url: RESULT.url }),
+    ]);
+  });
+});

--- a/agent/lib/minimax-anthropic-compatibility.test.ts
+++ b/agent/lib/minimax-anthropic-compatibility.test.ts
@@ -7,6 +7,7 @@
  * - JSON responses use the same narrow web-search result normalization.
  * - The configured AI SDK transport consumes MiniMax provider-managed search and final text.
  * - Malformed provider JSON fails with a stable boundary error.
+ * - Oversized non-streaming responses are rejected before body buffering.
  */
 import { anthropic } from "@ai-sdk/anthropic";
 import type { FetchFunction } from "@ai-sdk/provider-utils";
@@ -147,6 +148,22 @@ describe("createMiniMaxAnthropicCompatibilityFetch", () => {
         type: "web_search_tool_result",
       }],
     });
+  });
+
+  it("rejects an oversized declared JSON response before buffering", async () => {
+    const fetch = createMiniMaxAnthropicCompatibilityFetch(vi.fn(async () =>
+      new Response("{}", {
+        headers: {
+          "content-length": "2000001",
+          "content-type": "application/json",
+        },
+        status: 200,
+      })) as FetchFunction);
+
+    await expect(fetch("https://api.minimax.io/anthropic/v1/messages", {
+      body: "{}",
+      method: "POST",
+    })).rejects.toThrow("AGENT_MINIMAX_ANTHROPIC_JSON_LIMIT_EXCEEDED");
   });
 
   it("lets the AI SDK consume MiniMax web search followed by final text", async () => {

--- a/agent/lib/minimax-anthropic-compatibility.ts
+++ b/agent/lib/minimax-anthropic-compatibility.ts
@@ -16,6 +16,7 @@ import { AppError } from "./app-error.js";
 type WireDirection = "from-minimax" | "to-minimax";
 
 const ANTHROPIC_WEB_SEARCH_CONTENT_FIELD = "encrypted_content";
+const MAX_JSON_RESPONSE_BYTES = 2_000_000;
 const MAX_SSE_LINE_CHARACTERS = 2_000_000;
 const MINIMAX_WEB_SEARCH_CONTENT_FIELD = "content";
 const WEB_SEARCH_RESULT_TYPE = "web_search_result";
@@ -176,6 +177,38 @@ function rewrittenResponse(response: Response, body: BodyInit): Response {
   });
 }
 
+async function readBoundedJsonBody(response: Response): Promise<string> {
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength !== null && /^\d+$/u.test(declaredLength)) {
+    if (Number(declaredLength) > MAX_JSON_RESPONSE_BYTES) {
+      throw new AppError(
+        "AGENT_MINIMAX_ANTHROPIC_JSON_LIMIT_EXCEEDED",
+        "MiniMax передал слишком большой JSON-ответ",
+      );
+    }
+  }
+
+  // Count bytes while decoding so a missing or dishonest Content-Length cannot exhaust memory.
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let bytesRead = 0;
+  let source = "";
+  while (true) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    bytesRead += chunk.value.byteLength;
+    if (bytesRead > MAX_JSON_RESPONSE_BYTES) {
+      await reader.cancel();
+      throw new AppError(
+        "AGENT_MINIMAX_ANTHROPIC_JSON_LIMIT_EXCEEDED",
+        "MiniMax передал слишком большой JSON-ответ",
+      );
+    }
+    source += decoder.decode(chunk.value, { stream: true });
+  }
+  return source + decoder.decode();
+}
+
 async function rewriteResponse(response: Response): Promise<Response> {
   if (!response.ok || response.body === null) return response;
   const contentType = response.headers.get("content-type")?.toLowerCase();
@@ -183,7 +216,7 @@ async function rewriteResponse(response: Response): Promise<Response> {
     return rewrittenResponse(response, rewriteSseBody(response.body));
   }
   if (contentType?.includes("application/json")) {
-    const payload = rewriteIncomingPayload(parseWireJson(await response.text()));
+    const payload = rewriteIncomingPayload(parseWireJson(await readBoundedJsonBody(response)));
     return rewrittenResponse(response, JSON.stringify(payload));
   }
   return response;

--- a/agent/lib/minimax-anthropic-compatibility.ts
+++ b/agent/lib/minimax-anthropic-compatibility.ts
@@ -1,0 +1,197 @@
+/**
+ * MiniMax Anthropic Messages wire compatibility.
+ *
+ * Export:
+ * - `createMiniMaxAnthropicCompatibilityFetch`: preserves MiniMax web-search result content while
+ *   translating its field name to and from the Anthropic schema expected by the AI SDK.
+ *
+ * Key constructs:
+ * - Exact block matching leaves ordinary model payloads untouched.
+ * - Streaming normalization buffers split SSE lines without buffering the complete response.
+ */
+import type { FetchFunction } from "@ai-sdk/provider-utils";
+
+import { AppError } from "./app-error.js";
+
+type WireDirection = "from-minimax" | "to-minimax";
+
+const ANTHROPIC_WEB_SEARCH_CONTENT_FIELD = "encrypted_content";
+const MAX_SSE_LINE_CHARACTERS = 2_000_000;
+const MINIMAX_WEB_SEARCH_CONTENT_FIELD = "content";
+const WEB_SEARCH_RESULT_TYPE = "web_search_result";
+const WEB_SEARCH_TOOL_RESULT_TYPE = "web_search_tool_result";
+
+function parseWireJson(source: string): unknown {
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    // Preserve the parser error and stack while making provider-boundary failures diagnosable.
+    if (error instanceof Error) {
+      Object.defineProperty(error, "message", {
+        configurable: true,
+        value: `AGENT_MINIMAX_ANTHROPIC_PAYLOAD_INVALID: MiniMax передал некорректный JSON: ${error.message}`,
+        writable: true,
+      });
+    }
+    throw error;
+  }
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function rewriteSearchResult(value: unknown, direction: WireDirection): unknown {
+  const result = record(value);
+  if (!result || result.type !== WEB_SEARCH_RESULT_TYPE) return value;
+
+  const sourceField = direction === "from-minimax"
+    ? MINIMAX_WEB_SEARCH_CONTENT_FIELD
+    : ANTHROPIC_WEB_SEARCH_CONTENT_FIELD;
+  const targetField = direction === "from-minimax"
+    ? ANTHROPIC_WEB_SEARCH_CONTENT_FIELD
+    : MINIMAX_WEB_SEARCH_CONTENT_FIELD;
+  const source = result[sourceField];
+  if (typeof source !== "string" || result[targetField] !== undefined) return value;
+
+  // Move the exact opaque value rather than manufacturing an Anthropic encrypted payload.
+  const rewritten = { ...result, [targetField]: source };
+  delete rewritten[sourceField];
+  return rewritten;
+}
+
+function rewriteToolResultBlock(value: unknown, direction: WireDirection): unknown {
+  const block = record(value);
+  if (!block || block.type !== WEB_SEARCH_TOOL_RESULT_TYPE || !Array.isArray(block.content)) {
+    return value;
+  }
+  return {
+    ...block,
+    content: block.content.map((result) => rewriteSearchResult(result, direction)),
+  };
+}
+
+function rewriteIncomingPayload(value: unknown): unknown {
+  const payload = record(value);
+  if (!payload) return value;
+
+  // Streaming content blocks and complete JSON messages expose results at different levels.
+  if (payload.type === "content_block_start") {
+    return { ...payload, content_block: rewriteToolResultBlock(payload.content_block, "from-minimax") };
+  }
+  if (Array.isArray(payload.content)) {
+    return {
+      ...payload,
+      content: payload.content.map((block) => rewriteToolResultBlock(block, "from-minimax")),
+    };
+  }
+  return value;
+}
+
+function rewriteOutgoingPayload(value: unknown): unknown {
+  const payload = record(value);
+  if (!payload || !Array.isArray(payload.messages)) return value;
+  return {
+    ...payload,
+    messages: payload.messages.map((messageValue) => {
+      const message = record(messageValue);
+      if (!message || !Array.isArray(message.content)) return messageValue;
+      return {
+        ...message,
+        content: message.content.map((block) => rewriteToolResultBlock(block, "to-minimax")),
+      };
+    }),
+  };
+}
+
+function requestUrl(input: Parameters<FetchFunction>[0]): URL {
+  return new URL(input instanceof Request ? input.url : String(input));
+}
+
+function rewriteRequest(
+  input: Parameters<FetchFunction>[0],
+  init: Parameters<FetchFunction>[1],
+): Parameters<FetchFunction>[1] {
+  if (!requestUrl(input).pathname.endsWith("/messages") || typeof init?.body !== "string") {
+    return init;
+  }
+  return { ...init, body: JSON.stringify(rewriteOutgoingPayload(parseWireJson(init.body))) };
+}
+
+function rewriteSseLine(line: string): string {
+  const carriageReturn = line.endsWith("\r") ? "\r" : "";
+  const content = carriageReturn ? line.slice(0, -1) : line;
+  if (!content.startsWith("data:") || !content.includes(WEB_SEARCH_TOOL_RESULT_TYPE)) return line;
+  const data = content.slice("data:".length).trimStart();
+  if (!data || data === "[DONE]") return line;
+  return `data: ${JSON.stringify(rewriteIncomingPayload(parseWireJson(data)))}${carriageReturn}`;
+}
+
+function assertSseLineBound(buffer: string): void {
+  if (buffer.length <= MAX_SSE_LINE_CHARACTERS) return;
+  throw new AppError(
+    "AGENT_MINIMAX_ANTHROPIC_SSE_LIMIT_EXCEEDED",
+    "MiniMax передал слишком большой потоковый блок ответа",
+  );
+}
+
+function rewriteSseBody(body: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buffer = "";
+  return body.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+    flush(controller) {
+      buffer += decoder.decode();
+      if (buffer) {
+        assertSseLineBound(buffer);
+        controller.enqueue(encoder.encode(rewriteSseLine(buffer)));
+      }
+    },
+    transform(chunk, controller) {
+      buffer += decoder.decode(chunk, { stream: true });
+      let newlineIndex = buffer.indexOf("\n");
+      while (newlineIndex >= 0) {
+        const line = buffer.slice(0, newlineIndex);
+        assertSseLineBound(line);
+        buffer = buffer.slice(newlineIndex + 1);
+        controller.enqueue(encoder.encode(`${rewriteSseLine(line)}\n`));
+        newlineIndex = buffer.indexOf("\n");
+      }
+      assertSseLineBound(buffer);
+    },
+  }));
+}
+
+function rewrittenResponse(response: Response, body: BodyInit): Response {
+  const headers = new Headers(response.headers);
+  // Body bytes changed, so upstream compression and length metadata no longer describe them.
+  headers.delete("content-encoding");
+  headers.delete("content-length");
+  return new Response(body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+async function rewriteResponse(response: Response): Promise<Response> {
+  if (!response.ok || response.body === null) return response;
+  const contentType = response.headers.get("content-type")?.toLowerCase();
+  if (contentType?.includes("text/event-stream")) {
+    return rewrittenResponse(response, rewriteSseBody(response.body));
+  }
+  if (contentType?.includes("application/json")) {
+    const payload = rewriteIncomingPayload(parseWireJson(await response.text()));
+    return rewrittenResponse(response, JSON.stringify(payload));
+  }
+  return response;
+}
+
+export function createMiniMaxAnthropicCompatibilityFetch(fetch: FetchFunction): FetchFunction {
+  return async (input, init) => {
+    const response = await fetch(input, rewriteRequest(input, init));
+    return await rewriteResponse(response);
+  };
+}

--- a/agent/lib/model-provider-config.test.ts
+++ b/agent/lib/model-provider-config.test.ts
@@ -5,6 +5,7 @@
  * - `parseModelProviderConfig`: validates protocol-native agent transports and model IDs.
  * - Anthropic Messages and OpenAI Chat Completions remain provider-name independent.
  * - Required endpoint, authentication, thinking, and context metadata fail fast.
+ * - MiniMax Anthropic wire compatibility is explicit and rejects unknown modes.
  * - Active schema remains separate from the host-mounted deployment compatibility file.
  */
 import { readFile } from "node:fs/promises";
@@ -44,6 +45,28 @@ describe("parseModelProviderConfig", () => {
 
   it("accepts protocol-native primary, vision, and voice model selection", () => {
     expect(parseModelProviderConfig(validConfig)).toEqual(validConfig);
+  });
+
+  it("accepts only the explicit MiniMax Anthropic compatibility mode", () => {
+    const config = {
+      ...validConfig,
+      agent: {
+        ...validConfig.agent,
+        transport: {
+          ...validConfig.agent.transport,
+          compatibility: "minimax-anthropic",
+        },
+      },
+    } as const;
+
+    expect(parseModelProviderConfig(config)).toEqual(config);
+    expect(() => parseModelProviderConfig({
+      ...config,
+      agent: {
+        ...config.agent,
+        transport: { ...config.agent.transport, compatibility: "unknown" },
+      },
+    })).toThrow("AGENT_MODEL_PROVIDER_CONFIG_INVALID");
   });
 
   it("accepts a generic OpenAI-compatible transport without provider branching", () => {

--- a/agent/lib/model-provider-config.ts
+++ b/agent/lib/model-provider-config.ts
@@ -28,6 +28,7 @@ const externalBaseUrlSchema = z.url().superRefine((value, context) => {
 const anthropicMessagesTransportSchema = z.object({
   authentication: z.enum(["api-key", "bearer"]),
   baseUrl: externalBaseUrlSchema,
+  compatibility: z.literal("minimax-anthropic").optional(),
   protocol: z.literal("anthropic-messages"),
   thinking: z.object({ type: z.literal("adaptive") }).strict(),
 }).strict();

--- a/agent/lib/model-transport.ts
+++ b/agent/lib/model-transport.ts
@@ -7,6 +7,7 @@
  *
  * Key constructs:
  * - Anthropic Messages adaptive thinking is enforced at the transport boundary.
+ * - Explicit MiniMax compatibility preserves provider web-search payloads across Anthropic parsing.
  * - OpenAI Chat Completions remains a generic provider-independent transport.
  */
 import { createAnthropic } from "@ai-sdk/anthropic";
@@ -20,6 +21,7 @@ import { type LanguageModelMiddleware, wrapLanguageModel } from "ai";
 
 import type { AgentModelTransport } from "./model-provider-config.js";
 import { AppError } from "./app-error.js";
+import { createMiniMaxAnthropicCompatibilityFetch } from "./minimax-anthropic-compatibility.js";
 
 export interface ConfiguredLanguageModelOptions {
   readonly apiKey: string;
@@ -110,12 +112,15 @@ export function createConfiguredLanguageModel(options: ConfiguredLanguageModelOp
   const { transport } = options;
   const guardedFetch = createCredentialGuardedFetch(options);
   if (transport.protocol === "anthropic-messages") {
+    const fetch = transport.compatibility === "minimax-anthropic"
+      ? createMiniMaxAnthropicCompatibilityFetch(guardedFetch)
+      : guardedFetch;
     const provider = createAnthropic({
       baseURL: transport.baseUrl,
       ...(transport.authentication === "bearer"
         ? { authToken: options.apiKey }
         : { apiKey: options.apiKey }),
-      fetch: guardedFetch,
+      fetch,
     });
     return wrapLanguageModel({
       middleware: createTransportDefaultsMiddleware(options.maxOutputTokens, true),

--- a/agent/lib/telegram-on-message-reply-routing.test.ts
+++ b/agent/lib/telegram-on-message-reply-routing.test.ts
@@ -4,7 +4,9 @@
  * Constructs covered:
  * - Username-less replies to prior Osinara bot messages continue via persisted session routes.
  * - Timeline-proven replies without an Eve route start a fresh application continuation.
- * - Real HITL replies and resumable routes retain Eve's native synthetic reply handling.
+ * - Ordinary replies remain messages when a previously live route rotates before Eve dispatch.
+ * - Only authorized HITL replies retain Eve's native synthetic reply handling.
+ * - Private non-HITL replies also bypass synthetic input-response delivery.
  * - Sender-less Telegram reply references continue only when their exact persisted route exists.
  * - Replies to unknown bot messages stay ignored, so other bots cannot trigger Osinara turns.
  */
@@ -12,6 +14,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   groupMessage,
+  privateMessage,
   repositories,
   telegramContext,
 } from "./telegram-on-message.test-fixtures.js";
@@ -83,7 +86,7 @@ describe("createTelegramMessageHandler reply routing", () => {
     });
   });
 
-  it("continues a username-less reply to a known bot message route", async () => {
+  it("keeps a known-route reply as a message when session preparation rotates the route", async () => {
     const repository = familyGroupRepository();
     repository.telegram.findIdentity.mockResolvedValue({
       familyId: "family-1",
@@ -97,6 +100,14 @@ describe("createTelegramMessageHandler reply routing", () => {
       status: "inserted",
     });
     repository.session.hasRoute.mockResolvedValue(true);
+    repository.hitl.authorizeReply.mockResolvedValue("not_applicable");
+    repository.session.prepareTurn.mockResolvedValue({
+      continuationToken: "group-101::88:osinara:1",
+      generation: 1,
+      id: "session-rotated",
+      rotated: true,
+      sandboxSessionId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    });
     const handler = createTelegramMessageHandler(repository);
 
     const result = await handler(telegramContext().context, {
@@ -120,7 +131,37 @@ describe("createTelegramMessageHandler reply routing", () => {
         telegramReplyToMessageId: "89",
       },
     });
-    expect(result).not.toHaveProperty("replyHandling");
+    expect(result).toMatchObject({
+      continuationToken: "group-101::88:osinara:1",
+      replyHandling: "message",
+    });
+  });
+
+  it("dispatches a private non-HITL bot reply as an ordinary message", async () => {
+    const repository = repositories();
+    repository.telegram.findIdentity.mockResolvedValue({
+      familyId: "family-1",
+      role: "owner",
+      userId: "user-1",
+    });
+    repository.hitl.authorizeReply.mockResolvedValue("not_applicable");
+    const handler = createTelegramMessageHandler(repository);
+
+    const result = await handler(telegramContext().context, {
+      ...privateMessage("продолжим"),
+      messageId: "89",
+      replyToMessage: {
+        chat: { id: "telegram-101", type: "private" },
+        from: { firstName: "Osinara", id: "bot-1", isBot: true },
+        messageId: "88",
+      },
+    });
+
+    expect(repository.hitl.authorizeReply).toHaveBeenCalledWith(expect.objectContaining({
+      baseContinuationToken: "telegram-101::",
+      telegramMessageId: "88",
+    }));
+    expect(result).toMatchObject({ replyHandling: "message" });
   });
 
   it("preserves native reply handling for an authorized HITL response", async () => {

--- a/agent/lib/telegram-on-message.ts
+++ b/agent/lib/telegram-on-message.ts
@@ -342,9 +342,10 @@ export function createTelegramMessageHandler(repositories: TelegramMessageReposi
         await ctx.telegram.sendMessage(error);
         return null;
       }
-      // Only a non-HITL timeline reply without a live Eve route may become a fresh message turn.
-      if (replyAuthorization === "not_applicable" && trustedAgentReply && !hasResumableReplyRoute) {
-        verifiedReplyRoute = exactReplyRoute;
+      // DB authorization, not a pre-rotation route snapshot, decides whether this is synthetic HITL.
+      const ordinaryAgentReply = trustedAgentReply || message.chat.type === "private";
+      if (replyAuthorization === "not_applicable" && ordinaryAgentReply) {
+        if (!hasResumableReplyRoute) verifiedReplyRoute = exactReplyRoute;
         replyHandling = "message";
       }
     }

--- a/config/agent-model-providers.json
+++ b/config/agent-model-providers.json
@@ -5,6 +5,7 @@
       "protocol": "anthropic-messages",
       "baseUrl": "https://api.minimax.io/anthropic/v1",
       "authentication": "bearer",
+      "compatibility": "minimax-anthropic",
       "thinking": {
         "type": "adaptive"
       }

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -74,6 +74,10 @@ release can restart during recovery. Active model selection is immutable in each
 and vision model IDs, explicit output limits, and the primary context window. The current Anthropic
 Messages transport carries typed thinking blocks without text parsing. Changing active model
 selection therefore requires a reviewed release and rolls back atomically with that image.
+The MiniMax transport explicitly enables a narrow bidirectional web-search field adapter because
+MiniMax returns `content` where the Anthropic SDK requires `encrypted_content`; the exact value is
+preserved and restored on history replay rather than synthesized or discarded. Remove this adapter
+when MiniMax emits the Anthropic field or the AI SDK supports the MiniMax dialect natively.
 
 The `cli-proxy-api` service and sixth release image remain only because the installed production
 deployment controller validates manifest schema version 1 and its fixed six-image service graph.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.20",
+      "version": "0.2.21",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- classify verified non-HITL Telegram replies as ordinary messages even when session preparation rotates a previously live route
- add an explicit MiniMax Anthropic wire adapter that preserves web-search result content across SDK parsing and history replay
- validate chunked SSE, JSON responses, malformed payloads, and the real AI SDK provider-tool pipeline
- bump the production release to `0.2.21`

## Production incident
MiniMax-M3 returns provider-managed `web_search_tool_result` entries with `content`, while the Anthropic SDK requires `encrypted_content`. Nine production model calls were parked by `AI_TypeValidationError`. The adapter translates only this exact field at the configured MiniMax boundary and restores it on replay.

## Verification
- `docker compose -f compose.test.yaml up --build --abort-on-container-exit --exit-code-from tests`
- 597 tests passed with database integration enabled
- TypeScript typecheck passed
- Eve production build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Что изменилось

- Исправлена классификация обычных Telegram-ответов при ротации маршрута и для приватных non-HITL сообщений.
- Добавлена MiniMax Anthropic wire-совместимость для сохранения результатов web search при обработке SDK и реплее истории.
- Реализована поддержка SSE и JSON, включая обработку ошибок некорректных payload’ов и ограничение размера SSE-строк.
- Добавлена конфигурация `transport.compatibility: "minimax-anthropic"` и соответствующая валидация.
- Добавлены интеграционные и регрессионные тесты.
- Версия обновлена до `0.2.21`.

## Проверка

Пройдены 597 database-интеграционных тестов, TypeScript typecheck и production-сборка Eve.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->