### PR TITLE
Release v0.11.2 after backup capacity preflight

### DIFF
--- a/docs/releases/v0.11.2.md
+++ b/docs/releases/v0.11.2.md
@@ -1,0 +1,38 @@
+# Osinara v0.11.2
+
+Повторный immutable release памяти R0-R7 после безопасного pre-migration отказа production
+deployment controller при установке `v0.11.1`.
+
+## Что входит в release
+
+- Все возможности `v0.11.1` входят без изменения runtime-поведения: opaque memory refs, hybrid
+  Russian/E5 retrieval, evidence-backed claims, verified profiles, conflicts, memory threads,
+  confirmed outcomes, durable extraction worker и execution-time trust-zone authorization.
+- Версия увеличена до `v0.11.2`, потому что terminal failed proposal immutable release `v0.11.1`
+  нельзя повторно использовать, сбрасывать или вручную возвращать в `approved`.
+- Новый release создаёт отдельный manifest, новые image digests и отдельное owner approval.
+
+## Причина patch-релиза
+
+После owner approval controller успешно проверил `v0.11.1` и скачал exact candidate images, но
+остановил deployment с кодом `DEPLOY_BACKUP_SPACE_INSUFFICIENT`. Консервативный preflight требует
+свободное место в размере удвоенного объёма PostgreSQL и irreconstructible durable volumes плюс
+резерв `512 MiB`.
+
+Отказ произошёл до создания backup, остановки application writers и запуска migrations. Production
+продолжил работать на `v0.10.1`; current release symlink, контейнеры и PostgreSQL не переключались.
+Неиспользуемые images старых и terminal failed releases удалены только после проверки OCI version
+labels и отсутствия связанных running или stopped containers. Durable volumes и backups не
+изменялись.
+
+## Установка и данные
+
+- После публикации exact candidate images скачиваются до создания proposal, чтобы повторно проверить
+  реальный свободный объём уже с полным image set на сервере.
+- Deployment начинается только после нового подтверждения владельца в исходном личном Telegram-чате.
+- Сервер повторно проверяет immutable GitHub release, exact commit, Compose SHA-256, image digests и
+  полный service/image/mount/port/capability allowlist.
+- Перед переключением создаются и проверяются PostgreSQL dump и durable-volume backups.
+- Миграции `049`-`056` выполняются только one-shot `migrate` service внутри released Compose graph.
+- Candidate должен пройти production health check до atomic promotion `current` symlink.
+- Неуспешные proposals `v0.11.0` и `v0.11.1` остаются terminal audit records и не переиспользуются.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- publish a new immutable recovery version after the terminal v0.11.1 capacity failure
- document the exact pre-migration failure boundary and retained audit records
- require candidate image pull and exact disk-capacity verification before the new owner proposal

## Verification
- npm test -- production-release-contract.test.ts (19 passed)
- npm audit --omit=dev (0 vulnerabilities)
- production remains healthy on v0.10.1; no writers or migrations were started by v0.11.1