### PR TITLE
Restore personal chats with v0.11.6

### DIFF
--- a/agent/lib/manage-memory-conflict-tool.test.ts
+++ b/agent/lib/manage-memory-conflict-tool.test.ts
@@ -7,6 +7,7 @@
  */
 import type { ToolContext } from "eve/tools";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 
 const { requireApprovalEvidence, resolveConflict } = vi.hoisted(() => ({
   requireApprovalEvidence: vi.fn(),
@@ -34,6 +35,11 @@ describe("manage_memory_conflict", () => {
     requireApprovalEvidence.mockReset();
     requireApprovalEvidence.mockResolvedValue(undefined);
     resolveConflict.mockReset();
+  });
+
+  it("exposes an object-root JSON Schema accepted by the model provider", () => {
+    expect(z.toJSONSchema(manageMemoryConflict.inputSchema as z.ZodType))
+      .toMatchObject({ type: "object" });
   });
 
   it("routes an explicit winner without database IDs", async () => {
@@ -76,6 +82,15 @@ describe("manage_memory_conflict", () => {
     await expect(manageMemoryConflict.execute({
       action: "keep_both",
       conflictRef: "00000000-0000-4000-8000-000000000001",
+    }, context)).rejects.toThrowError(/AGENT_MEMORY_CONFLICT_INPUT_INVALID/u);
+    expect(resolveConflict).not.toHaveBeenCalled();
+  });
+
+  it("rejects a memory ref for non-choose actions", async () => {
+    await expect(manageMemoryConflict.execute({
+      action: "keep_both",
+      conflictRef: CONFLICT_REF,
+      memoryRef: MEMORY_REF,
     }, context)).rejects.toThrowError(/AGENT_MEMORY_CONFLICT_INPUT_INVALID/u);
     expect(resolveConflict).not.toHaveBeenCalled();
   });

--- a/agent/lib/tools/manage_memory_conflict.ts
+++ b/agent/lib/tools/manage_memory_conflict.ts
@@ -13,17 +13,11 @@ import { MEMORY_REF_PATTERN } from "../model-memory.js";
 import { AppError } from "../app-error.js";
 import { requireToolApprovalEvidence } from "../require-tool-approval-evidence.js";
 
-const conflictInputSchema = z.discriminatedUnion("action", [
-  z.object({
-    action: z.literal("choose"),
-    conflictRef: z.string(),
-    memoryRef: z.string(),
-  }).strict(),
-  z.object({
-    action: z.enum(["keep_both", "keep_unresolved"]),
-    conflictRef: z.string(),
-  }).strict(),
-]);
+const conflictInputSchema = z.object({
+  action: z.enum(["choose", "keep_both", "keep_unresolved"]),
+  conflictRef: z.string(),
+  memoryRef: z.string().optional(),
+}).strict();
 const CONFLICT_REF_PATTERN = /^conf_[0-9a-f]{32}$/u;
 
 function invalidInput(): AppError {
@@ -44,14 +38,25 @@ export default defineTool({
   async execute(input, ctx) {
     const parsed = conflictInputSchema.safeParse(input);
     if (!parsed.success || !CONFLICT_REF_PATTERN.test(parsed.data.conflictRef)) throw invalidInput();
-    if (parsed.data.action === "choose" && !MEMORY_REF_PATTERN.test(parsed.data.memoryRef)) {
+    if (
+      parsed.data.action === "choose" &&
+      (parsed.data.memoryRef === undefined || !MEMORY_REF_PATTERN.test(parsed.data.memoryRef))
+    ) {
       throw invalidInput();
     }
+    if (parsed.data.action !== "choose" && parsed.data.memoryRef !== undefined) throw invalidInput();
     // Conflict resolution is consequential even when both claims remain, so bind every action.
     await requireToolApprovalEvidence(ctx, "manage_memory_conflict", input);
-    return await memoryConflictRepository.resolve(requireMemoryAuthorization(ctx), {
-      ...parsed.data,
-      operationKey: ctx.callId,
-    });
+    const resolution = parsed.data.action === "choose"
+      ? {
+          action: parsed.data.action,
+          conflictRef: parsed.data.conflictRef,
+          memoryRef: parsed.data.memoryRef!,
+        }
+      : { action: parsed.data.action, conflictRef: parsed.data.conflictRef };
+    return await memoryConflictRepository.resolve(
+      requireMemoryAuthorization(ctx),
+      { ...resolution, operationKey: ctx.callId },
+    );
   },
 });

--- a/docs/releases/v0.11.6.md
+++ b/docs/releases/v0.11.6.md
@@ -1,0 +1,31 @@
+# Osinara v0.11.6
+
+Срочное исправление личных model turns после успешной установки `v0.11.5`.
+
+## Причина patch-релиза
+
+Tool `manage_memory_conflict` использовал корневой Zod discriminated union. Его JSON Schema содержала
+`oneOf` из object variants, но не имела корневого `type: "object"`. DeepSeek отклонял весь tool list
+до model execution с HTTP `400`:
+
+`Invalid schema for function 'manage_memory_conflict': schema must be a JSON Schema of type object`.
+
+Поскольку tool входит в trusted personal capability surface, ошибка блокировала обычные сообщения в
+личном Telegram-чате даже когда пользователь не просил разрешать конфликт памяти.
+
+## Что исправлено
+
+- Model-facing schema теперь является одним strict object с корневым `type: "object"`.
+- `action` остаётся закрытым enum: `choose`, `keep_both`, `keep_unresolved`.
+- Runtime validation требует `memoryRef` только для `choose` и запрещает его для остальных actions.
+- Opaque ref validation, exact HITL evidence, live authorization и replay-safe repository boundary не
+  изменены.
+- Regression test преобразует реальную Zod schema в JSON Schema и проверяет provider-required root.
+
+## Production
+
+- `v0.11.5` успешно promoted, edge/agent/ingress health доступны и единственный rolling backup
+  сохранён.
+- Memory extraction worker временно остановлен оператором, чтобы фоновые provider diagnostics не
+  мешали восстановлению личного чата; deployment `v0.11.6` запустит его штатно.
+- Release использует существующий exact controller и требует отдельное owner approval.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.11.5",
+      "version": "0.11.6",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- replace the root discriminated union for manage_memory_conflict with a strict object schema accepted by DeepSeek
- preserve action-specific memoryRef validation, opaque refs, HITL, authorization, and replay safety
- release v0.11.6 to restore ordinary personal Telegram turns

## Production incident
v0.11.5 deployed successfully, but DeepSeek rejected the complete personal tool list because manage_memory_conflict had no root JSON Schema type. Extraction worker is temporarily stopped; edge, ingress, and agent remain healthy.

## Verification
- real Zod-to-JSON-Schema root regression
- manage_memory_conflict behavior and tool surface: 11 passed
- typecheck passed
- npm audit --omit=dev: 0 vulnerabilities