### PR TITLE
Add manual release dispatch

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -1,6 +1,7 @@
 name: CI and release
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [develop, main]
   push:
@@ -27,7 +28,7 @@ jobs:
 
   release:
     name: Publish immutable production release
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -34,6 +34,12 @@ claims one approved PostgreSQL proposal after rechecking the current owner, veri
 release, Compose hash, fixed service/image/mount policy, and digest names. It pulls before stopping,
 backs up existing durable state, starts the released Compose graph without build, and checks
 `http://127.0.0.1:8082/eve/v1/health`.
+
+If GitHub loses the canonical `main` push event during an Actions outage, an operator may dispatch
+the same `CI and release` workflow manually with `gh workflow run "CI and release" --ref main`.
+The manual path still runs the production-equivalent test job first and publishes only from the
+current canonical `main` ref; it does not permit a branch build or bypass release validation.
+
 Before each non-initial deployment it also prunes older Osinara deployment backups, retaining the
 initial migration backup while clearing the timestamped slot for the pending snapshot; after
 successful backup creation exactly one previous-release backup remains. After a successful health

--- a/production-release-contract.test.ts
+++ b/production-release-contract.test.ts
@@ -203,6 +203,7 @@ describe("release workflow contract", () => {
   it("tests PR, develop, and main with the exact Compose suite", () => {
     const workflow = readProjectFile(".github/workflows/ci-release.yaml");
 
+    expect(workflow).toContain("workflow_dispatch:");
     expect(workflow).toContain("pull_request:");
     expect(workflow).toContain("develop");
     expect(workflow).toContain("main");
@@ -210,6 +211,9 @@ describe("release workflow contract", () => {
       "docker compose -f compose.test.yaml up --build --abort-on-container-exit --exit-code-from tests",
     );
     expect(workflow).toContain("cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}");
+    expect(workflow).toContain(
+      "github.event_name == 'push' || github.event_name == 'workflow_dispatch'",
+    );
   });
 
   it("publishes fixed GHCR names with immutable action revisions and attestations", () => {


### PR DESCRIPTION
## Summary
- add a workflow_dispatch recovery path for lost main push events
- keep release publication restricted to refs/heads/main
- retain the production-equivalent test dependency and all existing release validation
- document the exact operator command

## Verification
- npm test -- production-release-contract.test.ts

This operational recovery is needed because GitHub Actions lost the v0.10.1 main push event during the current Actions outage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Добавлен ручной запуск workflow через `workflow_dispatch`.
- Публикация релиза разрешена только для `refs/heads/main`.
- Сохранены production-эквивалентная зависимость и существующие проверки релиза.
- Тест контракта проверяет ручной запуск и условия публикации.
- Документация содержит точную команду для восстановления релиза.

## Проверка

`npm test -- production-release-contract.test.ts`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->