### PR TITLE
Release v0.5.1 startup health fix

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -282,6 +282,7 @@ jobs:
           if [[ "$RESUME_DRAFT" == "false" ]]; then
             gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --draft --target "$GITHUB_SHA" \
               --title "Osinara ${TAG}" \
+              --generate-notes \
               --notes "Immutable production images for commit ${GITHUB_SHA}."
           fi
           gh release upload "$TAG" --repo "$GITHUB_REPOSITORY" --clobber \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,8 +114,10 @@ Eve discovery воспримет такой файл как production tool ил
 
 ## Локальный патч Eve
 
-Eve `0.22.5` не предоставляет seam для durable Telegram ingress и не допускает zero-depth delegation limit.
-`scripts/apply-eve-patches.ts` добавляет verified-update/drain hooks, возврат Session и `maxSubagentDepth: 0`.
+Eve `0.22.5` не предоставляет seam для durable Telegram ingress, не допускает zero-depth delegation limit
+и ограничивает ожидание первого production startup 60 секундами.
+`scripts/apply-eve-patches.ts` добавляет verified-update/drain hooks, возврат Session,
+`maxSubagentDepth: 0` и пятиминутное ограниченное ожидание health при холодном старте.
 Патч применяется автоматически через `postinstall` после каждого `npm ci`.
 Он идемпотентен, проверяет точную версию и ожидаемые artifacts; несовпадение должно останавливать сборку.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,10 @@ Eve discovery воспримет такой файл как production tool ил
 
 ## Локальный патч Eve
 
-Eve `0.22.5` не предоставляет seam для durable Telegram ingress и не допускает zero-depth delegation limit.
-`scripts/apply-eve-patches.ts` добавляет verified-update/drain hooks, возврат Session и `maxSubagentDepth: 0`.
+Eve `0.22.5` не предоставляет seam для durable Telegram ingress, не допускает zero-depth delegation limit
+и ограничивает ожидание первого production startup 60 секундами.
+`scripts/apply-eve-patches.ts` добавляет verified-update/drain hooks, возврат Session,
+`maxSubagentDepth: 0` и пятиминутное ограниченное ожидание health при холодном старте.
 Патч применяется автоматически через `postinstall` после каждого `npm ci`.
 Он идемпотентен, проверяет точную версию и ожидаемые artifacts; несовпадение должно останавливать сборку.
 

--- a/agent/lib/eve-production-start-patch.test.ts
+++ b/agent/lib/eve-production-start-patch.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Eve production startup patch contract tests.
+ *
+ * Constructs covered:
+ * - Patched Eve health timeout: permits bounded first-start sandbox initialization.
+ * - Patch source: pins the reviewed timeout and exact Eve runtime artifact.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const PATCHED_HEALTH_TIMEOUT_MARKER = "const HEALTH_TIMEOUT_MS=3e5";
+
+describe("Eve production startup patch", () => {
+  it("allows five minutes for the built server to become healthy", async () => {
+    const [patchSource, runtime] = await Promise.all([
+      readFile("scripts/apply-eve-patches.ts", "utf8"),
+      readFile(
+        "node_modules/eve/dist/src/internal/nitro/host/start-production-server.js",
+        "utf8",
+      ),
+    ]);
+
+    expect(patchSource).toContain("const EVE_PRODUCTION_START_HEALTH_TIMEOUT_MS = 300_000;");
+    expect(runtime).toContain(PATCHED_HEALTH_TIMEOUT_MARKER);
+    expect(runtime).not.toContain("const HEALTH_TIMEOUT_MS=6e4");
+  });
+});

