### PR TITLE
Release v0.7.1 group tool contract fix

### DIFF
--- a/agent/lib/register-telegram-group-tool.test.ts
+++ b/agent/lib/register-telegram-group-tool.test.ts
@@ -75,6 +75,24 @@ describe("manage_telegram_group.register", () => {
     });
   });
 
+  it("ignores known top-level fields materialized beside registration", async () => {
+    await expect(manageTelegramGroup.execute({
+      action: "register",
+      messageMode: "owner_only",
+      registration: input,
+      skillAllowlist: ["pohuy"],
+      telegramChatId: "-1009999999999",
+      toolAllowlist: ["remember"],
+    }, context("private"))).resolves.toMatchObject({
+      telegramChatId: "-1003567628736",
+      type: "family_private",
+    });
+    expect(registerGroup).toHaveBeenCalledWith(expect.objectContaining({
+      telegramChatId: "-1003567628736",
+      type: "family_private",
+    }));
+  });
+
   it("rejects registration approval from a group chat", async () => {
     await expect(manageTelegramGroup.execute(
       { action: "register", registration: input },

--- a/agent/lib/remove-telegram-group-tool.test.ts
+++ b/agent/lib/remove-telegram-group-tool.test.ts
@@ -65,6 +65,20 @@ describe("manage_telegram_group.remove", () => {
     });
   });
 
+  it("ignores known sibling fields materialized beside the removal target", async () => {
+    await expect(manageTelegramGroup.execute({
+      action: "remove",
+      messageMode: "all",
+      registration: {},
+      skillAllowlist: ["pohuy"],
+      telegramChatId: "-1003567628736",
+      toolAllowlist: ["remember"],
+    }, context("private"))).resolves.toMatchObject({ registrationRemoved: true });
+    expect(removeRegistration).toHaveBeenCalledWith(expect.objectContaining({
+      telegramChatId: "-1003567628736",
+    }));
+  });
+
   it("rejects removal from a group chat", async () => {
     await expect(
       manageTelegramGroup.execute(

--- a/agent/lib/telegram-group-skills-tool.test.ts
+++ b/agent/lib/telegram-group-skills-tool.test.ts
@@ -71,6 +71,30 @@ describe("manage_telegram_group.update_skills", () => {
     });
   });
 
+  it("ignores known sibling fields materialized by the model transport", async () => {
+    await expect(manageTelegramGroup.execute({
+      action: "update_skills",
+      messageMode: "all",
+      registration: {
+        messageMode: "all",
+        telegramChatId: "-1009999999999",
+        title: "Не используется",
+        toolAllowlist: [],
+        type: "external",
+      },
+      skillAllowlist: ["pohuy"],
+      telegramChatId: "-1001234567890",
+      toolAllowlist: ["remember"],
+    }, context())).resolves.toMatchObject({
+      skillAllowlist: ["pohuy"],
+      skillsUpdated: true,
+    });
+    expect(updateSkills).toHaveBeenCalledWith(expect.objectContaining({
+      skillAllowlist: ["pohuy"],
+      telegramChatId: "-1001234567890",
+    }));
+  });
+
   it("rejects unreviewed and duplicate skills before persistence", async () => {
     await expect(manageTelegramGroup.execute({
       action: "update_skills",

--- a/agent/lib/tools/manage_telegram_group.ts
+++ b/agent/lib/tools/manage_telegram_group.ts
@@ -208,7 +208,7 @@ function requireRegistration(input: Record<string, unknown>) {
 const TOOL_DESCRIPTION = [
   "Показать статус Telegram-групп семьи, запросить новый контекст всех тем выбранной группы, зарегистрировать trust zone, заменить tool/skill policy или удалить регистрацию и связанные данные.",
   "Сначала выбери один action и используй только его payload. При команде /status или просьбе показать настройки групп вызови ровно {\"action\":\"status\"}: status не требует подтверждения и возвращает type, messageMode, полные toolAllowlist и skillAllowlist, базовые workspace tools и готовый startNewContextInput для каждой группы.",
-  "Некоторые model transports материализуют остальные известные optional-поля общей schema. Для read-only status и недеструктивного start_new_context tool безопасно игнорирует такие поля; всё равно не заполняй их и никогда не угадывай telegramChatId.",
+  "Некоторые model transports материализуют остальные известные optional-поля общей schema. Tool безопасно игнорирует поля других actions и читает только payload выбранного action; всё равно не заполняй лишние поля и никогда не угадывай telegramChatId.",
   "Повторный register с другим type пересоздаёт trust zone и безвозвратно удаляет её историю, workspace, память и сессии; для обычной смены прав всегда используй update_policy.",
   "Remove не вызывает Telegram leaveChat: бот остаётся участником чата. Самостоятельный выход бота из группы не поддерживается.",
   "Update_policy не отключает группу и сохраняет её ID, название, тип, историю, workspace, память и сессии.",
@@ -235,6 +235,9 @@ export default defineTool({
     requireOnlyFields(payload, TOP_LEVEL_FIELDS, "manage_telegram_group", INPUT_ERROR_CODE);
     const action = requireAction(payload, "manage_telegram_group", TOOL_ACTIONS, INPUT_ERROR_CODE);
     const owner = requirePrivateTelegramOwner(ctx);
+
+    // Shared-schema transports may materialize sibling optional fields. The global guard above
+    // still rejects unpublished fields; each action below validates and consumes only its contract.
     if (action === "status") {
       const groups = await telegramGroupAdministrationRepository.listStatuses({
         familyId: owner.familyId,
@@ -291,13 +294,7 @@ export default defineTool({
       };
     }
     if (action === "update_policy") {
-      // Policy updates are complete replacements; omitted or extra registration fields are rejected.
-      requireOnlyFields(
-        payload,
-        ["action", "telegramChatId", "messageMode", "toolAllowlist"],
-        "action=update_policy",
-        INPUT_ERROR_CODE,
-      );
+      // Policy updates are complete replacements; every required policy value remains mandatory.
       const telegramChatId = requireTelegramGroupId(payload.telegramChatId, "telegramChatId");
       const messageMode = requiredEnum(payload, "messageMode", EXTERNAL_MESSAGE_MODES, INPUT_ERROR_CODE);
       const toolAllowlist = requireExternalToolAllowlist(payload.toolAllowlist, "action=update_policy");
@@ -318,12 +315,6 @@ export default defineTool({
       };
     }
     if (action === "update_skills") {
-      requireOnlyFields(
-        payload,
-        ["action", "telegramChatId", "skillAllowlist"],
-        "action=update_skills",
-        INPUT_ERROR_CODE,
-      );
       const telegramChatId = requireTelegramGroupId(payload.telegramChatId, "telegramChatId");
       const skillAllowlist = requireSkillAllowlist(payload.skillAllowlist);
       const result = await telegramGroupAdministrationRepository.updateSkills({
@@ -341,7 +332,6 @@ export default defineTool({
       };
     }
     if (action === "remove") {
-      requireOnlyFields(payload, ["action", "telegramChatId"], "action=remove", INPUT_ERROR_CODE);
       const telegramChatId = requireTelegramGroupId(payload.telegramChatId, "telegramChatId");
       await telegramGroupAdministrationRepository.removeRegistration({
         familyId: owner.familyId,
@@ -355,7 +345,6 @@ export default defineTool({
       };
     }
 
-    requireOnlyFields(payload, ["action", "registration"], "action=register", INPUT_ERROR_CODE);
     const registration = requireRegistration(payload);
     const result = await telegramGroupAdministrationRepository.registerGroup({
       ...registration,

--- a/agent/lib/update-telegram-group-policy-tool.test.ts
+++ b/agent/lib/update-telegram-group-policy-tool.test.ts
@@ -81,13 +81,24 @@ describe("manage_telegram_group.update_policy", () => {
     expect(manageTelegramGroup.description).toContain("сохраняет её ID, название, тип, историю, workspace, память и сессии");
   });
 
+  it("ignores known sibling fields materialized beside the complete policy", async () => {
+    await expect(manageTelegramGroup.execute({
+      ...input,
+      registration: {},
+      skillAllowlist: ["pohuy"],
+    }, context("private"))).resolves.toMatchObject({ policyUpdated: true });
+    expect(updatePolicy).toHaveBeenCalledWith(expect.objectContaining({
+      messageMode: "owner_only",
+      toolAllowlist: ["remember", "list_group_history"],
+    }));
+  });
+
   it.each([
     { action: "update_policy", messageMode: "all", telegramChatId: "-1003567628736" },
     { action: "update_policy", telegramChatId: "-1003567628736", toolAllowlist: [] },
     { action: "update_policy", messageMode: "all", toolAllowlist: [] },
     { ...input, title: "Новое название" },
     { ...input, type: "external" },
-    { ...input, registration: {} },
     { ...input, telegramChatId: -1003567628736 },
   ])("rejects an incomplete or extended policy payload", async (invalidInput) => {
     await expect(manageTelegramGroup.execute(invalidInput as never, context("private"))).rejects.toThrowError(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary

- fix `manage_telegram_group.update_skills` rejecting MiniMax-materialized sibling fields after owner approval
- apply the same shared-schema contract to `update_policy`, `register`, and `remove` before they fail in production
- preserve fail-closed rejection for every unpublished field and all required action-specific values
- bump the immutable hotfix release to `0.7.1`

## Production evidence

The failed `v0.7.0` call contained valid `action`, `telegramChatId`, and `skillAllowlist`, plus transport-materialized `messageMode`, `registration`, and `toolAllowlist`. The repository was never called and the target group retained an empty `skill_allowlist`.

## Verification

- production-equivalent Docker Compose gate passed
- 169/169 test files passed
- 902/902 tests passed
- typecheck and Eve production build passed
- regression coverage added for all mutating group actions
- `git diff --check` passed