### PR TITLE
Release v0.11.1 deployment recovery

### DIFF
--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -111,6 +111,18 @@ The agent does not call this service. Its isolated baked compatibility config is
 model selection. Removing that deployment slot requires a separately approved two-phase controller
 migration; it must not be coupled to a model-provider switch.
 
+Any release that changes the exact production service, image, mount, port, logging, dependency, or
+host-capability allowlist is also a two-phase controller migration. After canonical merge and before
+owner approval, stop only `osinara-deploy.timer`, compare the installed root-owned controller modules
+with the exact canonical release commit, and atomically install only the changed modules. Verify the
+source checksum, shell syntax, `root:root` ownership, required `0750`/`0640` modes, then restart the
+timer. The running application and database remain untouched during this controller phase. Only
+afterward may the owner approve the application release in the bound private Telegram chat.
+
+If the old controller has already rejected an immutable release, its proposal remains terminal. Do
+not reset, clone, or reapprove it: publish a strictly newer patch release and require a new owner
+approval. This preserves the audit trail and the no-ambiguous-retry contract.
+
 The server host requires Docker Engine with Compose v2, systemd, `curl`, `jq`, `flock`, `stat`,
 `sha256sum`, `tar`, and standard GNU file utilities. Missing tools are deployment errors; the
 script does not download utilities or substitute alternate commands at runtime.

--- a/docs/releases/v0.11.1.md
+++ b/docs/releases/v0.11.1.md
@@ -1,0 +1,40 @@
+# Osinara v0.11.1
+
+Повторный immutable release памяти R0-R7 после безопасного pre-migration отказа production
+deployment controller при первой установке `v0.11.0`.
+
+## Что входит в release
+
+- Все возможности `v0.11.0` входят без изменения поведения: opaque memory refs, hybrid Russian/E5
+  retrieval, evidence-backed claims, verified profiles, conflicts, memory threads, confirmed
+  outcomes, durable extraction worker и execution-time trust-zone authorization.
+- Версия увеличена до `v0.11.1`, потому что terminal failed proposal immutable release `v0.11.0`
+  нельзя повторно использовать, сбрасывать или вручную возвращать в `approved`.
+- Новый release создаёт отдельный manifest, новые image digests и отдельное owner approval.
+- Production documentation теперь задаёт общий двухфазный protocol для любых изменений exact
+  service/image/mount allowlist root-owned deployment controller.
+
+## Причина patch-релиза
+
+`v0.11.0` добавил пятый app-image service `memory-extraction-worker`. Установленный controller
+`v0.10.1` корректно ожидал четыре app-image services и завершил candidate validation с кодом
+`DEPLOY_COMPOSE_IMAGE_SET_INVALID`.
+
+Отказ произошёл до pull candidate images, остановки application writers и запуска migrations.
+Production продолжил работать на `v0.10.1`; current release symlink, контейнеры и PostgreSQL не
+переключались.
+
+Root-owned `release.sh` был атомарно обновлён из canonical `v0.11.0` commit. Перед установкой и после
+неё проверены SHA-256 `a0d5b55d80807afe3d2662aa7e349a31c60617a9599ce1fa638580375ccf7e96`,
+shell syntax, `root:root 0640` и активный deploy timer. Остальные controller modules совпали
+байт-в-байт и не изменялись.
+
+## Установка и данные
+
+- Deployment начинается только после нового подтверждения владельца в исходном личном Telegram-чате.
+- Сервер повторно проверяет immutable GitHub release, exact commit, Compose SHA-256, image digests и
+  полный service/image/mount/port/capability allowlist.
+- Перед переключением создаются и проверяются PostgreSQL dump и durable-volume backups.
+- Миграции `049`-`056` выполняются только one-shot `migrate` service внутри released Compose graph.
+- Candidate должен пройти production health check до atomic promotion `current` symlink.
+- Неуспешный proposal `v0.11.0` остаётся terminal audit record и не переиспользуется.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary

- Publish a new immutable patch release after the terminal pre-migration rejection of `v0.11.0`.
- Preserve all R0-R7 memory behavior without application-code changes.
- Document the required two-phase update protocol for root-owned deployment controller allowlist changes.
- Keep the failed `v0.11.0` proposal as an immutable audit record and require a new owner approval.

## Incident

The installed `v0.10.1` controller expected four app-image services. `v0.11.0` correctly added `memory-extraction-worker` as the fifth app-image service, so the old controller rejected the candidate with `DEPLOY_COMPOSE_IMAGE_SET_INVALID` before image pull, writer shutdown, or migrations. Production remained healthy on `v0.10.1`.

The root-owned `release.sh` has now been atomically synchronized from canonical `v0.11.0` and verified with SHA-256 `a0d5b55d80807afe3d2662aa7e349a31c60617a9599ce1fa638580375ccf7e96`, shell syntax, `root:root 0640`, and an active deploy timer.

## Verification

- Production release contract: 19/19 passed.
- TypeScript typecheck passed.
- `npm audit --omit=dev`: 0 vulnerabilities.
- Independent recovery review: P0 = 0, P1 = 0, P2 = 0.

## Release notes

Detailed recovery and data-safety notes: `docs/releases/v0.11.1.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Версия пакета обновлена с `0.11.0` до `0.11.1`.
- Подготовлен неизменяемый patch-релиз без изменений прикладного кода и поведения памяти R0–R7.
- Документирован двухфазный протокол обновления allowlist контроллера деплоя.
- Сохранено отклонённое предложение `v0.11.0` как неизменяемая аудиторская запись.
- Синхронизирован и проверен канонический `v0.11.0` `release.sh`.
- Добавлены подробные сведения о восстановлении и безопасности данных в `docs/releases/v0.11.1.md`.

## Проверки

- Пройдены 19 из 19 production release-contract проверок.
- TypeScript typechecking завершён успешно.
- `npm audit --omit=dev` не обнаружил уязвимостей.
- Независимая проверка восстановления выявила 0 замечаний уровней P0, P1 и P2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->