### PR TITLE
Release v0.2.31

### DIFF
--- a/agent/lib/eve-model-retry-policy-patch.test.ts
+++ b/agent/lib/eve-model-retry-policy-patch.test.ts
@@ -1,10 +1,11 @@
 /**
- * Eve model-call exact-once patch tests.
+ * Eve model-call retry policy patch tests.
  *
  * Constructs covered:
- * - ToolLoopAgent and Eve outer orchestration perform one transport attempt.
+ * - AI SDK performs two bounded transport retries for retryable provider failures.
+ * - Eve outer orchestration never reissues a completed or partially observed model step.
  * - Empty output and unsupported provider tools propagate without a second paid call.
- * - Compaction and auxiliary Eve model surfaces disable AI SDK default retries.
+ * - Compaction and auxiliary Eve model surfaces use the same bounded transport policy.
  */
 import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
@@ -19,12 +20,12 @@ const CODE_MODE_PATH =
   "node_modules/eve/dist/src/compiled/experimental-ai-sdk-code-mode/index.js";
 const execFileAsync = promisify(execFile);
 
-describe("Eve model exact-once patch", () => {
-  it("disables retries and recovery reissues in the root tool loop", async () => {
+describe("Eve model retry policy patch", () => {
+  it("allows transport retries but disables Eve-level reissues in the root tool loop", async () => {
     const runtime = await readFile(TOOL_LOOP_PATH, "utf8");
 
     expect(runtime).toContain(
-      "new ToolLoopAgent({headers:B,instructions:i,maxRetries:0,model:L",
+      "new ToolLoopAgent({headers:B,instructions:i,maxRetries:2,model:L",
     );
     expect(runtime).toContain(
       "async function runModelCallWithRetries(e,t,n){throwIfTurnAborted(n);try{return await e(1)}catch(e){throwIfTurnAborted(n);throw e}}",
@@ -40,19 +41,19 @@ describe("Eve model exact-once patch", () => {
     expect(runtime).not.toContain("disabling unsupported provider tool(s); retrying step once");
   });
 
-  it("disables AI SDK retries on every auxiliary Eve model surface", async () => {
+  it("allows two transport retries on every auxiliary Eve model surface", async () => {
     const [compaction, autoeval, codeMode] = await Promise.all([
       readFile(COMPACTION_PATH, "utf8"),
       readFile(AUTOEVAL_PATH, "utf8"),
       readFile(CODE_MODE_PATH, "utf8"),
     ]);
 
-    expect(compaction).toContain("generateText({abortSignal:c,headers:s,maxRetries:0,model:r");
+    expect(compaction).toContain("generateText({abortSignal:c,headers:s,maxRetries:2,model:r");
     expect(compaction).toContain("EVE_COMPACTION_OUTPUT_TOO_LARGE");
     expect(compaction).not.toContain("return g;--l");
-    expect(autoeval).toContain("generateText({maxRetries:0,model:n.languageModel,messages:");
-    expect(codeMode).toContain("await n({...e,maxRetries:0})");
-    expect(codeMode).toContain("i({...e,maxRetries:0})");
+    expect(autoeval).toContain("generateText({maxRetries:2,model:n.languageModel,messages:");
+    expect(codeMode).toContain("await n({...e,maxRetries:2})");
+    expect(codeMode).toContain("i({...e,maxRetries:2})");
   });
 
   it("keeps every patched model runtime syntactically valid", async () => {

--- a/agent/lib/model-transport-retry.test.ts
+++ b/agent/lib/model-transport-retry.test.ts
@@ -61,7 +61,8 @@ describe("model transport retry policy", () => {
       modelId: "MiniMax-M3",
       transport: {
         authentication: "bearer",
-        baseUrl: "https://api.minimax.io/anthropic/v1",
+        // The mock accepts this deliberately malformed provider URL so the log must redact its query.
+        baseUrl: "https://api.minimax.io/anthropic/v1?api_key=provider-secret",
         protocol: "anthropic-messages",
         thinking: { type: "adaptive" },
       },
@@ -75,7 +76,7 @@ describe("model transport retry policy", () => {
       code: "AGENT_MODEL_TRANSIENT_RESPONSE",
       modelId: "MiniMax-M3",
       statusCode: 529,
-      url: "https://api.minimax.io/anthropic/v1/messages",
+      url: "https://api.minimax.io/anthropic/v1",
     });
     expect(log).toHaveBeenCalledTimes(2);
     expect(log).toHaveBeenNthCalledWith(1, transientLog);

--- a/agent/lib/model-transport-retry.test.ts
+++ b/agent/lib/model-transport-retry.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Model transport retry observability tests.
+ *
+ * Constructs covered:
+ * - AI SDK retries two provider-declared overload responses before succeeding.
+ * - Every failed physical provider attempt emits one structured application log.
+ */
+import { generateText } from "ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createConfiguredLanguageModel } from "./model-transport.js";
+
+function overloadedResponse(): Response {
+  return new Response(JSON.stringify({
+    error: {
+      message: "The server cluster is currently under high load. (2064)",
+      type: "overloaded_error",
+    },
+    type: "error",
+  }), {
+    headers: { "content-type": "application/json" },
+    status: 529,
+  });
+}
+
+function successfulResponse(): Response {
+  return new Response(JSON.stringify({
+    content: [{ text: "Готово", type: "text" }],
+    id: "msg_retry_001",
+    model: "MiniMax-M3",
+    role: "assistant",
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    type: "message",
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }), {
+    headers: { "content-type": "application/json" },
+    status: 200,
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("model transport retry policy", () => {
+  it("retries two overloaded responses and logs every failed physical attempt", async () => {
+    vi.useFakeTimers();
+    const log = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const responses = [overloadedResponse(), overloadedResponse(), successfulResponse()];
+    const fetch = vi.fn(async () => {
+      const response = responses.shift();
+      if (!response) throw new Error("Unexpected model request");
+      return response;
+    });
+    const model = createConfiguredLanguageModel({
+      apiKey: "model-secret",
+      fetch,
+      maxOutputTokens: 128_000,
+      modelId: "MiniMax-M3",
+      transport: {
+        authentication: "bearer",
+        baseUrl: "https://api.minimax.io/anthropic/v1",
+        protocol: "anthropic-messages",
+        thinking: { type: "adaptive" },
+      },
+    });
+
+    const result = generateText({ maxRetries: 2, model, prompt: "Проверка" });
+    await vi.runAllTimersAsync();
+    await expect(result).resolves.toMatchObject({ text: "Готово" });
+    expect(fetch).toHaveBeenCalledTimes(3);
+    const transientLog = JSON.stringify({
+      code: "AGENT_MODEL_TRANSIENT_RESPONSE",
+      modelId: "MiniMax-M3",
+      statusCode: 529,
+      url: "https://api.minimax.io/anthropic/v1/messages",
+    });
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenNthCalledWith(1, transientLog);
+    expect(log).toHaveBeenNthCalledWith(2, transientLog);
+  });
+});

--- a/agent/lib/model-transport.ts
+++ b/agent/lib/model-transport.ts
@@ -8,6 +8,7 @@
  * Key constructs:
  * - Anthropic Messages adaptive thinking is enforced at the transport boundary.
  * - Explicit MiniMax compatibility preserves provider web-search payloads across Anthropic parsing.
+ * - Retryable physical provider responses are logged before AI SDK applies its bounded retry policy.
  * - OpenAI Chat Completions remains a generic provider-independent transport.
  */
 import { createAnthropic } from "@ai-sdk/anthropic";
@@ -31,6 +32,20 @@ export interface ConfiguredLanguageModelOptions {
   readonly transport: AgentModelTransport;
 }
 
+const RETRYABLE_MODEL_HTTP_STATUS_CODES = new Set([408, 409, 429]);
+
+function modelRequestUrl(input: Parameters<FetchFunction>[0]): string {
+  const url = new URL(
+    typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+  );
+  // Query parameters are irrelevant to retry diagnosis and may contain provider credentials.
+  return `${url.origin}${url.pathname}`;
+}
+
+function isRetryableModelResponse(response: Response): boolean {
+  return RETRYABLE_MODEL_HTTP_STATUS_CODES.has(response.status) || response.status >= 500;
+}
+
 function createCredentialGuardedFetch(options: ConfiguredLanguageModelOptions): FetchFunction {
   return async (input, init) => {
     if (!options.apiKey || /\s/u.test(options.apiKey)) {
@@ -39,7 +54,16 @@ function createCredentialGuardedFetch(options: ConfiguredLanguageModelOptions): 
         "Не задан корректный ключ доступа к основной модели",
       );
     }
-    return (options.fetch ?? globalThis.fetch)(input, init);
+    const response = await (options.fetch ?? globalThis.fetch)(input, init);
+    if (isRetryableModelResponse(response)) {
+      console.error(JSON.stringify({
+        code: "AGENT_MODEL_TRANSIENT_RESPONSE",
+        modelId: options.modelId,
+        statusCode: response.status,
+        url: modelRequestUrl(input),
+      }));
+    }
+    return response;
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.30",
+      "version": "0.2.31",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "private": true,
   "type": "module",
   "imports": {

--- a/scripts/apply-eve-patches.ts
+++ b/scripts/apply-eve-patches.ts
@@ -11,7 +11,7 @@
  * - Ignores Telegram's reply-only pseudo thread IDs outside explicit forum topics.
  * - Propagates `input.requested` adapter failures so unbound approvals never park fail-open.
  * - Keeps callback-only channel context from separating an approval from its tool execution.
- * - Makes every Eve-authored model call exact-once with no hidden retry or degraded reissue.
+ * - Allows two AI SDK transport retries while preventing Eve-level or degraded model reissues.
  * - Supports a zero-depth subagent limit so the root agent can disable delegation completely.
  * - Routes local Workflow recovery through Eve's configured queue namespace.
  * - Fails installation when the pinned Eve artifact no longer matches the reviewed source.
@@ -20,6 +20,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
 const EXPECTED_EVE_VERSION = "0.22.5";
+const AI_SDK_TRANSPORT_MAX_RETRIES = 2;
 const telegramRuntimePath = resolve(
   "node_modules/eve/dist/src/public/channels/telegram/telegramChannel.js",
 );
@@ -95,11 +96,18 @@ if (evePackage.version !== EXPECTED_EVE_VERSION) {
   );
 }
 
-// Paid model operations are exact-once: transport failures and malformed output bubble unchanged.
+// AI SDK retries only provider-declared transport failures before returning a model result.
+const toolLoopTransportCall =
+  `y=new ToolLoopAgent({headers:B,instructions:i,maxRetries:${AI_SDK_TRANSPORT_MAX_RETRIES},model:L`;
+await replaceAll(
+  toolLoopRuntimePath,
+  "y=new ToolLoopAgent({headers:B,instructions:i,maxRetries:0,model:L",
+  toolLoopTransportCall,
+);
 await replaceOnce(
   toolLoopRuntimePath,
   "y=new ToolLoopAgent({headers:B,instructions:i,model:L",
-  "y=new ToolLoopAgent({headers:B,instructions:i,maxRetries:0,model:L",
+  toolLoopTransportCall,
 );
 const exactOnceModelCall = "async function runModelCallWithRetries(e,t,n){throwIfTurnAborted(n);try{return await e(1)}catch(e){throwIfTurnAborted(n);throw e}}";
 // Normalize the malformed marker emitted by the first local revision before canonical matching.
@@ -128,26 +136,47 @@ await replaceOnce(
   "if(b=P.session,S.input?.context!==void 0&&(S.input?.inputResponses?.length??0)===0)for(let e of S.input.context)N.push({content:e,role:`user`})",
 );
 
-// Auxiliary Eve surfaces must not reissue compaction, eval, or code-mode model calls either.
+// Auxiliary model surfaces use the same bounded transport policy without semantic reissues.
+const compactionTransportCall =
+  `generateText({abortSignal:c,headers:s,maxRetries:${AI_SDK_TRANSPORT_MAX_RETRIES},model:r`;
+await replaceAll(
+  compactionRuntimePath,
+  "generateText({abortSignal:c,headers:s,maxRetries:0,model:r",
+  compactionTransportCall,
+);
 await replaceOnce(
   compactionRuntimePath,
   "generateText({abortSignal:c,headers:s,model:r",
-  "generateText({abortSignal:c,headers:s,maxRetries:0,model:r",
+  compactionTransportCall,
 );
 await replaceOnce(
   compactionRuntimePath,
   "if(estimateTokens(g)<=i.threshold||l===0)return g;--l",
   "if(estimateTokens(g)<=i.threshold||l===0)return g;throw Error(`EVE_COMPACTION_OUTPUT_TOO_LARGE: Compaction result exceeds the configured threshold`)",
 );
+const autoevalTransportCall =
+  `generateText({maxRetries:${AI_SDK_TRANSPORT_MAX_RETRIES},model:n.languageModel,messages:`;
+await replaceAll(
+  autoevalRuntimePath,
+  "generateText({maxRetries:0,model:n.languageModel,messages:",
+  autoevalTransportCall,
+);
 await replaceOnce(
   autoevalRuntimePath,
   "generateText({model:n.languageModel,messages:",
-  "generateText({maxRetries:0,model:n.languageModel,messages:",
+  autoevalTransportCall,
+);
+const codeModeTransportCalls =
+  `function Jt(e,t={}){return Zt(await n({...e,maxRetries:${AI_SDK_TRANSPORT_MAX_RETRIES}}),t)}function Yt(e,t={}){let n=i({...e,maxRetries:${AI_SDK_TRANSPORT_MAX_RETRIES}});`;
+await replaceAll(
+  codeModeRuntimePath,
+  "function Jt(e,t={}){return Zt(await n({...e,maxRetries:0}),t)}function Yt(e,t={}){let n=i({...e,maxRetries:0});",
+  codeModeTransportCalls,
 );
 await replaceOnce(
   codeModeRuntimePath,
   "function Jt(e,t={}){return Zt(await n(e),t)}function Yt(e,t={}){let n=i(e);",
-  "function Jt(e,t={}){return Zt(await n({...e,maxRetries:0}),t)}function Yt(e,t={}){let n=i({...e,maxRetries:0});",
+  codeModeTransportCalls,
 );
 
 // A failed durable approval binding must fail the turn instead of parking without authorization.


### PR DESCRIPTION
## Summary
- allow two AI SDK transport retries for provider-declared transient model errors
- preserve exact-once model-step recovery after partial streams or tool activity
- log every retryable provider response without query parameters
- add MiniMax 529-to-success integration coverage

## Verification
- npm ci
- npm run typecheck
- npm test (632 passed)
- npm run build
- docker compose -f compose.test.yaml up --build --abort-on-container-exit --exit-code-from tests (632 passed and Eve build succeeded)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Обновлена версия пакета до `0.2.31`.
- Для основных вызовов AI SDK добавлены до двух транспортных повторов при временных ошибках провайдера.
- Повторные операции на уровне Eve остаются отключёнными.
- Добавлено логирование ответов со статусами `408`, `409`, `429` и `5xx`.
- В логах URL очищается от query-параметров.
- Добавлены тесты повторов, логирования и сценария MiniMax `529` → успешный ответ.
- Сохранено exact-once восстановление шага модели после частичного потока или активности инструментов.

## Проверка

- Пройдены type checking, тесты, сборка и Docker Compose tests.
- Все 632 теста прошли.
- Сборка Eve завершилась успешно.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->