### PR TITLE
Release v0.8.1 after safe deployment rejection

### DIFF
--- a/docs/releases/v0.8.1.md
+++ b/docs/releases/v0.8.1.md
@@ -1,0 +1,22 @@
+# Osinara v0.8.1
+
+Повторный immutable release обновления `v0.8.0` после безопасного отказа production deployment controller.
+
+## Что изменилось
+
+- Все пользовательские возможности `v0.8.0` без изменений входят в этот release: DeepSeek V4 Flash, безопасный Telegram Rich Markdown, полные HITL-подтверждения, улучшенные напоминания и расписания, memory undo, Google Workspace boundary, OAuth delivery state, защищённые вложения и изолированный `task_worker`.
+- Production deployment controller синхронизирован с новым Google Workspace security boundary. Validator теперь ожидает, что постоянный `google-workspace-credentials` mount отсутствует у `sandbox-runner`; Google Workspace mutations выполняются только в одноразовом контейнере с точными аргументами и ограниченными credentials.
+- Версия увеличена до `v0.8.1`, потому что terminal failed proposal для immutable `v0.8.0` нельзя повторно использовать, сбрасывать или перепривязывать вручную. Новый release создаёт отдельный manifest, отдельные image digests и новое owner approval.
+
+## Причина patch-релиза
+
+При первой попытке установки `v0.8.0` установленный на сервере controller версии `v0.7.3` корректно остановил deployment до скачивания images, остановки сервисов и запуска миграций. Его allowlist всё ещё требовал старый постоянный mount Google Workspace credentials, тогда как Compose `v0.8.0` намеренно удалил этот mount.
+
+Production продолжил работать на `v0.7.3` без прерывания обслуживания и без изменения данных. Root-owned controller module был обновлён из canonical merge commit, его checksum, синтаксис и права доступа проверены до публикации этого release.
+
+## Установка и данные
+
+- Deployment по-прежнему возможен только после нового подтверждения владельца в исходном личном Telegram-чате.
+- Сервер повторно проверяет immutable GitHub release, exact commit, Compose SHA-256, полный service/image/mount allowlist и digest references.
+- Перед переключением выполняются обязательные backup и миграции `045`-`048`; после запуска проверяется production health endpoint.
+- Неуспешный proposal `v0.8.0` остаётся terminal audit record и не переиспользуется.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- bump the immutable release version to v0.8.1
- document the v0.8.0 pre-deployment validator rejection and unchanged production state
- record synchronization of the root-owned deployment controller with the Google Workspace mount boundary

## Verification
- `npm test -- production-release-contract.test.ts`
- package and lockfile version consistency check
- production controller checksum, syntax, owner and mode verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Версия пакета `osinara-family-agent` обновлена с `0.8.0` до `0.8.1`.
- Задокументирован отказ валидатора перед развёртыванием версии `v0.8.0`.
- Зафиксировано отсутствие изменений в production-состоянии.
- Зафиксирована синхронизация контроллера развёртывания с границей монтирования Google Workspace.
- Проверены версия пакета, lock-файл, production-контракт и контрольная сумма контроллера.
- Проверены синтаксис, владелец и разрешения production-контроллера.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->