### PR TITLE
Release v0.2.27

### DIFF
--- a/agent/lib/minimax-anthropic-compatibility.test.ts
+++ b/agent/lib/minimax-anthropic-compatibility.test.ts
@@ -208,29 +208,54 @@ describe("createMiniMaxAnthropicCompatibilityFetch", () => {
     });
   });
 
-  it("rejects incomplete native web-search history before calling MiniMax", async () => {
-    const upstream = vi.fn();
+  it("removes unpaired native web-search history before calling MiniMax", async () => {
+    let body: unknown;
+    const upstream = vi.fn(async (_input, init) => {
+      body = JSON.parse(String(init?.body));
+      return new Response("{}", {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      });
+    });
     const fetch = createMiniMaxAnthropicCompatibilityFetch(upstream as FetchFunction);
 
-    await expect(fetch("https://api.minimax.io/anthropic/v1/messages", {
+    await fetch("https://api.minimax.io/anthropic/v1/messages", {
       body: JSON.stringify({
-        messages: [{
-          content: [{
-            content: [{
-              encrypted_content: RESULT.content,
-              title: RESULT.title,
-              type: RESULT.type,
-              url: RESULT.url,
-            }],
-            tool_use_id: "call-search-without-call",
-            type: "web_search_tool_result",
-          }],
-          role: "assistant",
-        }],
+        messages: [
+          {
+            content: [
+              { text: "Проверяю.", type: "text" },
+              {
+                id: "call-search-without-result",
+                input: { query: "доставка еды" },
+                name: "web_search",
+                type: "server_tool_use",
+              },
+              {
+                content: [{
+                  encrypted_content: RESULT.content,
+                  title: RESULT.title,
+                  type: RESULT.type,
+                  url: RESULT.url,
+                }],
+                tool_use_id: "call-search-without-call",
+                type: "web_search_tool_result",
+              },
+            ],
+            role: "assistant",
+          },
+          { content: [{ text: "Продолжай.", type: "text" }], role: "user" },
+        ],
       }),
       method: "POST",
-    })).rejects.toThrow("AGENT_MINIMAX_ANTHROPIC_HISTORY_INVALID");
-    expect(upstream).not.toHaveBeenCalled();
+    });
+
+    expect(body).toEqual({
+      messages: [
+        { content: [{ text: "Проверяю.", type: "text" }], role: "assistant" },
+        { content: [{ text: "Продолжай.", type: "text" }], role: "user" },
+      ],
+    });
   });
 
   it("normalizes non-streaming MiniMax message content", async () => {

--- a/agent/lib/minimax-anthropic-compatibility.ts
+++ b/agent/lib/minimax-anthropic-compatibility.ts
@@ -112,12 +112,6 @@ function replayableWebSearchIds(content: readonly unknown[]): ReadonlySet<string
     }
   }
   const replayIds = new Set([...callIds].filter((id) => resultIds.has(id)));
-  if (callIds.size !== replayIds.size || resultIds.size !== replayIds.size) {
-    throw new AppError(
-      "AGENT_MINIMAX_ANTHROPIC_HISTORY_INVALID",
-      "История веб-поиска MiniMax содержит непарный вызов или результат",
-    );
-  }
   return replayIds;
 }
 
@@ -138,7 +132,6 @@ function serializeReplayToolResult(content: unknown): string {
 function rewriteAssistantSearchHistory(message: Record<string, unknown>): Record<string, unknown>[] {
   if (message.role !== "assistant" || !Array.isArray(message.content)) return [message];
   const replayIds = replayableWebSearchIds(message.content);
-  if (replayIds.size === 0) return [message];
 
   const messages: Record<string, unknown>[] = [];
   let assistantContent: unknown[] = [];
@@ -152,33 +145,33 @@ function rewriteAssistantSearchHistory(message: Record<string, unknown>): Record
   // result, while preserving later text and ordinary local tool calls in their original order.
   for (const value of message.content) {
     const block = record(value);
-    if (
-      block?.type === "server_tool_use" && block.name === "web_search" &&
-      typeof block.id === "string" && replayIds.has(block.id)
-    ) {
-      assistantContent.push({
-        ...(block.cache_control === undefined ? {} : { cache_control: block.cache_control }),
-        id: block.id,
-        input: block.input,
-        name: block.name,
-        type: "tool_use",
-      });
+    if (block?.type === "server_tool_use" && block.name === "web_search") {
+      // A failed provider stream may persist only one half of the native search exchange.
+      // Omit that unusable trace; paired calls are replayed through ordinary tool messages.
+      if (typeof block.id === "string" && replayIds.has(block.id)) {
+        assistantContent.push({
+          ...(block.cache_control === undefined ? {} : { cache_control: block.cache_control }),
+          id: block.id,
+          input: block.input,
+          name: block.name,
+          type: "tool_use",
+        });
+      }
       continue;
     }
-    if (
-      block?.type === WEB_SEARCH_TOOL_RESULT_TYPE && typeof block.tool_use_id === "string" &&
-      replayIds.has(block.tool_use_id)
-    ) {
-      flushAssistant();
-      messages.push({
-        content: [{
-          ...(block.cache_control === undefined ? {} : { cache_control: block.cache_control }),
-          content: serializeReplayToolResult(block.content),
-          tool_use_id: block.tool_use_id,
-          type: "tool_result",
-        }],
-        role: "user",
-      });
+    if (block?.type === WEB_SEARCH_TOOL_RESULT_TYPE) {
+      if (typeof block.tool_use_id === "string" && replayIds.has(block.tool_use_id)) {
+        flushAssistant();
+        messages.push({
+          content: [{
+            ...(block.cache_control === undefined ? {} : { cache_control: block.cache_control }),
+            content: serializeReplayToolResult(block.content),
+            tool_use_id: block.tool_use_id,
+            type: "tool_result",
+          }],
+          role: "user",
+        });
+      }
       continue;
     }
     assistantContent.push(value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.26",
+      "version": "0.2.27",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- remove orphaned MiniMax native web-search calls and results from replay history
- preserve ordinary assistant content and complete search exchanges
- release v0.2.27

## Production incident
- MODEL_CALL_FAILED: f9eb93ee-fe5e-452b-a7b8-30008d71bda5
- root cause: AGENT_MINIMAX_ANTHROPIC_HISTORY_INVALID in a scheduled session

## Verification
- npm run typecheck
- npm test (625 tests, 530 passed and 95 skipped locally)
- npm run build
- docker compose -f compose.test.yaml up --build --abort-on-container-exit --exit-code-from tests (625 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Краткое описание

- Выпущена версия `0.2.27`.
- Исправлена ошибка `AGENT_MINIMAX_ANTHROPIC_HISTORY_INVALID` в запланированных сессиях.
- Перед отправкой запроса в MiniMax удаляются непарные записи нативного web search.
- Обычные сообщения ассистента сохраняются без изменений.
- Полные пары `web_search` и `web_search_tool_result` преобразуются в `tool_use` и `tool_result`.
- Обновлены тесты для проверки фильтрации неполных поисковых записей.

## Проверка

- Локальные тесты: 530 пройдено, 95 пропущено.
- Docker-тесты: 625 пройдено.
- Также выполнены проверка типов и сборка.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->