### PR TITLE
Release v0.7.2 dynamic skill sandbox fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ Owner-only операции разрешены только в личном Tele
 Нативные `glob`, `grep`, `read_file` и `write_file` остаются доступны и замкнуты внутри отдельного group workspace.
 Eve `0.22.5` не умеет скрывать собственные built-ins, поэтому `bash`, `todo`, `ask_question` и невыданные `web_fetch`/`web_search` во внешней группе перекрываются явным отказом. `load_skill` обёрнут отдельной live-проверкой: он загружает только code-reviewed skill из актуального per-group allowlist.
 Eve `0.22.5` всегда перечисляет статические authored skills в system prompt и не позволяет фильтровать их по сессии. Grantable `pohuy` поэтому вынесен из static discovery и выдаётся turn-scoped dynamic resolver только разрешённым группам; при обновлении Eve проверить, появился ли нативный механизм фильтрации.
+Restricted group sandbox держит `$HOME` на Docker tmpfs. Docker `putArchive` не пишет надёжно прямо в mount target, поэтому runner file I/O загружает bytes во временный rootfs path и переносит их внутрь контейнера; не возвращать прямой archive write без реального tmpfs smoke.
 
 ## Структура проекта
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ Owner-only операции разрешены только в личном Tele
 Нативные `glob`, `grep`, `read_file` и `write_file` остаются доступны и замкнуты внутри отдельного group workspace.
 Eve `0.22.5` не умеет скрывать собственные built-ins, поэтому `bash`, `todo`, `ask_question` и невыданные `web_fetch`/`web_search` во внешней группе перекрываются явным отказом. `load_skill` обёрнут отдельной live-проверкой: он загружает только code-reviewed skill из актуального per-group allowlist.
 Eve `0.22.5` всегда перечисляет статические authored skills в system prompt и не позволяет фильтровать их по сессии. Grantable `pohuy` поэтому вынесен из static discovery и выдаётся turn-scoped dynamic resolver только разрешённым группам; при обновлении Eve проверить, появился ли нативный механизм фильтрации.
+Restricted group sandbox держит `$HOME` на Docker tmpfs. Docker `putArchive` не пишет надёжно прямо в mount target, поэтому runner file I/O загружает bytes во временный rootfs path и переносит их внутрь контейнера; не возвращать прямой archive write без реального tmpfs smoke.
 
 ## Структура проекта
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "imports": {

--- a/services/sandbox-runner/docker-sandbox-engine.test.ts
+++ b/services/sandbox-runner/docker-sandbox-engine.test.ts
@@ -8,11 +8,12 @@
  * - Resource, capability, and privilege restrictions.
  * - Stale policy replacement and bounded warm-cache reconciliation at the Docker boundary.
  * - Explicit session and runner shutdown remove compute instead of retaining exited containers.
+ * - File writes stage outside tmpfs before an in-container move to the requested path.
  */
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { Readable } from "node:stream";
+import { PassThrough, Readable } from "node:stream";
 
 import type Docker from "dockerode";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -166,6 +167,53 @@ describe("buildSandboxContainerOptions", () => {
       expect.stringContaining("PROXY="),
       expect.stringContaining("/tools/"),
     ]));
