### PR TITLE
Fix v0.11.4 deployment and retention

### DIFF
--- a/docs/releases/v0.11.4.md
+++ b/docs/releases/v0.11.4.md
@@ -1,0 +1,40 @@
+# Osinara v0.11.4
+
+Повторный immutable release исправления production memory extraction worker после безопасного
+pre-backup отказа `v0.11.3`.
+
+## Причина patch-релиза
+
+`v0.11.3` добавил exact readiness healthcheck в released Compose и root-owned controller. Authored
+Compose сохранил одинарные кавычки внутри JavaScript health command, а controller ожидал
+семантически эквивалентную строку с двойными кавычками. Fail-closed validator остановил deployment
+с `DEPLOY_COMPOSE_SECURITY_INVALID` до backup, остановки writers и migration `057`.
+
+`v0.11.4` кодирует одинарные кавычки через JSON/JQ `\u0027`, поэтому validator сравнивает точные
+resolved Compose bytes без нарушения shell quoting. Новый release имеет отдельные manifest, image
+digests и owner approval; terminal proposal `v0.11.3` не переиспользуется.
+
+## Retention
+
+- На production сохраняются только два локальных release-каталога: current и previous rollback.
+- Перед новым snapshot удаляются все старые rolling deploy backups и legacy
+  `initial-migration-v0.1.1`; после успешного deployment остаётся ровно один новый проверенный backup.
+- Retired release directory удаляется только после удаления или подтверждённого отсутствия его image
+  refs. Если image ещё используется, directory сохраняется для следующего безопасного cleanup pass.
+- Immutable GitHub Releases остаются удалённым audit trail и не занимают production filesystem.
+
+## Исправления worker
+
+- Catch-up extraction сортирует `bigint sequence_id` численно.
+- Migration `057_repair_memory_extraction_sequence_ranges.sql` восстанавливает persisted boundaries
+  из immutable snapshots без изменения provider-call evidence.
+- DeepSeek structured-output prompt явно требует JSON.
+- Worker readiness требует успешный durable pass и 30 секунд стабильной работы.
+
+## Установка
+
+- До owner approval root-owned `release.sh` и `backup.sh` обновляются из exact canonical commit с
+  проверкой SHA-256, shell syntax, ownership и mode.
+- Candidate images скачиваются заранее; backup capacity проверяется после retention cleanup.
+- Deployment выполняет migration `057` только через one-shot Compose `migrate` service и promotes
+  candidate только после stabilized worker и полного health gate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "private": true,
   "type": "module",
   "imports": {

--- a/production-deploy-shell.test.ts
+++ b/production-deploy-shell.test.ts
@@ -136,7 +136,7 @@ describe("production deploy shell policies", () => {
     expect(owned.stderr).toContain("DEPLOY_BACKUP_VOLUME_MISSING");
   });
 
-  it("retains the initial backup and clears the slot for one deploy backup", () => {
+  it("clears every old backup before creating the one rolling deploy backup", () => {
     const directory = mkdtempSync(join(tmpdir(), "osinara-backup-retention-"));
     temporaryDirectories.push(directory);
     for (const name of [
@@ -160,9 +160,7 @@ describe("production deploy shell policies", () => {
     `);
 
     expect(result.status, result.stderr).toBe(0);
-    expect(readdirSync(directory).sort()).toEqual([
-      "initial-migration-v0.1.1",
-    ]);
+    expect(readdirSync(directory)).toEqual([]);
   });
 
   it("removes only non-retained Osinara release image references", () => {
@@ -200,5 +198,7 @@ describe("production deploy shell policies", () => {
     expect(calls).toContain(`image rm ghcr.io/nyxandro/osinara-app@sha256:${"a".repeat(64)}`);
     expect(calls).not.toContain(`image rm ghcr.io/nyxandro/osinara-app@sha256:${"b".repeat(64)}`);
     expect(calls).not.toContain(`image rm ghcr.io/nyxandro/osinara-app@sha256:${"c".repeat(64)}`);
+    expect(readdirSync(directory).filter((name) => name.startsWith("v")).sort())
+      .toEqual(["v0.2.10", "v0.2.9"]);
   });
 });

--- a/production-release-contract-fixtures.ts
+++ b/production-release-contract-fixtures.ts
@@ -2,6 +2,7 @@
  * Production release contract test fixtures.
  *
  * Exports:
+ * - `PRODUCTION_MEMORY_EXTRACTION_WORKER_HEALTH_COMMAND`: exact authored and resolved command.
  * - `resolvedComposeSecurityFixture`: accepted resolved production Compose security surface.
  * - `executeComposeSecurityPredicate`: invokes the real root deployment jq predicate.
  */
@@ -9,8 +10,8 @@ import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const projectRoot = new URL("./", import.meta.url);
-const WORKER_HEALTH_COMMAND =
-  "const fs=require(\"node:fs\"),p=\"/tmp/osinara-memory-extraction-worker-ready\";" +
+export const PRODUCTION_MEMORY_EXTRACTION_WORKER_HEALTH_COMMAND =
+  "const fs=require('node:fs'),p='/tmp/osinara-memory-extraction-worker-ready';" +
   "if(!fs.existsSync(p)||Date.now()-fs.statSync(p).mtimeMs<30000)process.exit(1)";
 
 export function resolvedComposeSecurityFixture(): Record<string, unknown> {
@@ -46,7 +47,10 @@ export function resolvedComposeSecurityFixture(): Record<string, unknown> {
       }),
       "memory-embedding-worker": service(),
       "memory-extraction-worker": service({
-        healthcheck: { retries: 120, test: ["CMD", "node", "-e", WORKER_HEALTH_COMMAND] },
+        healthcheck: {
+          retries: 120,
+          test: ["CMD", "node", "-e", PRODUCTION_MEMORY_EXTRACTION_WORKER_HEALTH_COMMAND],
+        },
         volumes: [
           volume("/opt/osinara/model-providers.json", "/app/config/model-providers.json", "bind", true),
         ],

--- a/production-release-contract.test.ts
+++ b/production-release-contract.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   executeComposeSecurityPredicate,
+  PRODUCTION_MEMORY_EXTRACTION_WORKER_HEALTH_COMMAND,
   resolvedComposeSecurityFixture,
 } from "./production-release-contract-fixtures.js";
 
@@ -143,6 +144,7 @@ describe("production container contract", () => {
     expect(worker).toContain("migrate:\n        condition: service_completed_successfully");
     expect(worker).toContain('.runtime/scripts/memory-extraction-worker.js');
     expect(worker).toContain("MODEL_UPSTREAM_API_KEY: ${DEEPSEEK_API_KEY:?");
+    expect(worker).toContain(PRODUCTION_MEMORY_EXTRACTION_WORKER_HEALTH_COMMAND);
     expect(worker).toContain("restart: unless-stopped");
   });
 

--- a/scripts/production-deploy/backup.sh
+++ b/scripts/production-deploy/backup.sh
@@ -5,6 +5,7 @@
 readonly BACKUP_RESERVE_BYTES=$((512 * 1024 * 1024))
 readonly RETAINED_DEPLOY_BACKUP_COUNT=1
 readonly PRE_DEPLOY_RETAINED_BACKUP_COUNT=$((RETAINED_DEPLOY_BACKUP_COUNT - 1))
+readonly LEGACY_INITIAL_MIGRATION_BACKUP_NAME="initial-migration-v0.1.1"
 readonly DEPLOY_BACKUP_NAME_PATTERN='^[0-9]{8}T[0-9]{6}Z-to-v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
 readonly DURABLE_VOLUMES=(
   osinara-production-google-workspace-credentials
@@ -30,13 +31,20 @@ prune_old_deploy_backups() {
 
   # Reserve one slot before preflight so the newly validated snapshot restores the final count.
   remove_count=$((${#deploy_backups[@]} - PRE_DEPLOY_RETAINED_BACKUP_COUNT))
-  ((remove_count > 0)) || return 0
   for ((index = 0; index < remove_count; index += 1)); do
     name="${deploy_backups[index]##*/}"
     rm -rf -- "${deploy_backups[index]}" ||
       fail "DEPLOY_BACKUP_RETENTION_FAILED" "Could not remove old deploy backup: ${name}"
     log_event "DEPLOY_BACKUP_PRUNED" "Removed old deploy backup: ${name}"
   done
+
+  # The rolling pre-deploy snapshot supersedes the historical bootstrap copy.
+  path="${BACKUPS_DIR}/${LEGACY_INITIAL_MIGRATION_BACKUP_NAME}"
+  if [[ -d "$path" ]]; then
+    rm -rf -- "$path" ||
+      fail "DEPLOY_BACKUP_RETENTION_FAILED" "Could not remove legacy initial migration backup"
+    log_event "DEPLOY_BACKUP_PRUNED" "Removed legacy initial migration backup"
+  fi
 }
 
 ensure_durable_volume() {

--- a/scripts/production-deploy/release.sh
+++ b/scripts/production-deploy/release.sh
@@ -55,7 +55,7 @@ release_image_refs_from_env() {
 prune_retired_release_images() {
   [[ -d "$RELEASES_DIR" ]] || return 0
   local -a release_dirs=()
-  local name path release_count retained_start index ref release_name
+  local name path release_count retained_start index ref release_name release_prunable
   declare -A retained_refs=()
 
   # Release directories are sorted by SemVer so v0.2.10 is newer than v0.2.9.
@@ -74,6 +74,7 @@ prune_retired_release_images() {
 
   for ((index = 0; index < retained_start; index += 1)); do
     release_name="${release_dirs[index]##*/}"
+    release_prunable=1
     while IFS= read -r ref; do
       [[ -n "${retained_refs[$ref]+retained}" ]] && continue
       if docker image inspect "$ref" >/dev/null 2>&1; then
@@ -82,9 +83,15 @@ prune_retired_release_images() {
           log_event "DEPLOY_RELEASE_IMAGE_PRUNED" "Removed retired ${release_name} image reference"
         else
           log_event "DEPLOY_RELEASE_IMAGE_PRUNE_SKIPPED" "Could not remove retired ${release_name} image reference"
+          release_prunable=0
         fi
       fi
     done < <(release_image_refs_from_env "${release_dirs[index]}/release.env")
+    if [[ "$release_prunable" -eq 1 ]]; then
+      rm -rf -- "${release_dirs[index]}" ||
+        fail "DEPLOY_RELEASE_DIRECTORY_PRUNE_FAILED" "Could not remove retired release directory: ${release_name}"
+      log_event "DEPLOY_RELEASE_DIRECTORY_PRUNED" "Removed retired release directory: ${release_name}"
+    fi
   done
 }
 
@@ -212,7 +219,7 @@ validate_resolved_compose_security() {
       .logging.options["max-size"] == "20m" and .logging.options["max-file"] == "5") and
     .services["memory-extraction-worker"].healthcheck.test == [
       "CMD", "node", "-e",
-      "const fs=require(\"node:fs\"),p=\"/tmp/osinara-memory-extraction-worker-ready\";if(!fs.existsSync(p)||Date.now()-fs.statSync(p).mtimeMs<30000)process.exit(1)"
+      "const fs=require(\u0027node:fs\u0027),p=\u0027/tmp/osinara-memory-extraction-worker-ready\u0027;if(!fs.existsSync(p)||Date.now()-fs.statSync(p).mtimeMs<30000)process.exit(1)"
     ] and
     .services["memory-extraction-worker"].healthcheck.retries == 120 and
     any(.services.agent.volumes[];


### PR DESCRIPTION
## Summary
- compare the exact single-quoted worker health command emitted by released Compose
- keep only current and previous local release directories
- replace every old/initial backup with one rolling pre-deploy backup
- publish a fresh immutable v0.11.4 after terminal v0.11.3

## Failure boundary
v0.11.3 stopped with DEPLOY_COMPOSE_SECURITY_INVALID before backup creation, writer shutdown, or migration 057. Production remains on v0.11.2.

## Verification
- production release/deploy contracts: 29 passed
- typecheck passed
- npm audit --omit=dev: 0 vulnerabilities
- exact authored health command is shared by Compose assertion and resolved security fixture