### PR TITLE
Fix Telegram HITL draft delivery

### DIFF
--- a/agent/channels/telegram.ts
+++ b/agent/channels/telegram.ts
@@ -138,7 +138,7 @@ export default telegramChannel({
       await telegramHitlApprovalRepository.clearForEveSession(sessionId, ctx.session.id);
       if (!isScheduledSession(ctx)) await rekeyTelegramSession(channel, ctx);
     },
-    async "turn.started"(_data, channel, ctx) {
+    async "turn.started"(data, channel, ctx) {
       const sessionId = applicationSessionId(ctx);
       await sessionRepository.bindEveSession(sessionId, ctx.session.id);
       // A started turn already owns a durable workflow input, so its embedded timeline delta can
@@ -159,7 +159,9 @@ export default telegramChannel({
           proactiveDeliveryCursor,
         );
       }
-      if (!isScheduledSession(ctx)) await startTelegramRichThinkingDraft(channel.telegram);
+      if (!isScheduledSession(ctx)) {
+        await startTelegramRichThinkingDraft(channel.telegram, data.turnId);
+      }
     },
     async "turn.completed"(_data, channel, ctx) {
       const sessionId = applicationSessionId(ctx);

--- a/agent/lib/telegram-channel-draft-policy.test.ts
+++ b/agent/lib/telegram-channel-draft-policy.test.ts
@@ -2,7 +2,7 @@
  * Telegram channel draft-rate regression contract.
  *
  * Constructs covered:
- * - The channel starts one native thinking draft at the turn boundary.
+ * - The channel starts one turn-scoped native thinking draft at the turn boundary.
  * - Token deltas and tool-loop events never trigger additional draft API calls.
  * - Scheduled Telegram delivery is durably confirmed before secondary group timeline persistence.
  */
@@ -17,6 +17,7 @@ describe("Telegram channel draft policy", () => {
     const source = await readFile(TELEGRAM_CHANNEL_PATH, "utf8");
 
     expect(source).toContain('async "turn.started"');
+    expect(source).toContain("startTelegramRichThinkingDraft(channel.telegram, data.turnId)");
     expect(source).not.toContain('"message.appended"');
     expect(source).not.toContain('"action.result"');
     expect(source).not.toContain('"actions.requested"');

--- a/agent/lib/telegram-rich-messages.test.ts
+++ b/agent/lib/telegram-rich-messages.test.ts
@@ -3,6 +3,7 @@
  *
  * Constructs covered:
  * - RichBlockThinking uses one stable draft per private chat/topic and Eve turn.
+ * - Private drafts reject a missing Eve turn identity before Telegram delivery.
  * - Completed output is persisted with sendRichMessage and anchors group conversations.
  * - The first chunk of a group response replies to the verified triggering message.
  * - Telegram rejection and ambiguous transport failures remain fail-fast without retries.
@@ -123,6 +124,18 @@ describe("Telegram rich drafts", () => {
       telegramTarget({ chatId: "-100123", chatType: "supergroup" }),
       "turn_1",
     );
+
+    expect(telegramFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a private draft without an Eve turn identity before delivery", async () => {
+    const telegramFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(telegramResponse(true));
+
+    await expect(
+      startTelegramRichThinkingDraft(telegramTarget(), ""),
+    ).rejects.toMatchObject({ code: "AGENT_TELEGRAM_RICH_TURN_ID_INVALID" });
 
     expect(telegramFetch).not.toHaveBeenCalled();
   });

--- a/agent/lib/telegram-rich-messages.test.ts
+++ b/agent/lib/telegram-rich-messages.test.ts
@@ -2,7 +2,7 @@
  * Native Telegram Rich Message delivery tests.
  *
  * Constructs covered:
- * - RichBlockThinking uses one stable draft per private chat/topic.
+ * - RichBlockThinking uses one stable draft per private chat/topic and Eve turn.
  * - Completed output is persisted with sendRichMessage and anchors group conversations.
  * - The first chunk of a group response replies to the verified triggering message.
  * - Telegram rejection and ambiguous transport failures remain fail-fast without retries.
@@ -56,6 +56,7 @@ describe("Telegram rich drafts", () => {
 
     await startTelegramRichThinkingDraft(
       telegramTarget({ messageThreadId: 42 }),
+      "turn_1",
     );
 
     expect(String(telegramFetch.mock.calls[0]![0])).toBe(
@@ -75,10 +76,38 @@ describe("Telegram rich drafts", () => {
 
     await startTelegramRichThinkingDraft(
       telegramTarget({ messageThreadId: 41 }),
+      "turn_1",
     );
     await startTelegramRichThinkingDraft(
       telegramTarget({ messageThreadId: 42 }),
+      "turn_1",
     );
+
+    expect(requestBody(telegramFetch, 0).draft_id).not.toBe(
+      requestBody(telegramFetch, 1).draft_id,
+    );
+  });
+
+  it("keeps repeated updates stable within the same Eve turn", async () => {
+    const telegramFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => telegramResponse(true));
+
+    await startTelegramRichThinkingDraft(telegramTarget(), "turn_24");
+    await startTelegramRichThinkingDraft(telegramTarget(), "turn_24");
+
+    expect(requestBody(telegramFetch, 0).draft_id).toBe(
+      requestBody(telegramFetch, 1).draft_id,
+    );
+  });
+
+  it("does not resume a pre-approval draft after HITL starts the next Eve turn", async () => {
+    const telegramFetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => telegramResponse(true));
+
+    await startTelegramRichThinkingDraft(telegramTarget(), "turn_24");
+    await startTelegramRichThinkingDraft(telegramTarget(), "turn_25");
 
     expect(requestBody(telegramFetch, 0).draft_id).not.toBe(
       requestBody(telegramFetch, 1).draft_id,
@@ -92,6 +121,7 @@ describe("Telegram rich drafts", () => {
 
     await startTelegramRichThinkingDraft(
       telegramTarget({ chatId: "-100123", chatType: "supergroup" }),
+      "turn_1",
     );
 
     expect(telegramFetch).not.toHaveBeenCalled();
@@ -111,7 +141,7 @@ describe("Telegram rich drafts", () => {
       );
 
     await expect(
-      startTelegramRichThinkingDraft(telegramTarget()),
+      startTelegramRichThinkingDraft(telegramTarget(), "turn_1"),
     ).rejects.toThrow("AGENT_TELEGRAM_RICH_DRAFT_DELIVERY_FAILED");
 
     expect(telegramFetch).toHaveBeenCalledTimes(1);

--- a/agent/lib/telegram-rich-messages.ts
+++ b/agent/lib/telegram-rich-messages.ts
@@ -7,7 +7,7 @@
  * - `SentTelegramMessage`: confirmed Telegram identity for each delivered rich chunk.
  *
  * Key constructs:
- * - One stable non-zero draft ID per private chat/topic across turns and model steps.
+ * - One stable non-zero draft ID per private chat/topic and Eve turn.
  * - Telegram Bot API 10.1 `sendRichMessageDraft` and `sendRichMessage` validation.
  * - Final-delivery ambiguity diagnostics without automatic retries.
  * - First-chunk group replies anchored to a verified inbound message.
@@ -55,13 +55,15 @@ export interface SentTelegramMessage {
   readonly messageId: string;
 }
 
-function draftId(target: TelegramRichTarget): number {
+function draftId(target: TelegramRichTarget, turnId: string): number {
   const thread =
     target.messageThreadId === undefined ? "" : String(target.messageThreadId);
   const digest = createHash("sha256")
     .update(target.chatId)
     .update(":")
     .update(thread)
+    .update(":")
+    .update(turnId)
     .digest();
   return (digest.readUInt32BE(0) % TELEGRAM_DRAFT_ID_MODULUS) + 1;
 }
@@ -246,11 +248,18 @@ function richBody(
 
 export async function startTelegramRichThinkingDraft(
   target: TelegramRichTarget,
+  turnId: string,
 ): Promise<void> {
   if (target.chatType !== "private") return;
+  if (!turnId) {
+    throw new AppError(
+      "AGENT_TELEGRAM_RICH_TURN_ID_INVALID",
+      "Не удалось связать потоковый ответ с текущим запросом",
+    );
+  }
   const response = await requestTelegramRichApi("sendRichMessageDraft", {
     ...richBody(target, { html: TELEGRAM_THINKING_HTML }, true),
-    draft_id: draftId(target),
+    draft_id: draftId(target, turnId),
   });
   requireDraftSuccess(response);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.2.32",
+      "version": "0.2.33",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- scope Telegram rich thinking drafts to one Eve turn
- prevent HITL resume turns from reusing the pre-approval draft identity
- add regression coverage and release v0.2.33 metadata

## Verification
- npm run typecheck
- npm test (638 tests)
- clean npm ci
- npm run build
- docker compose -f compose.test.yaml up --build --abort-on-container-exit --exit-code-from tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Изменения

- Ограничена область действия Telegram rich thinking draft одним ходом Eve.
- `turn.started` передаёт `data.turnId` при создании draft.
- HITL resume turns не используют идентификатор draft до подтверждения.
- `startTelegramRichThinkingDraft` требует непустой `turnId`.
- При пустом `turnId` функция возвращает `AGENT_TELEGRAM_RICH_TURN_ID_INVALID` и не вызывает `fetch`.
- Обновлены тесты для смены ходов, приватных топиков, групповых чатов и ошибок Telegram.
- Версия пакета обновлена до `0.2.33`.

## Проверка

- Typecheck.
- 638 тестов.
- Чистая установка зависимостей.
- Сборка.
- Тесты Docker Compose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->