### PR TITLE
Fix sandbox tmpfs file reads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "type": "module",
   "imports": {

--- a/services/sandbox-runner/docker-sandbox-engine.test.ts
+++ b/services/sandbox-runner/docker-sandbox-engine.test.ts
@@ -8,12 +8,11 @@
  * - Resource, capability, and privilege restrictions.
  * - Stale policy replacement and bounded warm-cache reconciliation at the Docker boundary.
  * - Explicit session and runner shutdown remove compute instead of retaining exited containers.
- * - File writes stage outside tmpfs before an in-container move to the requested path.
  */
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { PassThrough, Readable } from "node:stream";
+import { Readable } from "node:stream";
 
 import type Docker from "dockerode";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -167,104 +166,6 @@ describe("buildSandboxContainerOptions", () => {
       expect.stringContaining("PROXY="),
       expect.stringContaining("/tools/"),
     ]));
-  });
-
-  it("stages a hidden-home write outside tmpfs before moving it in-container", async () => {
-    const source = new PassThrough();
-    const exec = {
-      inspect: vi.fn(async () => ({ ExitCode: 0, Running: false })),
-      start: vi.fn(async () => source),
-    };
-    const container = {
-      exec: vi.fn(async () => exec),
-      inspect: vi.fn(async () => ({ Config: { Labels: {} }, State: { Running: true } })),
-      putArchive: vi.fn(async () => undefined),
-    };
-    const docker = {
-      getContainer: vi.fn(() => container),
-      modem: {
-        demuxStream: vi.fn((_stream, stdout, stderr) => {
-          stdout.end();
-          stderr.end();
-        }),
-      },
-    } as unknown as Docker;
-    const engine = createDockerSandboxEngine({
-      docker,
-      roots: {
-        googleWorkspaceCredentialsRoot: "/google-workspace-credentials",
-        toolsRoot: "/tools",
-        workspaceRoot: "/workspaces",
-      },
-      runtime,
-    });
-
-    await engine.writeFile(
-      SANDBOX_SESSION_ID,
-      "/tmp/home/.agents/skills/pohuy/LICENSE.txt",
-      new TextEncoder().encode("MIT"),
-    );
-
-    expect(container.putArchive).toHaveBeenCalledWith(
-      expect.anything(),
-      { path: "/.osinara-sandbox-uploads" },
-    );
-    const commands = container.exec.mock.calls.map(([options]) => options.Cmd.at(-1));
-    expect(commands).toEqual([
-      expect.stringMatching(/^mkdir -p -- .*\.osinara-sandbox-uploads/u),
-      expect.stringMatching(/^mv -T -- .* ".*\/tmp\/home\/\.agents\/skills\/pohuy\/LICENSE\.txt"$/u),
-    ]);
-  });
-
-  it("rejects a directory destination and observes failed staging cleanup", async () => {
-    const exitCodes = [0, 1, 1];
-    const container = {
-      exec: vi.fn(async () => {
-        const source = new PassThrough();
-        const exitCode = exitCodes.shift();
-        return {
-          inspect: vi.fn(async () => ({ ExitCode: exitCode, Running: false })),
-          start: vi.fn(async () => source),
-        };
-      }),
-      inspect: vi.fn(async () => ({ Config: { Labels: {} }, State: { Running: true } })),
-      putArchive: vi.fn(async () => undefined),
-    };
-    const docker = {
-      getContainer: vi.fn(() => container),
-      modem: {
-        demuxStream: vi.fn((_stream, stdout, stderr) => {
-          stdout.end();
-          stderr.end();
-        }),
-      },
-    } as unknown as Docker;
-    const engine = createDockerSandboxEngine({
-      docker,
-      roots: {
-        googleWorkspaceCredentialsRoot: "/google-workspace-credentials",
-        toolsRoot: "/tools",
-        workspaceRoot: "/workspaces",
-      },
-      runtime,
-    });
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-
-    await expect(engine.writeFile(
-      SANDBOX_SESSION_ID,
-      "/tmp/home/.agents/skills/pohuy",
-      new TextEncoder().encode("must-not-land-inside-directory"),
-    )).rejects.toThrowError(
-      /AGENT_SANDBOX_RUNNER_FILE_COMMIT_FAILED: Не удалось записать файл/u,
-    );
-    const commands = container.exec.mock.calls.map(([options]) => options.Cmd.at(-1));
-    expect(commands[1]).toMatch(/^mv -T -- /u);
-    expect(commands[2]).toMatch(/^rm -f -- /u);
-    expect(consoleError).toHaveBeenCalledWith(
-      "Sandbox staged file cleanup failed",
-      expect.objectContaining({ exitCode: 1 }),
-    );
-    consoleError.mockRestore();
   });
 
   it("replaces stale policy compute while preserving named-volume data", async () => {

--- a/services/sandbox-runner/docker-sandbox-engine.ts
+++ b/services/sandbox-runner/docker-sandbox-engine.ts
@@ -46,6 +46,7 @@ import {
 export { buildSandboxContainerOptions } from "./docker-sandbox-options.js";
 
 const FILE_UPLOAD_STAGING_DIRECTORY = "/.osinara-sandbox-uploads";
+const FILE_MISSING_EXIT_CODE = 44;
 const MOUNT_TOOLS_DESTINATION = "/runner/tools";
 const MOUNT_WORKSPACES_DESTINATION = "/runner/workspaces";
 const MOUNT_GOOGLE_WORKSPACE_CREDENTIALS_DESTINATION = "/runner/google-workspace-credentials";
@@ -226,11 +227,47 @@ export function createDockerSandboxEngine(input: {
     async readFile(sessionId, path) {
       return await activity.runActive(sessionId, async () => {
         const container = await requireRunningContainer(input.docker, sessionId);
+        const resolved = resolvePath(path);
+        const stagingPath = `${FILE_UPLOAD_STAGING_DIRECTORY}/${randomUUID()}`;
+        const copyResult = await executeSandboxProcess(input.docker, container, {
+          command:
+            `mkdir -p -- ${JSON.stringify(FILE_UPLOAD_STAGING_DIRECTORY)} && ` +
+            `if [ ! -f ${JSON.stringify(resolved)} ]; then exit ${FILE_MISSING_EXIT_CODE}; fi && ` +
+            `cp -T -- ${JSON.stringify(resolved)} ${JSON.stringify(stagingPath)}`,
+        });
+        if (copyResult.exitCode === FILE_MISSING_EXIT_CODE) return null;
+        if (copyResult.exitCode !== 0) {
+          throw new Error(
+            "AGENT_SANDBOX_RUNNER_FILE_STAGE_FAILED: " +
+            `Не удалось подготовить файл sandbox для чтения. ${copyResult.stderr}`,
+          );
+        }
+
+        // Docker's archive API cannot read files from restricted HOME on tmpfs. Copying to rootfs
+        // preserves binary archive reads while keeping the sandbox mount private and ephemeral.
+        let readFailed = false;
         try {
-          return await readSingleFileArchive(await container.getArchive({ path: resolvePath(path) }));
+          return await readSingleFileArchive(await container.getArchive({ path: stagingPath }));
         } catch (error) {
-          if (dockerStatus(error) === 404) return null;
+          readFailed = true;
           throw error;
+        } finally {
+          const cleanupResult = await executeSandboxProcess(input.docker, container, {
+            command: `rm -f -- ${JSON.stringify(stagingPath)}`,
+          });
+          if (cleanupResult.exitCode !== 0) {
+            console.error("Sandbox staged file cleanup failed", {
+              exitCode: cleanupResult.exitCode,
+              stagingPath,
+              stderr: cleanupResult.stderr,
+            });
+            if (!readFailed) {
+              throw new Error(
+                "AGENT_SANDBOX_RUNNER_FILE_CLEANUP_FAILED: " +
+                "Не удалось удалить временную копию прочитанного файла sandbox",
+              );
+            }
+          }
         }
       });
     },

--- a/services/sandbox-runner/docker-sandbox-filesystem.test.ts
+++ b/services/sandbox-runner/docker-sandbox-filesystem.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Docker sandbox filesystem bridge tests.
+ *
+ * Constructs covered:
+ * - Reads stage files outside tmpfs before using Docker's archive API.
+ * - Writes stage archives outside tmpfs before moving files in-container.
+ * - Failed file commits retain the original error and observe cleanup failures.
+ */
+import { PassThrough } from "node:stream";
+
+import type Docker from "dockerode";
+import tar from "tar-stream";
+import { describe, expect, it, vi } from "vitest";
+
+import { createDockerSandboxEngine } from "./docker-sandbox-engine.js";
+
+const SANDBOX_SESSION_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+const runtime = {
+  googleWorkspaceCredentialsVolume: "osinara_google-workspace-credentials",
+  egressNetwork: "osinara_sandbox-egress",
+  image: "osinara-sandbox-runtime:local",
+  project: "osinara",
+  toolsVolume: "osinara_tool-environments",
+  workspaceVolume: "osinara_workspace-data",
+};
+
+function successfulExec(source = new PassThrough()) {
+  return {
+    inspect: vi.fn(async () => ({ ExitCode: 0, Running: false })),
+    start: vi.fn(async () => source),
+  };
+}
+
+function createEngine(docker: Docker) {
+  return createDockerSandboxEngine({
+    docker,
+    roots: {
+      googleWorkspaceCredentialsRoot: "/google-workspace-credentials",
+      toolsRoot: "/tools",
+      workspaceRoot: "/workspaces",
+    },
+    runtime,
+  });
+}
+
+function archiveFile(name: string, content: string): NodeJS.ReadableStream {
+  const pack = tar.pack();
+  pack.entry({ name, type: "file" }, content);
+  pack.finalize();
+  return pack;
+}
+
+describe("Docker sandbox filesystem bridge", () => {
+  it("stages a hidden-home read outside tmpfs before using the archive API", async () => {
+    const container = {
+      exec: vi.fn(async () => successfulExec()),
+      getArchive: vi.fn(async () => archiveFile("staged", "skill instructions")),
+      inspect: vi.fn(async () => ({ Config: { Labels: {} }, State: { Running: true } })),
+    };
+    const docker = {
+      getContainer: vi.fn(() => container),
+      modem: {
+        demuxStream: vi.fn((_stream, stdout, stderr) => {
+          stdout.end();
+          stderr.end();
+        }),
+      },
+    } as unknown as Docker;
+
+    const content = await createEngine(docker).readFile(
+      SANDBOX_SESSION_ID,
+      "/tmp/home/.agents/skills/pohuy/SKILL.md",
+    );
+
+    expect(new TextDecoder().decode(content)).toBe("skill instructions");
+    expect(container.getArchive).toHaveBeenCalledWith({
+      path: expect.stringMatching(/^\/\.osinara-sandbox-uploads\//u),
+    });
+    const commands = container.exec.mock.calls.map(([options]) => options.Cmd.at(-1));
+    expect(commands).toEqual([
+      expect.stringMatching(/^mkdir -p -- .* && .*cp -T -- .*SKILL\.md/u),
+      expect.stringMatching(/^rm -f -- /u),
+    ]);
+  });
+
+  it("returns absence without invoking the archive API for a missing file", async () => {
+    const missingExec = successfulExec();
+    missingExec.inspect.mockResolvedValue({ ExitCode: 44, Running: false });
+    const container = {
+      exec: vi.fn(async () => missingExec),
+      getArchive: vi.fn(),
+      inspect: vi.fn(async () => ({ Config: { Labels: {} }, State: { Running: true } })),
+    };
+    const docker = {
+      getContainer: vi.fn(() => container),
+      modem: {
+        demuxStream: vi.fn((_stream, stdout, stderr) => {
+          stdout.end();
+          stderr.end();
+        }),
+      },
+    } as unknown as Docker;
+
+    await expect(createEngine(docker).readFile(
+      SANDBOX_SESSION_ID,
+      "/tmp/home/.agents/skills/missing/SKILL.md",
+    )).resolves.toBeNull();
+    expect(container.getArchive).not.toHaveBeenCalled();
+  });
+
+  it("stages a hidden-home write outside tmpfs before moving it in-container", async () => {
+    const source = new PassThrough();
+    const exec = successfulExec(source);
+    const container = {
+      exec: vi.fn(async () => exec),
+      inspect: vi.fn(async () => ({ Config: { Labels: {} }, State: { Running: true } })),
+      putArchive: vi.fn(async () => undefined),
+    };
+    const docker = {
+      getContainer: vi.fn(() => container),
+      modem: {
+        demuxStream: vi.fn((_stream, stdout, stderr) => {
+          stdout.end();
+          stderr.end();
+        }),
+      },
+    } as unknown as Docker;
+
+    await createEngine(docker).writeFile(
+      SANDBOX_SESSION_ID,
+      "/tmp/home/.agents/skills/pohuy/LICENSE.txt",
+      new TextEncoder().encode("MIT"),
+    );
+
+    expect(container.putArchive).toHaveBeenCalledWith(
+      expect.anything(),
+      { path: "/.osinara-sandbox-uploads" },
+    );
+    const commands = container.exec.mock.calls.map(([options]) => options.Cmd.at(-1));
+    expect(commands).toEqual([
+      expect.stringMatching(/^mkdir -p -- .*\.osinara-sandbox-uploads/u),
+      expect.stringMatching(/^mv -T -- .* ".*\/tmp\/home\/\.agents\/skills\/pohuy\/LICENSE\.txt"$/u),
+    ]);
+  });
+
+  it("rejects a directory destination and observes failed staging cleanup", async () => {
+    const exitCodes = [0, 1, 1];
+    const container = {
+      exec: vi.fn(async () => {
+        const source = new PassThrough();
+        const exitCode = exitCodes.shift();
+        return {
+          inspect: vi.fn(async () => ({ ExitCode: exitCode, Running: false })),
+          start: vi.fn(async () => source),
+        };
+      }),
+      inspect: vi.fn(async () => ({ Config: { Labels: {} }, State: { Running: true } })),
+      putArchive: vi.fn(async () => undefined),
+    };
+    const docker = {
+      getContainer: vi.fn(() => container),
+      modem: {
+        demuxStream: vi.fn((_stream, stdout, stderr) => {
+          stdout.end();
+          stderr.end();
+        }),
+      },
+    } as unknown as Docker;
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(createEngine(docker).writeFile(
+      SANDBOX_SESSION_ID,
+      "/tmp/home/.agents/skills/pohuy",
+      new TextEncoder().encode("must-not-land-inside-directory"),
+    )).rejects.toThrowError(
+      /AGENT_SANDBOX_RUNNER_FILE_COMMIT_FAILED: Не удалось записать файл/u,
+    );
+    const commands = container.exec.mock.calls.map(([options]) => options.Cmd.at(-1));
+    expect(commands[1]).toMatch(/^mv -T -- /u);
+    expect(commands[2]).toMatch(/^rm -f -- /u);
+    expect(consoleError).toHaveBeenCalledWith(
+      "Sandbox staged file cleanup failed",
+      expect.objectContaining({ exitCode: 1 }),
+    );
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- stage sandbox reads in container rootfs before invoking Docker archive APIs
- preserve missing-file semantics and clean temporary copies
- split filesystem bridge regressions into a dedicated colocated test module
- bump the immutable release version to 0.7.3

## Root cause
Docker `getArchive`, like `putArchive`, cannot access files under the restricted group `$HOME` tmpfs mount even though in-container processes can see them. Dynamic skill materialization succeeded, but Eve could not read `SKILL.md`.

## Verification
- `npx vitest run services/sandbox-runner/docker-sandbox-filesystem.test.ts services/sandbox-runner/docker-sandbox-engine.test.ts`
- `npm run typecheck`
- `npm test` (170 files, 906 tests: 763 passed, 143 skipped)
- `npm run build:runtime`
- production-container smoke: tmpfs file copied to rootfs staging and retrieved through Docker archive API with cleanup