### PR TITLE
Release v0.2.22: fix MiniMax web search replay

### DIFF
--- a/agent/lib/minimax-anthropic-compatibility.test.ts
+++ b/agent/lib/minimax-anthropic-compatibility.test.ts
@@ -2,17 +2,19 @@
  * MiniMax Anthropic wire-compatibility tests.
  *
  * Constructs covered:
- * - `createMiniMaxAnthropicCompatibilityFetch`: preserves web-search payload bytes bidirectionally.
+ * - `createMiniMaxAnthropicCompatibilityFetch`: preserves MiniMax web-search payload bytes.
  * - Chunked SSE records are normalized without changing unrelated provider events.
  * - JSON responses use the same narrow web-search result normalization.
- * - The configured AI SDK transport consumes MiniMax provider-managed search and final text.
+ * - Provider-managed search history is replayed through MiniMax-safe ordinary tool messages.
+ * - The configured AI SDK transport consumes MiniMax provider-managed search across model steps.
  * - Malformed provider JSON fails with a stable boundary error.
  * - Oversized non-streaming responses are rejected before body buffering.
  */
 import { anthropic } from "@ai-sdk/anthropic";
 import type { FetchFunction } from "@ai-sdk/provider-utils";
-import { streamText } from "ai";
+import { generateText, stepCountIs, streamText, tool } from "ai";
 import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 
 import { createConfiguredLanguageModel } from "./model-transport.js";
 import { createMiniMaxAnthropicCompatibilityFetch } from "./minimax-anthropic-compatibility.js";
@@ -84,7 +86,7 @@ describe("createMiniMaxAnthropicCompatibilityFetch", () => {
     );
   });
 