--- a/agent/lib/eve-production-start-patch.test.ts
+++ b/agent/lib/eve-production-start-patch.test.ts
@@ -13,14 +13,17 @@ const PATCHED_HEALTH_TIMEOUT_MARKER = "const HEALTH_TIMEOUT_MS=3e5";
 
 describe("Eve production startup patch", () => {
   it("allows five minutes for the built server to become healthy", async () => {
-    const [patchSource, runtime] = await Promise.all([
+    const [evePackageSource, patchSource, runtime] = await Promise.all([
+      readFile("node_modules/eve/package.json", "utf8"),
       readFile("scripts/apply-eve-patches.ts", "utf8"),
       readFile(
         "node_modules/eve/dist/src/internal/nitro/host/start-production-server.js",
         "utf8",
       ),
     ]);
+    const evePackage = JSON.parse(evePackageSource) as { version?: string };
 
+    expect(evePackage.version).toBe("0.22.5");
     expect(patchSource).toContain("const EVE_PRODUCTION_START_HEALTH_TIMEOUT_MS = 300_000;");
     expect(runtime).toContain(PATCHED_HEALTH_TIMEOUT_MARKER);
     expect(runtime).not.toContain("const HEALTH_TIMEOUT_MS=6e4");

--- a/compose.production.yaml
+++ b/compose.production.yaml
@@ -109,7 +109,7 @@ services:
       test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000/eve/v1/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
       interval: 5s
       timeout: 3s
-      retries: 60
+      retries: 72
     networks:
       - app-network
       - sandbox-control

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "imports": {

--- a/production-release-contract.test.ts
+++ b/production-release-contract.test.ts
@@ -228,6 +228,7 @@ describe("release workflow contract", () => {
     expect(workflow).toContain("compose.production.yaml");
     expect(workflow).toContain("gh release create");
     expect(workflow).toContain("--draft");
+    expect(workflow).toContain("--generate-notes");
     expect(workflow).toContain('--target "$GITHUB_SHA"');
     expect(workflow).toContain("gh release upload");
     expect(workflow).toContain("--clobber");

--- a/production-release-contract.test.ts
+++ b/production-release-contract.test.ts
@@ -229,7 +229,7 @@ describe("release workflow contract", () => {
     expect(workflow).toContain("compose.production.yaml");
     expect(workflow).toContain("gh release create");
     expect(workflow).toContain("--draft");
-    expect(workflow).toContain("--generate-notes");
+    expect(workflow).toMatch(/gh release create "\$TAG"[\s\S]*?--generate-notes/);
     expect(workflow).toContain('--target "$GITHUB_SHA"');
     expect(workflow).toContain("gh release upload");
     expect(workflow).toContain("--clobber");

--- a/production-release-contract.test.ts
+++ b/production-release-contract.test.ts
@@ -120,6 +120,7 @@ describe("production container contract", () => {
     expect(migrate).toContain("restart: \"no\"");
     expect(migrate).toContain(".runtime/scripts/migrate.js");
     expect(agent).toContain("healthcheck:");
+    expect(agent).toContain("retries: 72");
     expect(edge).toContain("healthcheck:");
     expect(edge).toContain('"127.0.0.1:8082:80"');
 

--- a/scripts/apply-eve-patches.ts
+++ b/scripts/apply-eve-patches.ts
@@ -14,6 +14,7 @@
  * - Allows two AI SDK transport retries while preventing Eve-level or degraded model reissues.
  * - Supports a zero-depth subagent limit so the root agent can disable delegation completely.
  * - Routes local Workflow recovery through Eve's configured queue namespace.
+ * - Extends the bounded production startup health wait for first-run sandbox preparation.
  * - Fails installation when the pinned Eve artifact no longer matches the reviewed source.
  */
 import { readFile, writeFile } from "node:fs/promises";
@@ -21,6 +22,7 @@ import { resolve } from "node:path";
 
 const EXPECTED_EVE_VERSION = "0.22.5";
 const AI_SDK_TRANSPORT_MAX_RETRIES = 2;
+const EVE_PRODUCTION_START_HEALTH_TIMEOUT_MS = 300_000;
 const telegramRuntimePath = resolve(
   "node_modules/eve/dist/src/public/channels/telegram/telegramChannel.js",
 );
@@ -63,6 +65,9 @@ const autoevalRuntimePath = resolve(
 const codeModeRuntimePath = resolve(
   "node_modules/eve/dist/src/compiled/experimental-ai-sdk-code-mode/index.js",
 );
+const startProductionServerRuntimePath = resolve(
+  "node_modules/eve/dist/src/internal/nitro/host/start-production-server.js",
+);
 
 async function replaceOnce(
   path: string,
@@ -95,6 +100,14 @@ if (evePackage.version !== EXPECTED_EVE_VERSION) {
     `AGENT_EVE_PATCH_VERSION_UNSUPPORTED: Ожидалась Eve ${EXPECTED_EVE_VERSION}, установлена ${String(evePackage.version)}`,
   );
 }
+
+// A cold production start may need to prepare the sandbox template and recover durable runs.
+// Keep the wait bounded while allowing the same process to reach its health endpoint.
+await replaceOnce(
+  startProductionServerRuntimePath,
+  "const HEALTH_TIMEOUT_MS=6e4",
+  `const HEALTH_TIMEOUT_MS=${EVE_PRODUCTION_START_HEALTH_TIMEOUT_MS.toExponential().replace("+", "")}`,
+);
 
 // AI SDK retries only provider-declared transport failures before returning a model result.
 const toolLoopTransportCall =


### PR DESCRIPTION
## Что изменено
- увеличено ограниченное ожидание health в Eve production startup с 60 секунд до 5 минут
- добавлен regression-тест точного локального патча Eve 0.22.5
- версия повышена до 0.5.1
- release workflow теперь добавляет автоматически сгенерированный changelog

## Причина
Первый запуск v0.5.0 подготавливал sandbox и восстанавливал 116 durable runs дольше 60 секунд. Agent стал healthy после повторного запуска, но deployment уже был terminally marked ambiguous.

## Проверка
- Docker Compose test suite: 162/162 файлов, 850/850 тестов
- TypeScript typecheck
- Eve build
- clean npm ci/postinstall внутри Docker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Увеличен таймаут ожидания production health endpoint Eve с 60 секунд до 300 секунд.
- Добавлена проверка версии Eve и точной замены таймаута в `scripts/apply-eve-patches.ts`.
- Добавлен регрессионный тест для production-патча Eve 0.22.5.
- Версия пакета обновлена до `0.5.1`.
- Release workflow настроен на автоматическую генерацию release notes.
- Добавлена проверка генерации release notes в контрактный тест workflow.

## Проверка

- Docker Compose: 162/162 файлов и 850/850 тестов.
- TypeScript typecheck пройден.
- Сборка Eve пройдена.
- Чистая установка Docker через `npm ci` и `postinstall` пройдена.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->