### PR TITLE
Fix incomplete DeepSeek tool history

### DIFF
--- a/agent/lib/deepseek-model-transport.test.ts
+++ b/agent/lib/deepseek-model-transport.test.ts
@@ -5,6 +5,7 @@
  * - Explicit thinking controls are sent on every DeepSeek model request.
  * - `reasoning_content` remains separate from visible output.
  * - Tool-call reasoning is replayed exactly as required by DeepSeek multi-round context.
+ * - Approval-only tool calls are removed unless a real tool result completes the pair.
  */
 import type { LanguageModelV4CallOptions } from "@ai-sdk/provider";
 import { generateText, stepCountIs, streamText, tool } from "ai";
@@ -138,6 +139,128 @@ describe("DeepSeek model transport", () => {
       reasoning_effort: "high",
       thinking: { type: "enabled" },
     });
+  });
+
+  it("removes approval-only tool calls while preserving completed tool pairs", async () => {
+    let body: Record<string, unknown> | undefined;
+    const model = deepSeekModel(async (_input, init) => {
+      body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return completion({
+        content: "История обработана.",
+        reasoning_content: "Продолжаю после подтверждения.",
+        role: "assistant",
+      }, "stop");
+    });
+
+    // Eve can resume with an approved call that has no execution result yet. DeepSeek only accepts
+    // assistant tool calls that have a corresponding tool message in the serialized history.
+    await model.doGenerate({
+      prompt: [
+        { content: [{ text: "Подготовь операции", type: "text" }], role: "user" },
+        {
+          content: [
+            { text: "Нужно выполнить операции.", type: "reasoning" },
+            {
+              input: { id: "done" },
+              toolCallId: "call_completed",
+              toolName: "mutate",
+              type: "tool-call",
+            },
+            {
+              input: { id: "approved" },
+              toolCallId: "call_approval_only",
+              toolName: "mutate",
+              type: "tool-call",
+            },
+          ],
+          role: "assistant",
+        },
+        {
+          content: [{
+            output: { type: "json", value: { ok: true } },
+            toolCallId: "call_completed",
+            toolName: "mutate",
+            type: "tool-result",
+          }],
+          role: "tool",
+        },
+        { content: [{ text: "Продолжай", type: "text" }], role: "user" },
+      ],
+    } as LanguageModelV4CallOptions);
+
+    const serialized = JSON.stringify(body?.messages);
+    expect(serialized).toContain("call_completed");
+    expect(serialized).not.toContain("call_approval_only");
+    expect(body?.messages).toEqual([
+      { content: "Подготовь операции", role: "user" },
+      expect.objectContaining({
+        reasoning_content: "Нужно выполнить операции.",
+        role: "assistant",
+        tool_calls: [expect.objectContaining({ id: "call_completed" })],
+      }),
+      expect.objectContaining({ role: "tool", tool_call_id: "call_completed" }),
+      { content: "Продолжай", role: "user" },
+    ]);
+  });
+
+  it("removes misordered tool results instead of pairing them across a user message", async () => {
+    let body: Record<string, unknown> | undefined;
+    const model = deepSeekModel(async (_input, init) => {
+      body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return completion({ content: "Готово.", role: "assistant" }, "stop");
+    });
+
+    await model.doGenerate({
+      prompt: [
+        {
+          content: [{
+            input: {},
+            toolCallId: "call_misordered",
+            toolName: "probe",
+            type: "tool-call",
+          }],
+          role: "assistant",
+        },
+        { content: [{ text: "Новый запрос", type: "text" }], role: "user" },
+        {
+          content: [{
+            output: { type: "json", value: { ok: true } },
+            toolCallId: "call_misordered",
+            toolName: "probe",
+            type: "tool-result",
+          }],
+          role: "tool",
+        },
+      ],
+    } as LanguageModelV4CallOptions);
+
+    expect(body?.messages).toEqual([{ content: "Новый запрос", role: "user" }]);
+  });
+
+  it("removes provider-executed calls that the compatible wire cannot represent as completed", async () => {
+    let body: Record<string, unknown> | undefined;
+    const model = deepSeekModel(async (_input, init) => {
+      body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return completion({ content: "Готово.", role: "assistant" }, "stop");
+    });
+
+    await model.doGenerate({
+      prompt: [
+        {
+          content: [{
+            input: { query: "пример" },
+            providerExecuted: true,
+            toolCallId: "call_provider",
+            toolName: "provider_search",
+            type: "tool-call",
+          }],
+          role: "assistant",
+        },
+        { content: [{ text: "Продолжай", type: "text" }], role: "user" },
+      ],
+    } as LanguageModelV4CallOptions);
+
+    expect(body?.messages).toEqual([{ content: "Продолжай", role: "user" }]);
   });
 
   it("streams reasoning separately and exposes only final content as text", async () => {

--- a/agent/lib/model-transport.ts
+++ b/agent/lib/model-transport.ts
@@ -15,6 +15,7 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type {
   LanguageModelV4FinishReason,
+  LanguageModelV4Prompt,
   LanguageModelV4StreamPart,
   SharedV4ProviderOptions,
 } from "@ai-sdk/provider";
@@ -92,6 +93,52 @@ function configuredProviderOptions(
   };
 }
 
+function removeUnresolvedOpenAIToolCalls(prompt: LanguageModelV4Prompt): LanguageModelV4Prompt {
+  // AI SDK treats a client-side approval as resolving its call, then removes the approval response
+  // from provider input. OpenAI-compatible APIs require immediate results for every retained call.
+  const normalized: LanguageModelV4Prompt = [];
+  for (let index = 0; index < prompt.length;) {
+    const message = prompt[index]!;
+    if (message.role !== "assistant") {
+      // A tool message outside its originating assistant group is invalid provider history.
+      if (message.role !== "tool") normalized.push(message);
+      index += 1;
+      continue;
+    }
+
+    // Only contiguous tool messages can complete this assistant turn under Chat Completions.
+    let nextIndex = index + 1;
+    const toolMessages: Extract<LanguageModelV4Prompt[number], { role: "tool" }>[] = [];
+    while (prompt[nextIndex]?.role === "tool") {
+      toolMessages.push(prompt[nextIndex] as typeof toolMessages[number]);
+      nextIndex += 1;
+    }
+    const immediateResultIds = new Set(toolMessages.flatMap((toolMessage) =>
+      toolMessage.content
+        .filter((part) => part.type === "tool-result")
+        .map((part) => part.toolCallId)
+    ));
+    const retainedCallIds = new Set<string>();
+    for (const part of message.content) {
+      if (part.type === "tool-call" && immediateResultIds.has(part.toolCallId)) {
+        retainedCallIds.add(part.toolCallId);
+      }
+    }
+    const content = message.content.filter((part) =>
+      part.type !== "tool-call" || retainedCallIds.has(part.toolCallId)
+    );
+    if (content.length > 0) normalized.push({ ...message, content });
+    for (const toolMessage of toolMessages) {
+      const toolContent = toolMessage.content.filter((part) =>
+        part.type === "tool-approval-response" || retainedCallIds.has(part.toolCallId)
+      );
+      if (toolContent.length > 0) normalized.push({ ...toolMessage, content: toolContent });
+    }
+    index = nextIndex;
+  }
+  return normalized;
+}
+
 function createTransportDefaultsMiddleware(
   maxOutputTokens: number,
   transport: AgentModelTransport,
@@ -102,6 +149,9 @@ function createTransportDefaultsMiddleware(
       return {
         ...params,
         maxOutputTokens: params.maxOutputTokens ?? maxOutputTokens,
+        prompt: transport.protocol === "openai-chat-completions"
+          ? removeUnresolvedOpenAIToolCalls(params.prompt)
+          : params.prompt,
         providerOptions: {
           ...params.providerOptions,
           ...configuredProviderOptions(params.providerOptions, transport),

--- a/docs/releases/v0.8.2.md
+++ b/docs/releases/v0.8.2.md
@@ -1,0 +1,20 @@
+# Osinara v0.8.2
+
+Исправление продолжения диалогов с DeepSeek после незавершённых или только подтверждённых вызовов инструментов в сохранённой истории.
+
+## Что исправлено
+
+- OpenAI Chat Completions transport больше не отправляет DeepSeek assistant `tool_calls`, для которых в фактической model history отсутствует соответствующий `tool-result`.
+- Завершённые пары `tool-call` / `tool-result` сохраняются без изменений вместе с их `reasoning_content`, аргументами и результатами.
+- Если в одном assistant turn были и завершённые, и незавершённые вызовы, удаляются только незавершённые вызовы. Обычный текст, reasoning и остальные сообщения истории сохраняются.
+- Нормализация применяется до provider serialization только к OpenAI-compatible transport. Anthropic Messages transport и его signed thinking history не затрагиваются.
+
+## Причина
+
+AI SDK считает client-side approval достаточным для закрытия pending tool call во внутренней проверке истории, но затем удаляет approval response из provider payload. OpenAI-compatible serializer при этом сохранял исходный assistant `tool_calls`. DeepSeek отклонял такой запрос с HTTP `400` и сообщением `insufficient tool messages following tool_calls message`, а пользователь видел `MODEL_CALL_FAILED`.
+
+## Надёжность
+
+- Добавлен regression test со смешанной историей: один вызов имеет реальный результат, второй завершён только approval-состоянием.
+- Исправление не создаёт фиктивные результаты, не повторяет model call и не подменяет модель fallback-провайдером.
+- Ошибочный turn остаётся в durable audit history; после обновления пользователь начинает новый turn обычным сообщением.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- normalize OpenAI-compatible tool history to retain only immediately completed call/result pairs
- remove approval-only, orphaned, misordered, and unrepresentable provider-executed calls before DeepSeek serialization
- release the production fix as v0.8.2 with detailed notes

## Root cause
AI SDK accepted client-side approval as resolving a tool call, removed the approval response from provider input, and left the assistant `tool_calls` entry. DeepSeek rejected the resulting request with HTTP 400.

## Verification
- `npm test` (190 files, 1086 tests)
- `npm run typecheck`
- `npm run build`