### PR TITLE
Release v0.2.29

### DIFF
--- a/agent/lib/eve-telegram-ingress-patch.test.ts
+++ b/agent/lib/eve-telegram-ingress-patch.test.ts
@@ -15,7 +15,11 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 
-import { telegramChannel, type TelegramInboundResult } from "eve/channels/telegram";
+import {
+  parseTelegramUpdate,
+  telegramChannel,
+  type TelegramInboundResult,
+} from "eve/channels/telegram";
 import { describe, expect, it, vi } from "vitest";
 
 import { callAdapterEventHandler } from "../../node_modules/eve/dist/src/channel/adapter.js";
@@ -395,11 +399,33 @@ describe("Eve Telegram verified ingress patch", () => {
     expect(onHitlCallbackQuery).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ id: "callback-1" }),
-      "-100:55:77",
+      "-100::77",
     );
     expect(send.mock.calls[0]?.[1]).toMatchObject({
       auth,
       continuationToken: "-100:55:77:osinara:3",
+    });
+  });
+
+  it("preserves an explicit forum topic ID on callback messages", () => {
+    const update = parseTelegramUpdate({
+      callback_query: {
+        data: "eve:0",
+        from: { first_name: "Анна", id: 101, is_bot: false },
+        id: "callback-forum",
+        message: {
+          chat: { id: -100, type: "supergroup" },
+          is_topic_message: true,
+          message_id: 77,
+          message_thread_id: 55,
+        },
+      },
+      update_id: 1007,
+    });
+
+    expect(update).toMatchObject({
+      callbackQuery: { message: { messageThreadId: 55 } },
+      kind: "callback_query",
     });
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.28",
+      "version": "0.2.29",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "private": true,
   "type": "module",
   "imports": {

--- a/scripts/apply-eve-patches.ts
+++ b/scripts/apply-eve-patches.ts
@@ -8,6 +8,7 @@
  * - Lets the application replace model-visible Telegram text with a durable context envelope.
  * - Lets the application version continuation tokens for rotation, including HITL callbacks.
  * - Lets the application authenticate the exact Telegram user resuming a HITL callback.
+ * - Ignores Telegram's reply-only pseudo thread IDs outside explicit forum topics.
  * - Propagates `input.requested` adapter failures so unbound approvals never park fail-open.
  * - Keeps callback-only channel context from separating an approval from its tool execution.
  * - Makes every Eve-authored model call exact-once with no hidden retry or degraded reissue.
@@ -21,6 +22,9 @@ import { resolve } from "node:path";
 const EXPECTED_EVE_VERSION = "0.22.5";
 const telegramRuntimePath = resolve(
   "node_modules/eve/dist/src/public/channels/telegram/telegramChannel.js",
+);
+const telegramInboundRuntimePath = resolve(
+  "node_modules/eve/dist/src/public/channels/telegram/inbound.js",
 );
 const channelAdapterRuntimePath = resolve(
   "node_modules/eve/dist/src/channel/adapter.js",
@@ -198,6 +202,13 @@ await replaceOnce(
   telegramRuntimePath,
   "try{await e.send({inputResponses:u,message:a,context:[o,...s]},{auth:r.auth,continuationToken:continuationTokenFromState(t),state:t})}catch(e){log.error(`message delivery failed`,{error:e})}",
   patchedMessageDispatch,
+);
+// Telegram may attach message_thread_id to a plain reply. It is a real topic boundary only when
+// the update explicitly marks the message as a forum-topic message.
+await replaceAll(
+  telegramInboundRuntimePath,
+  "messageThreadId:typeof e.message_thread_id==`number`?e.message_thread_id:void 0",
+  "messageThreadId:e.is_topic_message===!0&&typeof e.message_thread_id==`number`?e.message_thread_id:void 0",
 );
 // The application may prove that a bot reply is an ordinary timeline branch rather than HITL.
 await replaceOnce(


### PR DESCRIPTION
## Summary
- ignore Telegram reply-only pseudo thread IDs when parsing callback messages
- preserve explicit forum topic IDs
- prevent false AGENT_APPROVAL_EXPIRED for live HITL buttons
- release v0.2.29

## Production incident
- live approvals at Telegram messages 531 and 534 were rejected because callback routes gained synthetic message_thread_id values

## Verification
- clean npm ci and Eve patch application
- npm run typecheck
- npm test (627 tests, 531 passed and 96 skipped locally)
- npm run build
- npm run build:runtime
- docker compose production-equivalent gate (627 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Выпущена версия `0.2.29`.
- Парсер Telegram игнорирует синтетические `message_thread_id` для reply-only сообщений.
- Явные ID форумных тем сохраняются.
- Исправлена ошибка `AGENT_APPROVAL_EXPIRED` для активных HITL-кнопок.
- Обновлены Eve-патчи для continuation tokens, HITL callback-контрактов, Telegram hook и drain endpoint.
- Расширены публичные TypeScript-типы Telegram API.
- Добавлены тесты для callback-сообщений и сохранения `messageThreadId`.

## Проверка

- Установлены зависимости и применены Eve-патчи.
- Выполнены проверки типов, тесты и сборки.
- Пройден production-equivalent Docker Compose gate.
- Локально запущено 627 тестов: 531 прошёл, 96 пропущено.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->