### PR TITLE
Release v0.2.23: reserve deployment backup space

### DIFF
--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -32,7 +32,8 @@ release, Compose hash, fixed service/image/mount policy, and digest names. It pu
 backs up existing durable state, starts the released Compose graph without build, and checks
 `http://127.0.0.1:8082/eve/v1/health`.
 Before each non-initial deployment it also prunes older Osinara deployment backups, retaining the
-initial migration backup and the five newest timestamped deploy backups. After a successful health
+initial migration backup and four timestamped deploy backups so the pending snapshot has reserved
+space; after successful backup creation there are again five timestamped backups. After a successful health
 check and terminal success record it removes local first-party Osinara image references older than
 the current and previous release; this never prunes non-Osinara projects on the same server.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.22",
+      "version": "0.2.23",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "type": "module",
   "imports": {

--- a/production-deploy-shell.test.ts
+++ b/production-deploy-shell.test.ts
@@ -7,6 +7,7 @@
  * - `composeSha256` binds the exact released Compose bytes.
  * - PostgreSQL command tags cannot masquerade as returned proposal rows.
  * - Newly introduced durable volumes are bootstrapped only during the first compatible update.
+ * - Backup retention reserves one timestamped slot before every deployment snapshot.
  */
 import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -135,7 +136,7 @@ describe("production deploy shell policies", () => {
     expect(owned.stderr).toContain("DEPLOY_BACKUP_VOLUME_MISSING");
   });
 
-  it("retains the initial backup and only the latest deploy backups", () => {
+  it("retains the initial backup and reserves one deploy-backup slot", () => {
     const directory = mkdtempSync(join(tmpdir(), "osinara-backup-retention-"));
     temporaryDirectories.push(directory);
     for (const name of [
@@ -160,7 +161,6 @@ describe("production deploy shell policies", () => {
 
     expect(result.status, result.stderr).toBe(0);
     expect(readdirSync(directory).sort()).toEqual([
-      "20260714T065745Z-to-v0.2.0",
       "20260714T080346Z-to-v0.2.1",
       "20260714T083709Z-to-v0.2.2",
       "20260714T090552Z-to-v0.2.3",

--- a/scripts/production-deploy/backup.sh
+++ b/scripts/production-deploy/backup.sh
@@ -4,6 +4,7 @@
 
 readonly BACKUP_RESERVE_BYTES=$((512 * 1024 * 1024))
 readonly RETAINED_DEPLOY_BACKUP_COUNT=5
+readonly PRE_DEPLOY_RETAINED_BACKUP_COUNT=$((RETAINED_DEPLOY_BACKUP_COUNT - 1))
 readonly DEPLOY_BACKUP_NAME_PATTERN='^[0-9]{8}T[0-9]{6}Z-to-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
 readonly DURABLE_VOLUMES=(
   osinara-production-google-workspace-credentials
@@ -27,7 +28,8 @@ prune_old_deploy_backups() {
   done
   [[ "$nullglob_was_enabled" -eq 1 ]] || shopt -u nullglob
 
-  remove_count=$((${#deploy_backups[@]} - RETAINED_DEPLOY_BACKUP_COUNT))
+  # Reserve one slot before preflight so the newly validated snapshot restores the final count.
+  remove_count=$((${#deploy_backups[@]} - PRE_DEPLOY_RETAINED_BACKUP_COUNT))
   ((remove_count > 0)) || return 0
   for ((index = 0; index < remove_count; index += 1)); do
     name="${deploy_backups[index]##*/}"


### PR DESCRIPTION
## Summary
- reserve one timestamped backup slot before deployment preflight
- retain five deploy snapshots after successful backup creation
- release version 0.2.23 after the safely failed v0.2.22 deployment

## Verification
- production-equivalent Docker Compose gate
- 601 tests passed
- typecheck passed
- Eve build passed