+  });
+
+  it("stages a hidden-home write outside tmpfs before moving it in-container", async () => {
+    const source = new PassThrough();
+    const exec = {
+      inspect: vi.fn(async () => ({ ExitCode: 0, Running: false })),
+      start: vi.fn(async () => source),
+    };
+    const container = {
+      exec: vi.fn(async () => exec),
+      inspect: vi.fn(async () => ({ Config: { Labels: {} }, State: { Running: true } })),
+      putArchive: vi.fn(async () => undefined),
+    };
+    const docker = {
+      getContainer: vi.fn(() => container),
+      modem: {
+        demuxStream: vi.fn((_stream, stdout, stderr) => {
+          stdout.end();
+          stderr.end();
+        }),
+      },
+    } as unknown as Docker;
+    const engine = createDockerSandboxEngine({
+      docker,
+      roots: {
+        googleWorkspaceCredentialsRoot: "/google-workspace-credentials",
+        toolsRoot: "/tools",
+        workspaceRoot: "/workspaces",
+      },
+      runtime,
+    });
+
+    await engine.writeFile(
+      SANDBOX_SESSION_ID,
+      "/tmp/home/.agents/skills/pohuy/LICENSE.txt",
+      new TextEncoder().encode("MIT"),
+    );
+
+    expect(container.putArchive).toHaveBeenCalledWith(
+      expect.anything(),
+      { path: "/.osinara-sandbox-uploads" },
+    );
+    const commands = container.exec.mock.calls.map(([options]) => options.Cmd.at(-1));
+    expect(commands).toEqual([
+      expect.stringMatching(/^mkdir -p -- .*\.osinara-sandbox-uploads/u),
+      expect.stringMatching(/^mv -- .* ".*\/tmp\/home\/\.agents\/skills\/pohuy\/LICENSE\.txt"$/u),
+    ]);
   });
 
   it("replaces stale policy compute while preserving named-volume data", async () => {

--- a/services/sandbox-runner/docker-sandbox-engine.test.ts
+++ b/services/sandbox-runner/docker-sandbox-engine.test.ts
@@ -212,8 +212,59 @@ describe("buildSandboxContainerOptions", () => {
     const commands = container.exec.mock.calls.map(([options]) => options.Cmd.at(-1));
     expect(commands).toEqual([
       expect.stringMatching(/^mkdir -p -- .*\.osinara-sandbox-uploads/u),
-      expect.stringMatching(/^mv -- .* ".*\/tmp\/home\/\.agents\/skills\/pohuy\/LICENSE\.txt"$/u),
+      expect.stringMatching(/^mv -T -- .* ".*\/tmp\/home\/\.agents\/skills\/pohuy\/LICENSE\.txt"$/u),
     ]);
+  });
+
+  it("rejects a directory destination and observes failed staging cleanup", async () => {
+    const exitCodes = [0, 1, 1];
+    const container = {
+      exec: vi.fn(async () => {
+        const source = new PassThrough();
+        const exitCode = exitCodes.shift();
+        return {
+          inspect: vi.fn(async () => ({ ExitCode: exitCode, Running: false })),
+          start: vi.fn(async () => source),
+        };
+      }),
+      inspect: vi.fn(async () => ({ Config: { Labels: {} }, State: { Running: true } })),
+      putArchive: vi.fn(async () => undefined),
+    };
+    const docker = {
+      getContainer: vi.fn(() => container),
+      modem: {
+        demuxStream: vi.fn((_stream, stdout, stderr) => {
+          stdout.end();
+          stderr.end();
+        }),
+      },
+    } as unknown as Docker;
+    const engine = createDockerSandboxEngine({
+      docker,
+      roots: {
+        googleWorkspaceCredentialsRoot: "/google-workspace-credentials",
+        toolsRoot: "/tools",
+        workspaceRoot: "/workspaces",
+      },
+      runtime,
+    });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(engine.writeFile(
+      SANDBOX_SESSION_ID,
+      "/tmp/home/.agents/skills/pohuy",
+      new TextEncoder().encode("must-not-land-inside-directory"),
+    )).rejects.toThrowError(
+      /AGENT_SANDBOX_RUNNER_FILE_COMMIT_FAILED: Не удалось записать файл/u,
+    );
+    const commands = container.exec.mock.calls.map(([options]) => options.Cmd.at(-1));
+    expect(commands[1]).toMatch(/^mv -T -- /u);
+    expect(commands[2]).toMatch(/^rm -f -- /u);
+    expect(consoleError).toHaveBeenCalledWith(
+      "Sandbox staged file cleanup failed",
+      expect.objectContaining({ exitCode: 1 }),
+    );
+    consoleError.mockRestore();
   });
 
   it("replaces stale policy compute while preserving named-volume data", async () => {

--- a/services/sandbox-runner/docker-sandbox-engine.ts
+++ b/services/sandbox-runner/docker-sandbox-engine.ts
@@ -7,6 +7,7 @@
  * - `resolveSandboxRuntimeImage`: requires the exact sandbox runtime image identity.
  * - `resolveSandboxDockerRuntime`: discovers Compose-owned volumes/network fail-fast.
  */
+import { randomUUID } from "node:crypto";
 import { mkdir, rm, stat } from "node:fs/promises";
 import { posix } from "node:path";
 
@@ -33,6 +34,7 @@ import {
   sandboxContainerNeedsReplacement,
   sandboxRequestHash,
 } from "./docker-sandbox-lifecycle.js";
+
 import { reconcileSandboxContainers } from "./docker-sandbox-reconciliation.js";
 import { writeSandboxSeedArchive } from "./docker-sandbox-seed.js";
 import {
@@ -43,6 +45,7 @@ import {
 
 export { buildSandboxContainerOptions } from "./docker-sandbox-options.js";
 
+const FILE_UPLOAD_STAGING_DIRECTORY = "/.osinara-sandbox-uploads";
 const MOUNT_TOOLS_DESTINATION = "/runner/tools";
 const MOUNT_WORKSPACES_DESTINATION = "/runner/workspaces";
 const MOUNT_GOOGLE_WORKSPACE_CREDENTIALS_DESTINATION = "/runner/google-workspace-credentials";
@@ -235,13 +238,41 @@ export function createDockerSandboxEngine(input: {
       await activity.runActive(sessionId, async () => {
         const container = await requireRunningContainer(input.docker, sessionId);
         const resolved = resolvePath(path);
+        const stagingPath = `${FILE_UPLOAD_STAGING_DIRECTORY}/${randomUUID()}`;
         const directoryResult = await executeSandboxProcess(input.docker, container, {
-          command: `mkdir -p -- ${JSON.stringify(posix.dirname(resolved))}`,
+          command:
+            `mkdir -p -- ${JSON.stringify(posix.dirname(resolved))} ` +
+            JSON.stringify(FILE_UPLOAD_STAGING_DIRECTORY),
         });
         if (directoryResult.exitCode !== 0) {
           throw new Error(`AGENT_SANDBOX_RUNNER_DIRECTORY_CREATE_FAILED: ${directoryResult.stderr}`);
         }
-        await writeSingleFileArchive(container, resolved, content);
+
+        // Docker's archive API cannot target tmpfs mounts such as restricted `$HOME`. Upload to
+        // writable container rootfs first, then let an in-container process cross the mount boundary.
+        let committed = false;
+        try {
+          await writeSingleFileArchive(container, stagingPath, content);
+          const moveResult = await executeSandboxProcess(input.docker, container, {
+            command: `mv -- ${JSON.stringify(stagingPath)} ${JSON.stringify(resolved)}`,
+          });
+          if (moveResult.exitCode !== 0) {
+            throw new Error(
+              `AGENT_SANDBOX_RUNNER_FILE_COMMIT_FAILED: ${moveResult.stderr}`,
+            );
+          }
+          committed = true;
+        } finally {
+          if (!committed) {
+            try {
+              await executeSandboxProcess(input.docker, container, {
+                command: `rm -f -- ${JSON.stringify(stagingPath)}`,
+              });
+            } catch (cleanupError) {
+              console.error("Sandbox staged file cleanup failed", { cleanupError, stagingPath });
+            }
+          }
+        }
       });
     },
     async removePath(sessionId, request: SandboxRunnerRemovePathRequest) {

--- a/services/sandbox-runner/docker-sandbox-engine.ts
+++ b/services/sandbox-runner/docker-sandbox-engine.ts
@@ -245,7 +245,10 @@ export function createDockerSandboxEngine(input: {
             JSON.stringify(FILE_UPLOAD_STAGING_DIRECTORY),
         });
         if (directoryResult.exitCode !== 0) {
-          throw new Error(`AGENT_SANDBOX_RUNNER_DIRECTORY_CREATE_FAILED: ${directoryResult.stderr}`);
+          throw new Error(
+            "AGENT_SANDBOX_RUNNER_DIRECTORY_CREATE_FAILED: " +
+            `Не удалось создать каталог для файла. ${directoryResult.stderr}`,
+          );
         }
 
         // Docker's archive API cannot target tmpfs mounts such as restricted `$HOME`. Upload to
@@ -254,20 +257,28 @@ export function createDockerSandboxEngine(input: {
         try {
           await writeSingleFileArchive(container, stagingPath, content);
           const moveResult = await executeSandboxProcess(input.docker, container, {
-            command: `mv -- ${JSON.stringify(stagingPath)} ${JSON.stringify(resolved)}`,
+            command: `mv -T -- ${JSON.stringify(stagingPath)} ${JSON.stringify(resolved)}`,
           });
           if (moveResult.exitCode !== 0) {
             throw new Error(
-              `AGENT_SANDBOX_RUNNER_FILE_COMMIT_FAILED: ${moveResult.stderr}`,
+              "AGENT_SANDBOX_RUNNER_FILE_COMMIT_FAILED: " +
+              `Не удалось записать файл в sandbox. ${moveResult.stderr}`,
             );
           }
           committed = true;
         } finally {
           if (!committed) {
             try {
-              await executeSandboxProcess(input.docker, container, {
+              const cleanupResult = await executeSandboxProcess(input.docker, container, {
                 command: `rm -f -- ${JSON.stringify(stagingPath)}`,
               });
+              if (cleanupResult.exitCode !== 0) {
+                console.error("Sandbox staged file cleanup failed", {
+                  exitCode: cleanupResult.exitCode,
+                  stagingPath,
+                  stderr: cleanupResult.stderr,
+                });
+              }
             } catch (cleanupError) {
               console.error("Sandbox staged file cleanup failed", { cleanupError, stagingPath });
             }


### PR DESCRIPTION
## Summary

- fix dynamic skill package writes into restricted-group `$HOME` on Docker tmpfs
- stage bytes in writable container rootfs, then move them across the mount boundary in-container
- preserve parent creation, size limits, activity tracking, and cleanup on failed commits
- bump the immutable hotfix release to `0.7.2`

## Production evidence

Error `9fe21272-ab3f-4b29-89f3-d020ab3a02b6` failed at `writeSkillPackageToSandbox`: Docker `putArchive` returned 404 for `/tmp/home/.agents/skills/pohuy` even though `docker exec stat` showed the directory existed. Restricted group HOME is a tmpfs mount, which Docker archive upload cannot reliably target.

## Verification

- real Docker tmpfs smoke wrote and read `/tmp/home/.agents/skills/pohuy/LICENSE.txt` through the updated engine
- staging directory was empty after commit and the temporary container was removed
- production-equivalent Docker Compose gate passed
- 169/169 test files and 903/903 tests passed
- typecheck, Eve build, and runtime bundle passed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Что изменено

- Выпущена версия `osinara-family-agent` `0.7.2`.
- Исправлена запись динамических skill-пакетов в `$HOME` restricted-групп, если каталог использует Docker tmpfs.
- Архив сначала записывается во временный каталог в корневой файловой системе контейнера.
- Затем файл перемещается внутри контейнера в целевой каталог через границу mount-точки.
- Сохранены создание родительских каталогов, ограничения размера, отслеживание активности и очистка временного файла после ошибки фиксации.
- Добавлены отдельные ошибки для создания каталога и фиксации файла.
- Добавлен Docker smoke-тест для записи в скрытый домашний каталог.

## Проверка

- 169 тестовых файлов.
- 903 успешно выполненных теста.
- Проверка Docker tmpfs.
- Тесты в Docker Compose, эквивалентные production-конфигурации.
- Typecheck.
- Сборка Eve.
- Проверка runtime bundle.
- `git diff --check`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->