### PR TITLE
Release v0.2.30

### DIFF
--- a/agent/lib/sandbox-runner/runner-client.ts
+++ b/agent/lib/sandbox-runner/runner-client.ts
@@ -4,6 +4,8 @@
  * Export:
  * - `SandboxRunnerClient`: session lifecycle, command, and binary file operations.
  */
+import { Agent, fetch } from "undici";
+
 import type {
   SandboxRunnerCreateRequest,
   SandboxRunnerProcessRequest,
@@ -11,14 +13,25 @@ import type {
   SandboxRunnerRemovePathRequest,
   SandboxRunnerSessionResponse,
 } from "./sandbox-runner-contract.js";
-import { SANDBOX_RUNNER_API_PREFIX } from "./sandbox-runner-contract.js";
+import {
+  SANDBOX_RUNNER_API_PREFIX,
+  SANDBOX_RUNNER_HTTP_TIMEOUT_MS,
+} from "./sandbox-runner-contract.js";
+
+type RunnerResponse = Awaited<ReturnType<typeof fetch>>;
+
+// Process responses intentionally send no headers until execution completes.
+const runnerDispatcher = new Agent({
+  bodyTimeout: SANDBOX_RUNNER_HTTP_TIMEOUT_MS,
+  headersTimeout: SANDBOX_RUNNER_HTTP_TIMEOUT_MS,
+});
 
 interface RunnerErrorBody {
   code?: unknown;
   message?: unknown;
 }
 
-async function runnerError(response: Response): Promise<Error> {
+async function runnerError(response: RunnerResponse): Promise<Error> {
   let body: RunnerErrorBody = {};
   try {
     body = await response.json() as RunnerErrorBody;
@@ -30,7 +43,7 @@ async function runnerError(response: Response): Promise<Error> {
   return new Error(`${code}: ${message} (HTTP ${response.status})`);
 }
 
-async function requireSuccess(response: Response): Promise<Response> {
+async function requireSuccess(response: RunnerResponse): Promise<RunnerResponse> {
   if (response.ok) return response;
   throw await runnerError(response);
 }
@@ -68,6 +81,7 @@ export class SandboxRunnerClient {
       `${this.#baseUrl}${SANDBOX_RUNNER_API_PREFIX}/sessions`,
       {
         body: JSON.stringify(request),
+        dispatcher: runnerDispatcher,
         headers: { "content-type": "application/json" },
         method: "POST",
       },
@@ -90,6 +104,7 @@ export class SandboxRunnerClient {
   ): Promise<SandboxRunnerProcessResponse> {
     const response = await requireSuccess(await fetch(this.#sessionUrl(sessionId, "/processes"), {
       body: JSON.stringify(request),
+      dispatcher: runnerDispatcher,
       headers: { "content-type": "application/json" },
       method: "POST",
       signal,
@@ -99,7 +114,7 @@ export class SandboxRunnerClient {
 
   async readFile(sessionId: string, path: string, signal?: AbortSignal): Promise<Uint8Array | null> {
     const url = `${this.#sessionUrl(sessionId, "/files")}?path=${encodeURIComponent(path)}`;
-    const response = await fetch(url, { signal });
+    const response = await fetch(url, { dispatcher: runnerDispatcher, signal });
     if (response.status === 404) return null;
     await requireSuccess(response);
     return new Uint8Array(await response.arrayBuffer());
@@ -114,6 +129,7 @@ export class SandboxRunnerClient {
     const url = `${this.#sessionUrl(sessionId, "/files")}?path=${encodeURIComponent(path)}`;
     await requireSuccess(await fetch(url, {
       body: Buffer.from(content),
+      dispatcher: runnerDispatcher,
       headers: { "content-type": "application/octet-stream" },
       method: "PUT",
       signal,
@@ -129,17 +145,21 @@ export class SandboxRunnerClient {
     if (request.force !== undefined) search.set("force", String(request.force));
     if (request.recursive !== undefined) search.set("recursive", String(request.recursive));
     await requireSuccess(await fetch(`${this.#sessionUrl(sessionId, "/files")}?${search}`, {
+      dispatcher: runnerDispatcher,
       method: "DELETE",
       signal,
     }));
   }
 
   async stop(sessionId: string): Promise<void> {
-    await requireSuccess(await fetch(this.#sessionUrl(sessionId, "/stop"), { method: "POST" }));
+    await requireSuccess(await fetch(this.#sessionUrl(sessionId, "/stop"), {
+      dispatcher: runnerDispatcher,
+      method: "POST",
+    }));
   }
 
   async deleteToolEnvironment(workspaceId: string): Promise<void> {
     const url = `${this.#baseUrl}${SANDBOX_RUNNER_API_PREFIX}/tool-environments/${encodeURIComponent(workspaceId)}`;
-    await requireSuccess(await fetch(url, { method: "DELETE" }));
+    await requireSuccess(await fetch(url, { dispatcher: runnerDispatcher, method: "DELETE" }));
   }
 }

--- a/agent/lib/sandbox-runner/runner-client.ts
+++ b/agent/lib/sandbox-runner/runner-client.ts
@@ -115,7 +115,11 @@ export class SandboxRunnerClient {
   async readFile(sessionId: string, path: string, signal?: AbortSignal): Promise<Uint8Array | null> {
     const url = `${this.#sessionUrl(sessionId, "/files")}?path=${encodeURIComponent(path)}`;
     const response = await fetch(url, { dispatcher: runnerDispatcher, signal });
-    if (response.status === 404) return null;
+    if (response.status === 404) {
+      // Undici requires every body to be consumed or cancelled before its pooled connection is reusable.
+      await response.body?.cancel();
+      return null;
+    }
     await requireSuccess(response);
     return new Uint8Array(await response.arrayBuffer());
   }

--- a/agent/lib/sandbox-runner/sandbox-runner-contract.ts
+++ b/agent/lib/sandbox-runner/sandbox-runner-contract.ts
@@ -6,7 +6,7 @@
  * - `sandboxSeedDigest`: canonical content identity used by both agent and runner policy checks.
  * - `parseCreateSandboxRequest`: enforces the trusted/restricted scope boundary.
  * - Other `parse*` helpers: validate every untrusted HTTP payload fail-closed.
- * - Runner endpoint and execution-limit constants.
+ * - Runner endpoint, execution-limit, and transport-timeout constants.
  */
 import { createHash } from "node:crypto";
 import { posix } from "node:path";
@@ -18,7 +18,9 @@ export const SANDBOX_RUNNER_COMMAND_MAX_CHARACTERS = 100_000;
 export const SANDBOX_RUNNER_ENVIRONMENT_MAX_ENTRIES = 100;
 export const SANDBOX_RUNNER_MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
 export const SANDBOX_RUNNER_REQUEST_MAX_BYTES = 64 * 1024 * 1024;
+export const SANDBOX_RUNNER_PROCESS_DEFAULT_TIMEOUT_MS = 2 * 60 * 1_000;
 export const SANDBOX_RUNNER_TIMEOUT_MAX_MS = 30 * 60 * 1_000;
+export const SANDBOX_RUNNER_HTTP_TIMEOUT_MS = SANDBOX_RUNNER_TIMEOUT_MAX_MS + 30_000;
 export const SANDBOX_RUNNER_SEED_FILES_MAX = 512;
 export const SANDBOX_RUNNER_SEED_FILE_MAX_BYTES = 50 * 1024 * 1024;
 

--- a/agent/skills/agent-browser/SKILL.md
+++ b/agent/skills/agent-browser/SKILL.md
@@ -16,7 +16,7 @@ Osinara preconfigures `AGENT_BROWSER_SESSION=osinara`, `AGENT_BROWSER_RESTORE=os
 
 Open once, then use separate `snapshot`, `fill`, `click`, `screenshot`, and other commands as needed. A screenshot or completed CLI process does not close Chromium. Never call `close` or `close --all` until the entire user task is complete. Before claiming the browser or authorization was lost, run `agent-browser session info --json`; after a real sandbox recreation, the configured restore state reloads cookies and localStorage on the next `open`.
 
-Bound every CLI call with `timeout --signal=TERM --kill-after=5s 45s agent-browser ...`. Run `open`, `wait`, `eval`, and `close` as separate Bash calls; never chain multiple browser calls into one command. If `open` times out, inspect `session info --json` once and switch to another origin instead of retrying the same blocked site.
+Bound every CLI call with `timeout --signal=TERM --kill-after=5s 45s agent-browser ...`. Run `open`, `wait`, `eval`, and `close` as separate Bash calls; never chain multiple browser calls into one command. If `open` times out, inspect `session info --json` and report the timeout. Retry once only when the session check identifies a startup/runtime transient; otherwise switch origin instead of repeating the blocked site.
 
 ## Start here
 

--- a/agent/skills/agent-browser/SKILL.md
+++ b/agent/skills/agent-browser/SKILL.md
@@ -16,6 +16,8 @@ Osinara preconfigures `AGENT_BROWSER_SESSION=osinara`, `AGENT_BROWSER_RESTORE=os
 
 Open once, then use separate `snapshot`, `fill`, `click`, `screenshot`, and other commands as needed. A screenshot or completed CLI process does not close Chromium. Never call `close` or `close --all` until the entire user task is complete. Before claiming the browser or authorization was lost, run `agent-browser session info --json`; after a real sandbox recreation, the configured restore state reloads cookies and localStorage on the next `open`.
 
+Bound every CLI call with `timeout --signal=TERM --kill-after=5s 45s agent-browser ...`. Run `open`, `wait`, `eval`, and `close` as separate Bash calls; never chain multiple browser calls into one command. If `open` times out, inspect `session info --json` once and switch to another origin instead of retrying the same blocked site.
+
 ## Start here
 
 This file is a discovery stub, not the usage guide. Before running any

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",
@@ -20,6 +20,7 @@
         "pg": "8.22.0",
         "tar-stream": "3.2.0",
         "tsx": "4.23.0",
+        "undici": "8.9.0",
         "zod": "4.4.3"
       },
       "devDependencies": {
@@ -80,6 +81,15 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -3549,12 +3559,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "private": true,
   "type": "module",
   "imports": {
@@ -34,6 +34,7 @@
     "pg": "8.22.0",
     "tar-stream": "3.2.0",
     "tsx": "4.23.0",
+    "undici": "8.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/services/sandbox-runner/docker-sandbox-engine.ts
+++ b/services/sandbox-runner/docker-sandbox-engine.ts
@@ -7,9 +7,7 @@
  * - `resolveSandboxRuntimeImage`: requires the exact sandbox runtime image identity.
  * - `resolveSandboxDockerRuntime`: discovers Compose-owned volumes/network fail-fast.
  */
-import { randomUUID } from "node:crypto";
 import { mkdir, rm, stat } from "node:fs/promises";
-import { PassThrough } from "node:stream";
 import { posix } from "node:path";
 
 import Docker from "dockerode";
@@ -18,8 +16,6 @@ import {
   SANDBOX_RUNNER_MAX_OUTPUT_BYTES,
   SANDBOX_RUNNER_TIMEOUT_MAX_MS,
   type SandboxRunnerCreateRequest,
-  type SandboxRunnerProcessRequest,
-  type SandboxRunnerProcessResponse,
   type SandboxRunnerRemovePathRequest,
   type SandboxRunnerSessionResponse,
 } from "../../agent/lib/sandbox-runner/sandbox-runner-contract.js";
@@ -29,6 +25,7 @@ import {
   readSingleFileArchive,
   writeSingleFileArchive,
 } from "./docker-sandbox-files.js";
+import { executeSandboxProcess } from "./docker-sandbox-process.js";
 import {
   createSandboxActivityRegistry,
   SANDBOX_IDLE_TIMEOUT_MS,
@@ -50,7 +47,6 @@ const MOUNT_TOOLS_DESTINATION = "/runner/tools";
 const MOUNT_WORKSPACES_DESTINATION = "/runner/workspaces";
 const MOUNT_GOOGLE_WORKSPACE_CREDENTIALS_DESTINATION = "/runner/google-workspace-credentials";
 const SANDBOX_NETWORK_LABEL = "sandbox-egress";
-const PROCESS_DEFAULT_TIMEOUT_MS = 10 * 60 * 1_000;
 const SANDBOX_SESSION_LABEL = "dev.osinara.sandbox.session-id";
 const SANDBOX_PROJECT_LABEL = "dev.osinara.sandbox.project";
 const SANDBOX_REQUEST_HASH_LABEL = "dev.osinara.sandbox.request-hash";
@@ -96,66 +92,6 @@ async function requireDirectory(path: string, code: string): Promise<void> {
   if (!metadata.isDirectory()) throw new Error(`${code}: Required path is not a directory`);
 }
 
-async function execute(
-  docker: Docker,
-  container: Docker.Container,
-  request: SandboxRunnerProcessRequest,
-  signal?: AbortSignal,
-): Promise<SandboxRunnerProcessResponse> {
-  const timeoutMs = request.timeoutMs ?? PROCESS_DEFAULT_TIMEOUT_MS;
-  const timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1_000));
-  const exec = await container.exec({
-    AttachStderr: true,
-    AttachStdout: true,
-    Cmd: ["timeout", "--signal=KILL", String(timeoutSeconds), "bash", "-c", request.command],
-    Env: request.environment
-      ? Object.entries(request.environment).map(([name, value]) => `${name}=${value}`)
-      : undefined,
-    Tty: false,
-    WorkingDir: request.workingDirectory ? resolvePath(request.workingDirectory) : "/workspace",
-  });
-  let stream: NodeJS.ReadWriteStream;
-  try {
-    stream = await exec.start({ Tty: false, abortSignal: signal });
-  } catch (error) {
-    await container.remove({ force: true, v: true }).catch(() => undefined);
-    throw error;
-  }
-  const stdout = new PassThrough();
-  const stderr = new PassThrough();
-  docker.modem.demuxStream(stream, stdout, stderr);
-  stream.once("end", () => {
-    stdout.end();
-    stderr.end();
-  });
-  stream.once("error", (error) => {
-    stdout.destroy(error);
-    stderr.destroy(error);
-  });
-  let stdoutBytes: Buffer;
-  let stderrBytes: Buffer;
-  try {
-    [stdoutBytes, stderrBytes] = await Promise.all([
-      collectLimitedStream(stdout, SANDBOX_RUNNER_MAX_OUTPUT_BYTES),
-      collectLimitedStream(stderr, SANDBOX_RUNNER_MAX_OUTPUT_BYTES),
-    ]);
-  } catch (error) {
-    // Aborted or oversized commands must not keep running detached inside a durable session.
-    await container.remove({ force: true, v: true }).catch(() => undefined);
-    throw error;
-  }
-  const inspection = await exec.inspect();
-  if (inspection.Running || inspection.ExitCode === null) {
-    throw new Error("AGENT_SANDBOX_RUNNER_PROCESS_STATE_INVALID: Process did not terminate");
-  }
-  return {
-    exitCode: inspection.ExitCode,
-    processId: randomUUID(),
-    stderr: stderrBytes.toString("utf8"),
-    stdout: stdoutBytes.toString("utf8"),
-  };
-}
-
 async function ensureToolDirectories(
   docker: Docker,
   container: Docker.Container,
@@ -170,7 +106,7 @@ async function ensureToolDirectories(
     `mkdir -p ${directories.map((path) => JSON.stringify(path)).join(" ")}`,
     `(test -x ${JSON.stringify(`${python}/bin/python`)} || python3 -m venv ${JSON.stringify(python)})`,
   ].join(" && ");
-  const result = await execute(docker, container, {
+  const result = await executeSandboxProcess(docker, container, {
     command,
     timeoutMs: SANDBOX_RUNNER_TIMEOUT_MAX_MS,
   });
@@ -278,7 +214,10 @@ export function createDockerSandboxEngine(input: {
     async runProcess(sessionId, request, signal) {
       return await activity.runActive(sessionId, async () => {
         const container = await requireRunningContainer(input.docker, sessionId);
-        return await execute(input.docker, container, request, signal);
+        const processRequest = request.workingDirectory
+          ? { ...request, workingDirectory: resolvePath(request.workingDirectory) }
+          : request;
+        return await executeSandboxProcess(input.docker, container, processRequest, signal);
       });
     },
     async readFile(sessionId, path) {
@@ -296,7 +235,7 @@ export function createDockerSandboxEngine(input: {
       await activity.runActive(sessionId, async () => {
         const container = await requireRunningContainer(input.docker, sessionId);
         const resolved = resolvePath(path);
-        const directoryResult = await execute(input.docker, container, {
+        const directoryResult = await executeSandboxProcess(input.docker, container, {
           command: `mkdir -p -- ${JSON.stringify(posix.dirname(resolved))}`,
         });
         if (directoryResult.exitCode !== 0) {

--- a/services/sandbox-runner/docker-sandbox-process.test.ts
+++ b/services/sandbox-runner/docker-sandbox-process.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Docker sandbox process lifecycle regression tests.
+ *
+ * Constructs covered:
+ * - Default command timeout and stable timeout diagnostics.
+ * - Forced disposable-compute cleanup when Docker exec remains active.
+ */
+import { Readable } from "node:stream";
+
+import type Docker from "dockerode";
+import { describe, expect, it, vi } from "vitest";
+
+import { createDockerSandboxEngine } from "./docker-sandbox-engine.js";
+
+const SANDBOX_SESSION_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+const runtime = {
+  googleWorkspaceCredentialsVolume: "osinara_google-workspace-credentials",
+  egressNetwork: "osinara_sandbox-egress",
+  image: "osinara-sandbox-runtime:local",
+  project: "osinara",
+  toolsVolume: "osinara_tool-environments",
+  workspaceVolume: "osinara_workspace-data",
+};
+
+function processHarness(inspection: { ExitCode: number | null; Running: boolean }) {
+  const remove = vi.fn(async () => undefined);
+  const exec = {
+    inspect: vi.fn(async () => inspection),
+    start: vi.fn(async () => Readable.from([])),
+  };
+  const container = {
+    exec: vi.fn(async () => exec),
+    inspect: vi.fn(async () => ({ Config: { Labels: {} }, State: { Running: true } })),
+    remove,
+  };
+  const docker = {
+    getContainer: vi.fn(() => container),
+    modem: {
+      demuxStream: vi.fn((_stream, stdout, stderr) => {
+        stdout.end();
+        stderr.end();
+      }),
+    },
+  } as unknown as Docker;
+  const engine = createDockerSandboxEngine({
+    docker,
+    roots: {
+      googleWorkspaceCredentialsRoot: "/google-workspace-credentials",
+      toolsRoot: "/tools",
+      workspaceRoot: "/workspaces",
+    },
+    runtime,
+  });
+  return { container, engine, remove };
+}
+
+describe("Docker sandbox process lifecycle", () => {
+  it("bounds commands by default and reports GNU timeout termination", async () => {
+    const harness = processHarness({ ExitCode: 124, Running: false });
+
+    await expect(harness.engine.runProcess(SANDBOX_SESSION_ID, { command: "sleep infinity" }))
+      .resolves.toMatchObject({
+        exitCode: 124,
+        stderr: expect.stringContaining("AGENT_SANDBOX_RUNNER_PROCESS_TIMED_OUT"),
+      });
+    expect(harness.container.exec).toHaveBeenCalledWith(expect.objectContaining({
+      Cmd: ["timeout", "--signal=TERM", "--kill-after=5s", "120", "bash", "-c", "sleep infinity"],
+    }));
+  });
+
+  it("removes disposable compute when an aborted exec is still running", async () => {
+    const harness = processHarness({ ExitCode: null, Running: true });
+
+    await expect(harness.engine.runProcess(SANDBOX_SESSION_ID, { command: "stuck-command" }))
+      .rejects.toThrowError(/AGENT_SANDBOX_RUNNER_PROCESS_STATE_INVALID/);
+    expect(harness.remove).toHaveBeenCalledWith({ force: true, v: true });
+  });
+});

--- a/services/sandbox-runner/docker-sandbox-process.test.ts
+++ b/services/sandbox-runner/docker-sandbox-process.test.ts
@@ -4,13 +4,15 @@
  * Constructs covered:
  * - Default command timeout and stable timeout diagnostics.
  * - Forced disposable-compute cleanup when Docker exec remains active.
+ * - Multiplexed source closure when either bounded output collector fails.
  */
-import { Readable } from "node:stream";
+import { PassThrough } from "node:stream";
 
 import type Docker from "dockerode";
 import { describe, expect, it, vi } from "vitest";
 
 import { createDockerSandboxEngine } from "./docker-sandbox-engine.js";
+import { SANDBOX_RUNNER_MAX_OUTPUT_BYTES } from "../../agent/lib/sandbox-runner/sandbox-runner-contract.js";
 
 const SANDBOX_SESSION_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 
@@ -23,11 +25,15 @@ const runtime = {
   workspaceVolume: "osinara_workspace-data",
 };
 
-function processHarness(inspection: { ExitCode: number | null; Running: boolean }) {
+function processHarness(
+  inspection: { ExitCode: number | null; Running: boolean },
+  outputBytes = 0,
+) {
   const remove = vi.fn(async () => undefined);
+  const source = new PassThrough();
   const exec = {
     inspect: vi.fn(async () => inspection),
-    start: vi.fn(async () => Readable.from([])),
+    start: vi.fn(async () => source),
   };
   const container = {
     exec: vi.fn(async () => exec),
@@ -38,7 +44,7 @@ function processHarness(inspection: { ExitCode: number | null; Running: boolean 
     getContainer: vi.fn(() => container),
     modem: {
       demuxStream: vi.fn((_stream, stdout, stderr) => {
-        stdout.end();
+        stdout.end(Buffer.alloc(outputBytes));
         stderr.end();
       }),
     },
@@ -52,7 +58,7 @@ function processHarness(inspection: { ExitCode: number | null; Running: boolean 
     },
     runtime,
   });
-  return { container, engine, remove };
+  return { container, engine, remove, source };
 }
 
 describe("Docker sandbox process lifecycle", () => {
@@ -74,6 +80,18 @@ describe("Docker sandbox process lifecycle", () => {
 
     await expect(harness.engine.runProcess(SANDBOX_SESSION_ID, { command: "stuck-command" }))
       .rejects.toThrowError(/AGENT_SANDBOX_RUNNER_PROCESS_STATE_INVALID/);
+    expect(harness.remove).toHaveBeenCalledWith({ force: true, v: true });
+  });
+
+  it("closes the multiplexed exec stream when bounded output collection fails", async () => {
+    const harness = processHarness(
+      { ExitCode: 0, Running: false },
+      SANDBOX_RUNNER_MAX_OUTPUT_BYTES + 1,
+    );
+
+    await expect(harness.engine.runProcess(SANDBOX_SESSION_ID, { command: "noisy-command" }))
+      .rejects.toThrowError(/AGENT_SANDBOX_RUNNER_OUTPUT_TOO_LARGE/);
+    expect(harness.source.destroyed).toBe(true);
     expect(harness.remove).toHaveBeenCalledWith({ force: true, v: true });
   });
 });

--- a/services/sandbox-runner/docker-sandbox-process.test.ts
+++ b/services/sandbox-runner/docker-sandbox-process.test.ts
@@ -28,8 +28,11 @@ const runtime = {
 function processHarness(
   inspection: { ExitCode: number | null; Running: boolean },
   outputBytes = 0,
+  removeError?: Error,
 ) {
-  const remove = vi.fn(async () => undefined);
+  const remove = vi.fn(async () => {
+    if (removeError) throw removeError;
+  });
   const source = new PassThrough();
   const exec = {
     inspect: vi.fn(async () => inspection),
@@ -93,5 +96,28 @@ describe("Docker sandbox process lifecycle", () => {
       .rejects.toThrowError(/AGENT_SANDBOX_RUNNER_OUTPUT_TOO_LARGE/);
     expect(harness.source.destroyed).toBe(true);
     expect(harness.remove).toHaveBeenCalledWith({ force: true, v: true });
+  });
+
+  it("preserves the primary process error when orphan cleanup also fails", async () => {
+    const cleanupError = new Error("Docker remove failed");
+    const harness = processHarness(
+      { ExitCode: 0, Running: false },
+      SANDBOX_RUNNER_MAX_OUTPUT_BYTES + 1,
+      cleanupError,
+    );
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(harness.engine.runProcess(SANDBOX_SESSION_ID, { command: "noisy-command" }))
+      .rejects.toThrowError(/AGENT_SANDBOX_RUNNER_OUTPUT_TOO_LARGE/);
+    expect(log).toHaveBeenCalledWith("Sandbox process cleanup failed after primary error", {
+      cleanupError: expect.objectContaining({
+        cause: cleanupError,
+        message: expect.stringContaining("AGENT_SANDBOX_RUNNER_PROCESS_CLEANUP_FAILED"),
+      }),
+      primaryError: expect.objectContaining({
+        message: expect.stringContaining("AGENT_SANDBOX_RUNNER_OUTPUT_TOO_LARGE"),
+      }),
+    });
+    log.mockRestore();
   });
 });

--- a/services/sandbox-runner/docker-sandbox-process.ts
+++ b/services/sandbox-runner/docker-sandbox-process.ts
@@ -31,6 +31,21 @@ async function removeOrphanedCompute(container: Docker.Container): Promise<void>
   }
 }
 
+async function removeAfterPrimaryFailure(
+  container: Docker.Container,
+  primaryError: unknown,
+): Promise<void> {
+  try {
+    await removeOrphanedCompute(container);
+  } catch (cleanupError) {
+    // Cleanup remains observable without replacing the actionable command or cancellation error.
+    console.error("Sandbox process cleanup failed after primary error", {
+      cleanupError,
+      primaryError,
+    });
+  }
+}
+
 export async function executeSandboxProcess(
   docker: Docker,
   container: Docker.Container,
@@ -64,7 +79,7 @@ export async function executeSandboxProcess(
   try {
     stream = await exec.start({ Tty: false, abortSignal: signal });
   } catch (error) {
-    await removeOrphanedCompute(container);
+    await removeAfterPrimaryFailure(container, error);
     throw error;
   }
 
@@ -97,7 +112,7 @@ export async function executeSandboxProcess(
     stdout.destroy();
     stderr.destroy();
     // Aborted or oversized commands must not keep running detached inside a durable session.
-    await removeOrphanedCompute(container);
+    await removeAfterPrimaryFailure(container, error);
     throw error;
   }
 

--- a/services/sandbox-runner/docker-sandbox-process.ts
+++ b/services/sandbox-runner/docker-sandbox-process.ts
@@ -1,0 +1,120 @@
+/**
+ * Bounded Docker exec implementation for sandbox commands.
+ *
+ * Exports:
+ * - `executeSandboxProcess`: runs one command, collects bounded output, and removes orphaned compute.
+ */
+import { randomUUID } from "node:crypto";
+import { PassThrough } from "node:stream";
+
+import type Docker from "dockerode";
+
+import {
+  SANDBOX_RUNNER_MAX_OUTPUT_BYTES,
+  SANDBOX_RUNNER_PROCESS_DEFAULT_TIMEOUT_MS,
+  type SandboxRunnerProcessRequest,
+  type SandboxRunnerProcessResponse,
+} from "../../agent/lib/sandbox-runner/sandbox-runner-contract.js";
+import { collectLimitedStream } from "./docker-sandbox-files.js";
+
+const PROCESS_KILL_GRACE_SECONDS = 5;
+
+async function removeOrphanedCompute(container: Docker.Container): Promise<void> {
+  // Compute is disposable while named-volume workspaces survive recreation on the next command.
+  try {
+    await container.remove({ force: true, v: true });
+  } catch (error) {
+    throw new Error(
+      "AGENT_SANDBOX_RUNNER_PROCESS_CLEANUP_FAILED: Unterminated process container could not be removed",
+      { cause: error },
+    );
+  }
+}
+
+export async function executeSandboxProcess(
+  docker: Docker,
+  container: Docker.Container,
+  request: SandboxRunnerProcessRequest,
+  signal?: AbortSignal,
+): Promise<SandboxRunnerProcessResponse> {
+  const timeoutMs = request.timeoutMs ?? SANDBOX_RUNNER_PROCESS_DEFAULT_TIMEOUT_MS;
+  const timeoutSeconds = Math.max(1, Math.ceil(timeoutMs / 1_000));
+  const exec = await container.exec({
+    AttachStderr: true,
+    AttachStdout: true,
+    // TERM lets cooperative children clean up; KILL guarantees the process group cannot outlive grace.
+    Cmd: [
+      "timeout",
+      "--signal=TERM",
+      `--kill-after=${PROCESS_KILL_GRACE_SECONDS}s`,
+      String(timeoutSeconds),
+      "bash",
+      "-c",
+      request.command,
+    ],
+    Env: request.environment
+      ? Object.entries(request.environment).map(([name, value]) => `${name}=${value}`)
+      : undefined,
+    Tty: false,
+    WorkingDir: request.workingDirectory ?? "/workspace",
+  });
+  const startedAt = Date.now();
+
+  let stream: NodeJS.ReadWriteStream;
+  try {
+    stream = await exec.start({ Tty: false, abortSignal: signal });
+  } catch (error) {
+    await removeOrphanedCompute(container);
+    throw error;
+  }
+
+  // Docker multiplexes both output streams over one exec connection.
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  docker.modem.demuxStream(stream, stdout, stderr);
+  stream.once("end", () => {
+    stdout.end();
+    stderr.end();
+  });
+  stream.once("error", (error) => {
+    stdout.destroy(error);
+    stderr.destroy(error);
+  });
+
+  let stdoutBytes: Buffer;
+  let stderrBytes: Buffer;
+  try {
+    [stdoutBytes, stderrBytes] = await Promise.all([
+      collectLimitedStream(stdout, SANDBOX_RUNNER_MAX_OUTPUT_BYTES),
+      collectLimitedStream(stderr, SANDBOX_RUNNER_MAX_OUTPUT_BYTES),
+    ]);
+  } catch (error) {
+    // Aborted or oversized commands must not keep running detached inside a durable session.
+    await removeOrphanedCompute(container);
+    throw error;
+  }
+
+  const inspection = await exec.inspect();
+  if (inspection.Running || inspection.ExitCode === null) {
+    await removeOrphanedCompute(container);
+    throw new Error(
+      "AGENT_SANDBOX_RUNNER_PROCESS_STATE_INVALID: Process did not terminate; sandbox compute was removed",
+    );
+  }
+
+  // GNU timeout returns 137 when an uncooperative process reaches the KILL grace boundary.
+  const timedOut = inspection.ExitCode === 124 ||
+    (inspection.ExitCode === 137 && Date.now() - startedAt >= timeoutMs);
+  const stderrText = timedOut
+    ? [
+        stderrBytes.toString("utf8").trimEnd(),
+        `AGENT_SANDBOX_RUNNER_PROCESS_TIMED_OUT: Command exceeded ${timeoutMs} ms`,
+      ].filter(Boolean).join("\n")
+    : stderrBytes.toString("utf8");
+  return {
+    exitCode: inspection.ExitCode,
+    processId: randomUUID(),
+    stderr: stderrText,
+    stdout: stdoutBytes.toString("utf8"),
+  };
+}

--- a/services/sandbox-runner/docker-sandbox-process.ts
+++ b/services/sandbox-runner/docker-sandbox-process.ts
@@ -71,6 +71,9 @@ export async function executeSandboxProcess(
   // Docker multiplexes both output streams over one exec connection.
   const stdout = new PassThrough();
   const stderr = new PassThrough();
+  // Collectors propagate the primary error; these listeners absorb only follow-up demux writes.
+  stdout.on("error", () => undefined);
+  stderr.on("error", () => undefined);
   docker.modem.demuxStream(stream, stdout, stderr);
   stream.once("end", () => {
     stdout.end();
@@ -89,6 +92,10 @@ export async function executeSandboxProcess(
       collectLimitedStream(stderr, SANDBOX_RUNNER_MAX_OUTPUT_BYTES),
     ]);
   } catch (error) {
+    // Close every side before cleanup so neither demux nor the remaining collector can stay active.
+    stream.destroy();
+    stdout.destroy();
+    stderr.destroy();
     // Aborted or oversized commands must not keep running detached inside a durable session.
     await removeOrphanedCompute(container);
     throw error;


### PR DESCRIPTION
## Summary
- bound sandbox commands and return stable timeout diagnostics
- remove disposable compute when Docker exec remains active
- align runner HTTP timeouts and harden agent-browser command usage

## Verification
- npm ci
- npm test (533 passed, 96 skipped locally)
- npm run typecheck
- npm run build
- npm run build:runtime
- docker compose -f compose.test.yaml up --build --abort-on-container-exit --exit-code-from tests (629 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Что изменено

- Добавлено выполнение sandbox-команд через Docker с тайм-аутом, принудительным завершением и диагностикой GNU `timeout`.
- Добавлено удаление disposable-контейнера, если прерванный Docker exec остаётся активным.
- Вынесена логика выполнения процессов в `executeSandboxProcess`.
- Добавлены стандартные тайм-ауты процесса и HTTP-клиента sandbox runner.
- Все HTTP-запросы runner используют общий `undici.Agent` с тайм-аутами заголовков и тела ответа.
- Усилены требования к вызовам `agent-browser`: тайм-аут 45 секунд и принудительное завершение через 5 секунд.
- Обновлена версия пакета до `0.2.30`.
- Добавлены регрессионные тесты жизненного цикла Docker sandbox process.

## Проверка

- Локальные тесты: 533 пройдено, 96 пропущено.
- Docker Compose тесты: 629 пройдено.
- Выполнены установка зависимостей, проверка типов, сборка и runtime-сборка.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->