-  it("restores the exact MiniMax content field when replaying assistant history", async () => {
+  it("rewrites MiniMax web-search history as a replay-safe ordinary tool exchange", async () => {
     let body: unknown;
     const fetch = createMiniMaxAnthropicCompatibilityFetch(vi.fn(async (_input, init) => {
       body = JSON.parse(String(init?.body));
@@ -96,30 +98,83 @@ describe("createMiniMaxAnthropicCompatibilityFetch", () => {
 
     await fetch("https://api.minimax.io/anthropic/v1/messages", {
       body: JSON.stringify({
-        messages: [{
-          content: [{
-            content: [{
-              encrypted_content: RESULT.content,
-              title: RESULT.title,
-              type: RESULT.type,
-              url: RESULT.url,
-            }],
-            tool_use_id: "call-search-1",
-            type: "web_search_tool_result",
-          }],
-          role: "assistant",
-        }],
+        messages: [
+          { content: [{ text: "Ищу.", type: "text" }], role: "assistant" },
+          {
+            content: [
+              {
+                id: "call-search-1",
+                input: { query: "доставка еды" },
+                name: "web_search",
+                type: "server_tool_use",
+              },
+              {
+                content: [{
+                  encrypted_content: RESULT.content,
+                  title: RESULT.title,
+                  type: RESULT.type,
+                  url: RESULT.url,
+                }],
+                tool_use_id: "call-search-1",
+                type: "web_search_tool_result",
+              },
+              {
+                id: "call-fetch-1",
+                input: { url: RESULT.url },
+                name: "web_fetch",
+                type: "tool_use",
+              },
+            ],
+            role: "assistant",
+          },
+          {
+            content: [{ content: "Страница", tool_use_id: "call-fetch-1", type: "tool_result" }],
+            role: "user",
+          },
+        ],
       }),
       method: "POST",
     });
 
-    expect(body).toMatchObject({
-      messages: [{
-        content: [{
-          content: [RESULT],
-          type: "web_search_tool_result",
-        }],
-      }],
+    expect(body).toEqual({
+      messages: [
+        { content: [{ text: "Ищу.", type: "text" }], role: "assistant" },
+        {
+          content: [{
+            id: "call-search-1",
+            input: { query: "доставка еды" },
+            name: "web_search",
+            type: "tool_use",
+          }],
+          role: "assistant",
+        },
+        {
+          content: [{
+            content: JSON.stringify([{
+              title: RESULT.title,
+              type: RESULT.type,
+              url: RESULT.url,
+              content: RESULT.content,
+            }]),
+            tool_use_id: "call-search-1",
+            type: "tool_result",
+          }],
+          role: "user",
+        },
+        {
+          content: [{
+            id: "call-fetch-1",
+            input: { url: RESULT.url },
+            name: "web_fetch",
+            type: "tool_use",
+          }],
+          role: "assistant",
+        },
+        {
+          content: [{ content: "Страница", tool_use_id: "call-fetch-1", type: "tool_result" }],
+          role: "user",
+        },
+      ],
     });
   });
 
@@ -246,5 +301,104 @@ describe("createMiniMaxAnthropicCompatibilityFetch", () => {
     await expect(result.sources).resolves.toEqual([
       expect.objectContaining({ title: RESULT.title, url: RESULT.url }),
     ]);
+  });
+
+  it("lets the AI SDK continue after MiniMax search and a local tool result", async () => {
+    const requests: unknown[] = [];
+    const fetch = vi.fn(async (_input, init) => {
+      requests.push(JSON.parse(String(init?.body)));
+      const firstCall = requests.length === 1;
+      return new Response(JSON.stringify(firstCall
+        ? {
+            content: [
+              {
+                id: "call-search-1",
+                input: { query: "доставка еды" },
+                name: "web_search",
+                type: "server_tool_use",
+              },
+              {
+                content: [RESULT],
+                tool_use_id: "call-search-1",
+                type: "web_search_tool_result",
+              },
+              {
+                id: "call-fetch-1",
+                input: { url: RESULT.url },
+                name: "web_fetch",
+                type: "tool_use",
+              },
+            ],
+            id: "message-search-1",
+            model: "MiniMax-M3",
+            role: "assistant",
+            stop_reason: "tool_use",
+            stop_sequence: null,
+            type: "message",
+            usage: { input_tokens: 10, output_tokens: 8 },
+          }
+        : {
+            content: [{ text: "Проверка завершена.", type: "text" }],
+            id: "message-search-2",
+            model: "MiniMax-M3",
+            role: "assistant",
+            stop_reason: "end_turn",
+            stop_sequence: null,
+            type: "message",
+            usage: { input_tokens: 20, output_tokens: 6 },
+          }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      });
+    }) as FetchFunction;
+    const model = createConfiguredLanguageModel({
+      apiKey: "model-secret",
+      fetch,
+      maxOutputTokens: 128_000,
+      modelId: "MiniMax-M3",
+      transport: {
+        authentication: "bearer",
+        baseUrl: "https://api.minimax.io/anthropic/v1",
+        compatibility: "minimax-anthropic",
+        protocol: "anthropic-messages",
+        thinking: { type: "adaptive" },
+      },
+    });
+
+    const result = await generateText({
+      model,
+      prompt: "Найди и проверь доставку еды",
+      stopWhen: stepCountIs(2),
+      tools: {
+        web_fetch: tool({
+          execute: async () => ({ content: "Страница доставки" }),
+          inputSchema: z.object({ url: z.url() }),
+        }),
+        // The provider package and root AI SDK resolve separate branded tool schema instances.
+        web_search: anthropic.tools.webSearch_20250305() as never,
+      },
+    });
+
+    expect(result.text).toBe("Проверка завершена.");
+    expect(requests).toHaveLength(2);
+    expect(requests[1]).toMatchObject({
+      messages: expect.arrayContaining([
+        {
+          content: [expect.objectContaining({
+            id: "call-search-1",
+            name: "web_search",
+            type: "tool_use",
+          })],
+          role: "assistant",
+        },
+        {
+          content: [expect.objectContaining({
+            tool_use_id: "call-search-1",
+            type: "tool_result",
+          })],
+          role: "user",
+        },
+      ]),
+    });
   });
 });

--- a/agent/lib/minimax-anthropic-compatibility.test.ts
+++ b/agent/lib/minimax-anthropic-compatibility.test.ts
@@ -178,6 +178,31 @@ describe("createMiniMaxAnthropicCompatibilityFetch", () => {
     });
   });
 
+  it("rejects incomplete native web-search history before calling MiniMax", async () => {
+    const upstream = vi.fn();
+    const fetch = createMiniMaxAnthropicCompatibilityFetch(upstream as FetchFunction);
+
+    await expect(fetch("https://api.minimax.io/anthropic/v1/messages", {
+      body: JSON.stringify({
+        messages: [{
+          content: [{
+            content: [{
+              encrypted_content: RESULT.content,
+              title: RESULT.title,
+              type: RESULT.type,
+              url: RESULT.url,
+            }],
+            tool_use_id: "call-search-without-call",
+            type: "web_search_tool_result",
+          }],
+          role: "assistant",
+        }],
+      }),
+      method: "POST",
+    })).rejects.toThrow("AGENT_MINIMAX_ANTHROPIC_HISTORY_INVALID");
+    expect(upstream).not.toHaveBeenCalled();
+  });
+
   it("normalizes non-streaming MiniMax message content", async () => {
     const fetch = createMiniMaxAnthropicCompatibilityFetch(vi.fn(async () =>
       new Response(JSON.stringify({

--- a/agent/lib/minimax-anthropic-compatibility.ts
+++ b/agent/lib/minimax-anthropic-compatibility.ts
@@ -3,10 +3,11 @@
  *
  * Export:
  * - `createMiniMaxAnthropicCompatibilityFetch`: preserves MiniMax web-search result content while
- *   translating its field name to and from the Anthropic schema expected by the AI SDK.
+ *   translating responses for the AI SDK and replaying results through ordinary tool messages.
  *
  * Key constructs:
  * - Exact block matching leaves ordinary model payloads untouched.
+ * - Provider search history is downgraded because MiniMax rejects its own native result blocks.
  * - Streaming normalization buffers split SSE lines without buffering the complete response.
  */
 import type { FetchFunction } from "@ai-sdk/provider-utils";
@@ -74,6 +75,107 @@ function rewriteToolResultBlock(value: unknown, direction: WireDirection): unkno
   };
 }
 
+function replayableWebSearchIds(content: readonly unknown[]): ReadonlySet<string> {
+  const callIds = new Set<string>();
+  const resultIds = new Set<string>();
+  for (const value of content) {
+    const block = record(value);
+    if (
+      block?.type === "server_tool_use" && block.name === "web_search" &&
+      typeof block.id === "string"
+    ) {
+      callIds.add(block.id);
+    }
+    if (block?.type === WEB_SEARCH_TOOL_RESULT_TYPE && typeof block.tool_use_id === "string") {
+      resultIds.add(block.tool_use_id);
+    }
+  }
+  return new Set([...callIds].filter((id) => resultIds.has(id)));
+}
+
+function serializeReplayToolResult(content: unknown): string {
+  // Ordinary tool output keeps the snippets model-visible without asking MiniMax to validate
+  // the native provider-owned result block that its Anthropic endpoint cannot replay.
+  const normalized = Array.isArray(content)
+    ? content.map((result) => rewriteSearchResult(result, "to-minimax"))
+    : content;
+  const serialized = JSON.stringify(normalized);
+  if (serialized !== undefined) return serialized;
+  throw new AppError(
+    "AGENT_MINIMAX_ANTHROPIC_HISTORY_INVALID",
+    "История веб-поиска MiniMax содержит некорректный результат инструмента",
+  );
+}
+
+function rewriteAssistantSearchHistory(message: Record<string, unknown>): Record<string, unknown>[] {
+  if (message.role !== "assistant" || !Array.isArray(message.content)) return [message];
+  const replayIds = replayableWebSearchIds(message.content);
+  if (replayIds.size === 0) return [message];
+
+  const messages: Record<string, unknown>[] = [];
+  let assistantContent: unknown[] = [];
+  const flushAssistant = () => {
+    if (assistantContent.length === 0) return;
+    messages.push({ ...message, content: assistantContent });
+    assistantContent = [];
+  };
+
+  // Split at every native result so each converted tool call has the required following user
+  // result, while preserving later text and ordinary local tool calls in their original order.
+  for (const value of message.content) {
+    const block = record(value);
+    if (
+      block?.type === "server_tool_use" && block.name === "web_search" &&
+      typeof block.id === "string" && replayIds.has(block.id)
+    ) {
+      assistantContent.push({
+        ...(block.cache_control === undefined ? {} : { cache_control: block.cache_control }),
+        id: block.id,
+        input: block.input,
+        name: block.name,
+        type: "tool_use",
+      });
+      continue;
+    }
+    if (
+      block?.type === WEB_SEARCH_TOOL_RESULT_TYPE && typeof block.tool_use_id === "string" &&
+      replayIds.has(block.tool_use_id)
+    ) {
+      flushAssistant();
+      messages.push({
+        content: [{
+          ...(block.cache_control === undefined ? {} : { cache_control: block.cache_control }),
+          content: serializeReplayToolResult(block.content),
+          tool_use_id: block.tool_use_id,
+          type: "tool_result",
+        }],
+        role: "user",
+      });
+      continue;
+    }
+    assistantContent.push(value);
+  }
+  flushAssistant();
+  return messages;
+}
+
+function appendOutgoingMessage(
+  messages: Record<string, unknown>[],
+  message: Record<string, unknown>,
+): void {
+  const previous = messages.at(-1);
+  if (
+    previous?.role === "user" && message.role === "user" &&
+    Array.isArray(previous.content) && Array.isArray(message.content)
+  ) {
+    // A result at the end of an assistant turn and the next user prompt form one Anthropic user
+    // message, with tool_result first as required by the wire protocol.
+    previous.content = [...previous.content, ...message.content];
+    return;
+  }
+  messages.push(message);
+}
+
 function rewriteIncomingPayload(value: unknown): unknown {
   const payload = record(value);
   if (!payload) return value;
@@ -94,16 +196,22 @@ function rewriteIncomingPayload(value: unknown): unknown {
 function rewriteOutgoingPayload(value: unknown): unknown {
   const payload = record(value);
   if (!payload || !Array.isArray(payload.messages)) return value;
+  const messages: Record<string, unknown>[] = [];
+  for (const messageValue of payload.messages) {
+    const message = record(messageValue);
+    if (!message) {
+      throw new AppError(
+        "AGENT_MINIMAX_ANTHROPIC_HISTORY_INVALID",
+        "История сообщений MiniMax содержит некорректную запись",
+      );
+    }
+    for (const rewritten of rewriteAssistantSearchHistory(message)) {
+      appendOutgoingMessage(messages, rewritten);
+    }
+  }
   return {
     ...payload,
-    messages: payload.messages.map((messageValue) => {
-      const message = record(messageValue);
-      if (!message || !Array.isArray(message.content)) return messageValue;
-      return {
-        ...message,
-        content: message.content.map((block) => rewriteToolResultBlock(block, "to-minimax")),
-      };
-    }),
+    messages,
   };
 }
 

--- a/agent/lib/minimax-anthropic-compatibility.ts
+++ b/agent/lib/minimax-anthropic-compatibility.ts
@@ -80,17 +80,33 @@ function replayableWebSearchIds(content: readonly unknown[]): ReadonlySet<string
   const resultIds = new Set<string>();
   for (const value of content) {
     const block = record(value);
-    if (
-      block?.type === "server_tool_use" && block.name === "web_search" &&
-      typeof block.id === "string"
-    ) {
+    if (block?.type === "server_tool_use" && block.name === "web_search") {
+      if (typeof block.id !== "string") {
+        throw new AppError(
+          "AGENT_MINIMAX_ANTHROPIC_HISTORY_INVALID",
+          "История веб-поиска MiniMax содержит вызов без идентификатора",
+        );
+      }
       callIds.add(block.id);
     }
-    if (block?.type === WEB_SEARCH_TOOL_RESULT_TYPE && typeof block.tool_use_id === "string") {
+    if (block?.type === WEB_SEARCH_TOOL_RESULT_TYPE) {
+      if (typeof block.tool_use_id !== "string") {
+        throw new AppError(
+          "AGENT_MINIMAX_ANTHROPIC_HISTORY_INVALID",
+          "История веб-поиска MiniMax содержит результат без идентификатора вызова",
+        );
+      }
       resultIds.add(block.tool_use_id);
     }
   }
-  return new Set([...callIds].filter((id) => resultIds.has(id)));
+  const replayIds = new Set([...callIds].filter((id) => resultIds.has(id)));
+  if (callIds.size !== replayIds.size || resultIds.size !== replayIds.size) {
+    throw new AppError(
+      "AGENT_MINIMAX_ANTHROPIC_HISTORY_INVALID",
+      "История веб-поиска MiniMax содержит непарный вызов или результат",
+    );
+  }
+  return replayIds;
 }
 
 function serializeReplayToolResult(content: unknown): string {
@@ -170,7 +186,10 @@ function appendOutgoingMessage(
   ) {
     // A result at the end of an assistant turn and the next user prompt form one Anthropic user
     // message, with tool_result first as required by the wire protocol.
-    previous.content = [...previous.content, ...message.content];
+    messages[messages.length - 1] = {
+      ...previous,
+      content: [...previous.content, ...message.content],
+    };
     return;
   }
   messages.push(message);

--- a/agent/lib/sessions/session-repository.integration.test.ts
+++ b/agent/lib/sessions/session-repository.integration.test.ts
@@ -4,6 +4,7 @@
  * Constructs covered:
  * - Generation-zero session creation and route re-keying.
  * - Monotonic Eve root rebinding after a terminal workflow replacement.
+ * - Terminal failure resolution through any durable Telegram route after re-keying.
  * - Rotation after thresholds while pending operations remain pinned.
  * - Stable sandbox identity across generations and replacement at a trust-zone boundary.
  * - Retention leasing for retired Eve sessions.
@@ -192,6 +193,34 @@ describeWithDatabase("session repository", () => {
           AND pending_operation = false
           AND rotation_requested_at IS NOT NULL`,
       [current.id, failedRoot],
+    )).resolves.toMatchObject({ rowCount: 1 });
+  });
+
+  it("records a terminal failure through an earlier route after Telegram re-keying", async () => {
+    const f = await fixture();
+    const current = await sessionRepository.prepareTurn({
+      baseContinuationToken: "106::426",
+      familyId: f.familyId,
+      groupId: null,
+      now: new Date("2026-07-12T12:00:00.000Z"),
+      scope: "personal",
+      userId: f.userId,
+    });
+    const failedRoot = "wrun_01KXBRD0AY4NP50QXR7C5D6YEK";
+    await sessionRepository.bindEveSession(current.id, failedRoot);
+    await sessionRepository.registerRoute(current.id, "106::437");
+
+    await expect(sessionRepository.recordSessionFailedByContinuationToken(
+      "106::426",
+      failedRoot,
+    )).resolves.toBe("recorded");
+
+    await expect(database().query(
+      `SELECT 1 FROM conversation_sessions
+        WHERE id = $1
+          AND pending_operation = false
+          AND rotation_requested_at IS NOT NULL`,
+      [current.id],
     )).resolves.toMatchObject({ rowCount: 1 });
   });
 

--- a/agent/lib/sessions/session-repository.ts
+++ b/agent/lib/sessions/session-repository.ts
@@ -323,29 +323,36 @@ export const sessionRepository = {
     continuationToken: string,
     eveSessionId: string,
   ): Promise<SessionEventResult> {
-    const result = await database().query<{ id: string }>(
+    // A long Telegram turn can re-anchor several times before Eve emits session.failed. Resolve
+    // both the current token and every durable route retained for the same application session.
+    const sessions = await database().query<{ id: string }>(
+      `SELECT DISTINCT s.id
+         FROM conversation_sessions s
+         LEFT JOIN conversation_session_routes r ON r.session_id = s.id
+        WHERE s.retired_at IS NULL
+          AND (s.continuation_token = $1 OR r.base_continuation_token = $1)`,
+      [continuationToken],
+    );
+    if (sessions.rowCount !== 1) {
+      throw new AppError(
+        "AGENT_SESSION_FAILURE_RECORD_FAILED",
+        sessions.rowCount === 0
+          ? "Не удалось завершить повреждённый контекст"
+          : "Маршрут повреждённого контекста связан с несколькими сессиями",
+      );
+    }
+    const id = sessions.rows[0]!.id;
+
+    const result = await database().query(
       `UPDATE conversation_sessions
           SET pending_operation = false,
               rotation_requested_at = now(),
               eve_session_id = $2
-        WHERE continuation_token = $1
-          AND retired_at IS NULL
+        WHERE id = $1 AND retired_at IS NULL
           AND (eve_session_id IS NULL OR eve_session_id <= $2)`,
-      [continuationToken, eveSessionId],
+      [id, eveSessionId],
     );
     if (result.rowCount === 1) return "recorded";
-    const session = await database().query<{ id: string }>(
-      `SELECT id FROM conversation_sessions
-        WHERE continuation_token = $1 AND retired_at IS NULL`,
-      [continuationToken],
-    );
-    const id = session.rows[0]?.id;
-    if (!id) {
-      throw new AppError(
-        "AGENT_SESSION_FAILURE_RECORD_FAILED",
-        "Не удалось завершить повреждённый контекст",
-      );
-    }
     return await classifyMissedSessionEvent(
       id,
       eveSessionId,

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -74,10 +74,13 @@ release can restart during recovery. Active model selection is immutable in each
 and vision model IDs, explicit output limits, and the primary context window. The current Anthropic
 Messages transport carries typed thinking blocks without text parsing. Changing active model
 selection therefore requires a reviewed release and rolls back atomically with that image.
-The MiniMax transport explicitly enables a narrow bidirectional web-search field adapter because
-MiniMax returns `content` where the Anthropic SDK requires `encrypted_content`; the exact value is
-preserved and restored on history replay rather than synthesized or discarded. Remove this adapter
-when MiniMax emits the Anthropic field or the AI SDK supports the MiniMax dialect natively.
+The MiniMax transport explicitly enables a narrow web-search adapter because MiniMax returns
+`content` where the Anthropic SDK requires `encrypted_content`, but rejects its own native
+`server_tool_use` / `web_search_tool_result` blocks when they are replayed. Responses retain the
+exact result value for SDK parsing; history converts each matched provider pair into an ordinary
+`tool_use` / `tool_result` exchange so later model steps remain valid. Remove this adapter only when
+MiniMax emits the Anthropic field and accepts native provider-tool history, or when the AI SDK
+supports the complete MiniMax dialect natively.
 
 The `cli-proxy-api` service and sixth release image remain only because the installed production
 deployment controller validates manifest schema version 1 and its fixed six-image service graph.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.21",
+      "version": "0.2.22",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- replay MiniMax provider-managed web search through ordinary tool messages
- resolve terminal Telegram failures through durable historical routes
- release version 0.2.22

## Verification
- production-equivalent Docker Compose gate
- 600 tests passed
- typecheck passed
- Eve build passed
- real MiniMax mixed web-search/local-tool replay returned HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Что изменилось

- Исправлено воспроизведение MiniMax web search: provider-managed поисковые результаты преобразуются в обычные `tool_use`/`tool_result` сообщения, совместимые с последующими запросами.
- Добавлена поддержка многошагового сценария MiniMax с web search и локальным инструментом.
- Улучшено объединение последовательных пользовательских сообщений и добавлена валидация некорректной истории.
- Исправлена запись терминальных ошибок Telegram через любой durable route после re-keying.
- Версия обновлена до `0.2.22`.

## Проверка

- 600 тестов проходят.
- Typecheck и Eve build успешны.
- Production-equivalent Docker Compose gate пройден.
- Реальный MiniMax mixed web-search/local-tool replay вернул HTTP 200.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->