### PR TITLE
Release v0.2.28

### DIFF
--- a/agent/lib/eve-telegram-ingress-patch.test.ts
+++ b/agent/lib/eve-telegram-ingress-patch.test.ts
@@ -6,6 +6,7 @@
  * - Patched native dispatch: returns the Eve session and accepts application continuation/auth.
  * - `replyHandling: "message"`: suppresses only preliminary Telegram HITL reply synthesis.
  * - Application-authored durable message overrides replace only the model-visible inbound text.
+ * - Pure HITL callbacks do not insert channel context between approval and tool execution.
  * - Patch installation remains safe when lifecycle scripts invoke it repeatedly.
  */
 import { execFile } from "node:child_process";
@@ -43,6 +44,10 @@ describe("Eve Telegram verified ingress patch", () => {
       "node_modules/eve/dist/src/public/channels/telegram/telegramChannel.js",
       "utf8",
     );
+    const toolLoopRuntime = await readFile(
+      "node_modules/eve/dist/src/harness/tool-loop.js",
+      "utf8",
+    );
     const types = await readFile(
       "node_modules/eve/dist/src/public/channels/telegram/telegramChannel.d.ts",
       "utf8",
@@ -64,6 +69,9 @@ describe("Eve Telegram verified ingress patch", () => {
     expect(runtime.match(/r\.replyHandling!==`message`/g)).toHaveLength(1);
     expect(runtime.match(/i\.acknowledgementText\?\?`Answer received\.`/g)).toHaveLength(1);
     expect(runtime.match(/message:r\.message\?\?a/g)).toHaveLength(1);
+    expect(
+      toolLoopRuntime.match(/\(S\.input\?\.inputResponses\?\.length\?\?0\)===0/g),
+    ).toHaveLength(1);
     expect(types.match(/readonly message\?: string;/g)).toHaveLength(1);
     expect(types.match(/readonly replyHandling\?: "message";/g)).toHaveLength(1);
     expect(valid).toMatchObject({ replyHandling: "message" });

--- a/agent/lib/telegram-group-timeline-repository.integration.test.ts
+++ b/agent/lib/telegram-group-timeline-repository.integration.test.ts
@@ -118,8 +118,11 @@ describeWithDatabase("unified Telegram group timeline repository", () => {
       attachment_file_id: string | null;
       attachment_file_name: string | null;
       attachment_kind: string | null;
+      attachment_media_type: string | null;
+      attachment_size: string | null;
     }>(
-      `SELECT actor_kind, attachment_file_id, attachment_file_name, attachment_kind
+      `SELECT actor_kind, attachment_file_id, attachment_file_name, attachment_kind,
+              attachment_media_type, attachment_size::text
        FROM telegram_group_messages WHERE id = $1`,
       [result.entryId],
     );
@@ -128,6 +131,8 @@ describeWithDatabase("unified Telegram group timeline repository", () => {
       attachment_file_id: null,
       attachment_file_name: "report.pdf",
       attachment_kind: "document",
+      attachment_media_type: "application/pdf",
+      attachment_size: "1024",
     });
   });
 

--- a/agent/lib/telegram-group-timeline-repository.integration.test.ts
+++ b/agent/lib/telegram-group-timeline-repository.integration.test.ts
@@ -4,6 +4,7 @@
  * Constructs covered:
  * - Group-wide monotonic sequence allocation across user and agent entries.
  * - Every delivered agent chunk resolves to one logical entry and trusted replies.
+ * - Tool-delivered agent attachments persist without an inbound Telegram file identifier.
  * - Retention never resets or reuses the durable group counter.
  */
 import type { TelegramMessage } from "eve/channels/telegram";
@@ -91,6 +92,43 @@ describeWithDatabase("unified Telegram group timeline repository", () => {
     });
     expect(entries.map((entry) => [entry.sequenceId, entry.actorKind, entry.replyToSequenceId]))
       .toEqual([["1", "user", null], ["2", "agent_self", "1"], ["3", "user", "2"]]);
+  });
+
+  it("records an agent-delivered attachment without an inbound Telegram file ID", async () => {
+    const groupId = await group();
+
+    const result = await telegramGroupJournalRepository.recordAgentResponse({
+      applicationSessionId: null,
+      attachment: {
+        fileName: "report.pdf",
+        kind: "document",
+        mediaType: "application/pdf",
+        size: 1_024,
+      },
+      contentText: "Финансовый отчёт",
+      deliveredAt: new Date("2026-07-31T10:00:00.000Z"),
+      groupId,
+      messageThreadId: null,
+      replyToEntryId: null,
+      telegramMessageIds: ["40"],
+    });
+
+    const stored = await database().query<{
+      actor_kind: string;
+      attachment_file_id: string | null;
+      attachment_file_name: string | null;
+      attachment_kind: string | null;
+    }>(
+      `SELECT actor_kind, attachment_file_id, attachment_file_name, attachment_kind
+       FROM telegram_group_messages WHERE id = $1`,
+      [result.entryId],
+    );
+    expect(stored.rows[0]).toEqual({
+      actor_kind: "agent_self",
+      attachment_file_id: null,
+      attachment_file_name: "report.pdf",
+      attachment_kind: "document",
+    });
   });
 
   it("does not reset the sequence after physical pruning", async () => {

--- a/migrations/036_agent_timeline_attachments.sql
+++ b/migrations/036_agent_timeline_attachments.sql
@@ -1,0 +1,30 @@
+ALTER TABLE telegram_group_messages
+  DROP CONSTRAINT telegram_group_messages_attachment_shape;
+
+ALTER TABLE telegram_group_messages
+  ADD CONSTRAINT telegram_group_messages_attachment_shape CHECK (
+    (
+      attachment_kind IS NULL AND
+      attachment_file_id IS NULL AND
+      attachment_file_unique_id IS NULL AND
+      attachment_file_name IS NULL AND
+      attachment_media_type IS NULL AND
+      attachment_size IS NULL
+    ) OR (
+      attachment_kind IN ('document', 'photo') AND
+      (attachment_file_name IS NULL OR char_length(attachment_file_name) > 0) AND
+      (attachment_media_type IS NULL OR char_length(attachment_media_type) > 0) AND
+      (attachment_size IS NULL OR attachment_size > 0) AND
+      (
+        (
+          attachment_file_id IS NOT NULL AND
+          char_length(attachment_file_id) > 0 AND
+          (attachment_file_unique_id IS NULL OR char_length(attachment_file_unique_id) > 0)
+        ) OR (
+          actor_kind = 'agent_self' AND
+          attachment_file_id IS NULL AND
+          attachment_file_unique_id IS NULL
+        )
+      )
+    )
+  );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.27",
+      "version": "0.2.28",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "private": true,
   "type": "module",
   "imports": {

--- a/scripts/apply-eve-patches.ts
+++ b/scripts/apply-eve-patches.ts
@@ -9,6 +9,7 @@
  * - Lets the application version continuation tokens for rotation, including HITL callbacks.
  * - Lets the application authenticate the exact Telegram user resuming a HITL callback.
  * - Propagates `input.requested` adapter failures so unbound approvals never park fail-open.
+ * - Keeps callback-only channel context from separating an approval from its tool execution.
  * - Makes every Eve-authored model call exact-once with no hidden retry or degraded reissue.
  * - Supports a zero-depth subagent limit so the root agent can disable delegation completely.
  * - Routes local Workflow recovery through Eve's configured queue namespace.
@@ -113,6 +114,14 @@ await replaceOnce(
   toolLoopRuntimePath,
   "async function attemptUnsupportedProviderToolRecovery(e){let t=extractUnsupportedProviderToolTypes(e.error);if(t.length===0)return{outcome:`skipped`};let n=[];for(let e of t){let t=resolveFrameworkToolFromUpstreamType(e);t!==null&&!n.includes(t)&&n.push(t)}if(n.length===0)return{outcome:`skipped`};log.warn(`disabling unsupported provider tool(s); retrying step once`,{disabled:n,sessionId:e.sessionId,turnId:e.turnId,upstreamTypes:t});let r={disabledProviderTools:new Set(n),extraSystemNote:buildDisabledToolNote(n)};try{return{outcome:`recovered`,result:await e.runOneModelCall({...r,suppressStepStartedEmission:!0})}}catch(e){return{outcome:`failed`,error:e,retryCallOptions:r}}}",
   "async function attemptUnsupportedProviderToolRecovery(e){return{outcome:`skipped`}}",
+);
+
+// A pure HITL response must remain the final history item so AI SDK executes the approved tool
+// before any new channel context is presented to the model.
+await replaceOnce(
+  toolLoopRuntimePath,
+  "if(b=P.session,S.input?.context!==void 0)for(let e of S.input.context)N.push({content:e,role:`user`})",
+  "if(b=P.session,S.input?.context!==void 0&&(S.input?.inputResponses?.length??0)===0)for(let e of S.input.context)N.push({content:e,role:`user`})",
 );
 
 // Auxiliary Eve surfaces must not reissue compaction, eval, or code-mode model calls either.


### PR DESCRIPTION
## Summary
- keep callback-only Telegram context from separating an HITL approval from approved tool execution
- permit confirmed agent-delivered group attachments without an inbound Telegram file ID
- add migration 036 and production regressions
- release v0.2.28

## Production incidents
- MODEL_CALL_FAILED: 8e215504-874d-4f5d-a337-79d00bf1db7d
- Telegram group attachment constraint failures after successful file delivery

## Verification
- clean npm ci and Eve patch application
- npm run typecheck
- npm test (626 tests, 530 passed and 96 skipped locally)
- npm run build
- npm run build:runtime
- docker compose production-equivalent gate (626 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Выпущена версия `osinara-family-agent` `0.2.28`.
- Сохранён callback-only Telegram-контекст между HITL-подтверждением и выполнением инструмента.
- Подтверждены агентские вложения в группах без входного Telegram `file_id`.
- Добавлена миграция `036` для обновления ограничения формы вложений.
- Добавлены контрактные и интеграционные регрессионные тесты.
- Зафиксированы исправления инцидента `MODEL_CALL_FAILED` и ошибок ограничения вложений после успешной передачи файла.

## Проверка

- Выполнены чистая установка зависимостей и применение патчей Eve.
- Пройдены проверка типов, тесты и сборка.
- Пройден production-equivalent gate в Docker Compose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->