### PR TITLE
Scope durable Eve turn identities

### DIFF
--- a/agent/channels/telegram.ts
+++ b/agent/channels/telegram.ts
@@ -85,6 +85,7 @@ export default telegramChannel({
           messageThreadId: channel.telegram.messageThreadId ?? null,
           replyParameters: replyParameters ?? null,
         },
+        eveSessionId: ctx.session.id,
         eveTurnId: ctx.session.turn.id,
         markdown: message,
         sendChunk: (chunk, ordinal) => postTelegramRichMessageChunk(
@@ -178,9 +179,12 @@ export default telegramChannel({
         );
       }
       // A final send that started may already be visible; never append a second failure message.
-       const finalDeliveryMayBeVisible =
-         await telegramFinalDeliveryRepository.shouldSuppressFailureMessage(ctx.session.turn.id);
-       if (!finalDeliveryMayBeVisible) {
+      const finalDeliveryMayBeVisible =
+        await telegramFinalDeliveryRepository.shouldSuppressFailureMessage(
+          ctx.session.id,
+          ctx.session.turn.id,
+        );
+      if (!finalDeliveryMayBeVisible) {
         const replyParameters = isScheduledSession(ctx)
           ? undefined
           : telegramTurnReplyParameters(channel.state, ctx);
@@ -216,6 +220,7 @@ export default telegramChannel({
       if (
         typeof conversationId === "string" &&
         Array.isArray(visibleEntryIds) &&
+        visibleEntryIds.length > 0 &&
         visibleEntryIds.every((value): value is string => typeof value === "string")
       ) {
         const callerTelegramUserId = attributes?.telegramUserId;
@@ -231,6 +236,7 @@ export default telegramChannel({
           callerTelegramUserId,
           conversationId,
           entryIds: visibleEntryIds,
+          eveSessionId: ctx.session.id,
           omittedBeforeSequence:
             typeof attributes?.telegramTimelineOmittedBeforeSequence === "string"
               ? attributes.telegramTimelineOmittedBeforeSequence

--- a/agent/lib/eve-turn-identity-migration.integration.test.ts
+++ b/agent/lib/eve-turn-identity-migration.integration.test.ts
@@ -54,7 +54,8 @@ describeWithDatabase("058 Eve turn identity migration", () => {
       `);
       await client.query(`
         INSERT INTO conversation_sessions (id, eve_session_id) VALUES
-          ('00000000-0000-4000-8000-000000000001', 'wrun_existing');
+          ('00000000-0000-4000-8000-000000000001', 'wrun_existing'),
+          ('00000000-0000-4000-8000-000000000002', 'wrun_second');
         INSERT INTO memory_extraction_batches
           (id, conversation_id, application_session_id, turn_id, extractor_version, schema_version)
         VALUES
@@ -82,7 +83,7 @@ describeWithDatabase("058 Eve turn identity migration", () => {
             turn_id, extractor_version, schema_version)
          VALUES ('00000000-0000-4000-8000-000000000013',
                  '00000000-0000-4000-8000-000000000021',
-                 '00000000-0000-4000-8000-000000000001', 'turn', 'wrun_second',
+                 '00000000-0000-4000-8000-000000000002', 'turn', 'wrun_second',
                  'turn_0', 'extractor-v1', 'schema-v1')`,
       )).resolves.toHaveProperty("rowCount", 1);
       await expect(client.query(
@@ -91,7 +92,7 @@ describeWithDatabase("058 Eve turn identity migration", () => {
             turn_id, extractor_version, schema_version)
          VALUES ('00000000-0000-4000-8000-000000000014',
                  '00000000-0000-4000-8000-000000000021',
-                 '00000000-0000-4000-8000-000000000001', 'turn', 'wrun_second',
+                 '00000000-0000-4000-8000-000000000002', 'turn', 'wrun_second',
                  'turn_0', 'extractor-v1', 'schema-v1')`,
       )).rejects.toMatchObject({ code: "23505" });
 
@@ -103,13 +104,13 @@ describeWithDatabase("058 Eve turn identity migration", () => {
         `INSERT INTO telegram_final_deliveries
            (id, eve_session_id, eve_turn_id, application_session_id)
          VALUES ('00000000-0000-4000-8000-000000000032', 'wrun_second', 'turn_0',
-                 '00000000-0000-4000-8000-000000000001')`,
+                 '00000000-0000-4000-8000-000000000002')`,
       )).resolves.toHaveProperty("rowCount", 1);
       await expect(client.query(
         `INSERT INTO telegram_final_deliveries
            (id, eve_session_id, eve_turn_id, application_session_id)
          VALUES ('00000000-0000-4000-8000-000000000033', 'wrun_second', 'turn_0',
-                 '00000000-0000-4000-8000-000000000001')`,
+                 '00000000-0000-4000-8000-000000000002')`,
       )).rejects.toMatchObject({ code: "23505" });
     } finally {
       await client.query("RESET search_path");

--- a/agent/lib/eve-turn-identity-migration.integration.test.ts
+++ b/agent/lib/eve-turn-identity-migration.integration.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Eve execution identity migration integration tests.
+ *
+ * Constructs covered:
+ * - Existing turn-owned rows receive their verified Eve session identity.
+ * - Catch-up extraction rows remain explicitly sessionless.
+ * - Repeated Eve turn ids are isolated between framework sessions.
+ */
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { closeDatabase, database } from "./database.js";
+
+const describeWithDatabase = process.env.RUN_DATABASE_INTEGRATION_TESTS === "true"
+  ? describe
+  : describe.skip;
+const TEST_SCHEMA = "test_eve_turn_identity_migration";
+const MIGRATION_NAME = "058_scope_eve_turn_identity.sql";
+
+describeWithDatabase("058 Eve turn identity migration", () => {
+  afterAll(closeDatabase);
+
+  it("backfills persisted rows and scopes repeated turn ids by Eve session", async () => {
+    const client = await database().connect();
+    try {
+      await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+      await client.query(`CREATE SCHEMA ${TEST_SCHEMA}`);
+      await client.query(`SET search_path TO ${TEST_SCHEMA}, public`);
+
+      // This exact pre-058 surface keeps the migration test independent from later application code.
+      await client.query(`
+        CREATE TABLE conversation_sessions (
+          id uuid PRIMARY KEY,
+          eve_session_id text
+        );
+        CREATE TABLE memory_extraction_batches (
+          id uuid PRIMARY KEY,
+          conversation_id uuid NOT NULL,
+          application_session_id uuid,
+          turn_id text NOT NULL,
+          extractor_version text NOT NULL,
+          schema_version text NOT NULL,
+          CONSTRAINT memory_extraction_batches_conversation_id_turn_id_extractor_key
+            UNIQUE (conversation_id, turn_id, extractor_version, schema_version)
+        );
+        CREATE TABLE telegram_final_deliveries (
+          id uuid PRIMARY KEY,
+          eve_turn_id text NOT NULL,
+          application_session_id uuid,
+          CONSTRAINT telegram_final_deliveries_eve_turn_id_key UNIQUE (eve_turn_id)
+        );
+      `);
+      await client.query(`
+        INSERT INTO conversation_sessions (id, eve_session_id) VALUES
+          ('00000000-0000-4000-8000-000000000001', 'wrun_existing');
+        INSERT INTO memory_extraction_batches
+          (id, conversation_id, application_session_id, turn_id, extractor_version, schema_version)
+        VALUES
+          ('00000000-0000-4000-8000-000000000011', '00000000-0000-4000-8000-000000000021',
+           '00000000-0000-4000-8000-000000000001', 'turn_0', 'extractor-v1', 'schema-v1'),
+          ('00000000-0000-4000-8000-000000000012', '00000000-0000-4000-8000-000000000021',
+           NULL, 'catchup:2:2', 'extractor-v1', 'schema-v1');
+        INSERT INTO telegram_final_deliveries (id, eve_turn_id, application_session_id)
+        VALUES ('00000000-0000-4000-8000-000000000031', 'turn_0',
+                '00000000-0000-4000-8000-000000000001');
+      `);
+
+      await client.query(await readFile(resolve("migrations", MIGRATION_NAME), "utf8"));
+
+      const batches = await client.query<{ eve_session_id: string | null; turn_id: string }>(
+        `SELECT turn_id, eve_session_id FROM memory_extraction_batches ORDER BY turn_id`,
+      );
+      expect(batches.rows).toEqual([
+        { eve_session_id: null, turn_id: "catchup:2:2" },
+        { eve_session_id: "wrun_existing", turn_id: "turn_0" },
+      ]);
+      await expect(client.query(
+        `INSERT INTO memory_extraction_batches
+           (id, conversation_id, application_session_id, batch_kind, eve_session_id,
+            turn_id, extractor_version, schema_version)
+         VALUES ('00000000-0000-4000-8000-000000000013',
+                 '00000000-0000-4000-8000-000000000021',
+                 '00000000-0000-4000-8000-000000000001', 'turn', 'wrun_second',
+                 'turn_0', 'extractor-v1', 'schema-v1')`,
+      )).resolves.toHaveProperty("rowCount", 1);
+      await expect(client.query(
+        `INSERT INTO memory_extraction_batches
+           (id, conversation_id, application_session_id, batch_kind, eve_session_id,
+            turn_id, extractor_version, schema_version)
+         VALUES ('00000000-0000-4000-8000-000000000014',
+                 '00000000-0000-4000-8000-000000000021',
+                 '00000000-0000-4000-8000-000000000001', 'turn', 'wrun_second',
+                 'turn_0', 'extractor-v1', 'schema-v1')`,
+      )).rejects.toMatchObject({ code: "23505" });
+
+      const delivery = await client.query<{ eve_session_id: string }>(
+        "SELECT eve_session_id FROM telegram_final_deliveries WHERE eve_turn_id = 'turn_0'",
+      );
+      expect(delivery.rows).toEqual([{ eve_session_id: "wrun_existing" }]);
+      await expect(client.query(
+        `INSERT INTO telegram_final_deliveries
+           (id, eve_session_id, eve_turn_id, application_session_id)
+         VALUES ('00000000-0000-4000-8000-000000000032', 'wrun_second', 'turn_0',
+                 '00000000-0000-4000-8000-000000000001')`,
+      )).resolves.toHaveProperty("rowCount", 1);
+      await expect(client.query(
+        `INSERT INTO telegram_final_deliveries
+           (id, eve_session_id, eve_turn_id, application_session_id)
+         VALUES ('00000000-0000-4000-8000-000000000033', 'wrun_second', 'turn_0',
+                 '00000000-0000-4000-8000-000000000001')`,
+      )).rejects.toMatchObject({ code: "23505" });
+    } finally {
+      await client.query("RESET search_path");
+      await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+      client.release();
+    }
+  });
+});

--- a/agent/lib/memory-extraction-batch-coordinator.ts
+++ b/agent/lib/memory-extraction-batch-coordinator.ts
@@ -53,6 +53,7 @@ async function createExactBatch(input: {
   callerTelegramUserId: string | null;
   conversationId: string;
   entryIds: readonly string[];
+  eveSessionId: string | null;
   omittedBeforeSequence: string | null;
   skipCoveredEntries: boolean;
   turnId: string;
@@ -86,9 +87,20 @@ async function createExactBatch(input: {
     timelineEntryIds: rows.map((row) => row.id),
     turnId: input.turnId,
   };
-  return input.skipCoveredEntries
-    ? await memoryExtractionRepository.createTurnBatch(batchInput)
-    : await memoryExtractionRepository.createRecoveryBatch(batchInput);
+  if (!input.skipCoveredEntries) {
+    return await memoryExtractionRepository.createRecoveryBatch(batchInput);
+  }
+  if (input.applicationSessionId === null || input.eveSessionId === null) {
+    throw new AppError(
+      "AGENT_MEMORY_EXTRACTION_SESSION_BOUNDARY_INVALID",
+      "Turn-пакет извлечения не связан с текущей сессией Eve",
+    );
+  }
+  return await memoryExtractionRepository.createTurnBatch({
+    ...batchInput,
+    applicationSessionId: input.applicationSessionId,
+    eveSessionId: input.eveSessionId,
+  });
 }
 
 export async function createTurnExtractionBatch(input: {
@@ -96,6 +108,7 @@ export async function createTurnExtractionBatch(input: {
   callerTelegramUserId: string;
   conversationId: string;
   entryIds: readonly string[];
+  eveSessionId: string;
   omittedBeforeSequence: string | null;
   turnId: string;
 }): Promise<MemoryExtractionBatch | null> {
@@ -181,6 +194,7 @@ export async function createCatchUpExtractionBatches(): Promise<number> {
         callerTelegramUserId: null,
         conversationId: conversation.id,
         entryIds: rows.map((row) => row.id),
+        eveSessionId: null,
         omittedBeforeSequence: null,
         skipCoveredEntries: false,
         turnId: `catchup:${rows[0]!.sequence_id}:${rows.at(-1)!.sequence_id}`,

--- a/agent/lib/memory-extraction-batch-repository.ts
+++ b/agent/lib/memory-extraction-batch-repository.ts
@@ -11,6 +11,7 @@ import {
   loadExtractionBatch,
   requireExtractionBigint,
   type CreateMemoryExtractionBatchInput,
+  type CreateTurnMemoryExtractionBatchInput,
   type MemoryExtractionBatch,
 } from "./memory-extraction-contract.js";
 import {
@@ -37,8 +38,12 @@ interface TimelineSnapshotRow {
 }
 
 type CoverageMode = "reject" | "skip";
+type PersistedMemoryExtractionBatchInput = CreateMemoryExtractionBatchInput & {
+  batchKind: "catchup" | "turn";
+  eveSessionId: string | null;
+};
 
-function validateBatchInput(input: CreateMemoryExtractionBatchInput): {
+function validateBatchInput(input: PersistedMemoryExtractionBatchInput): {
   entryIds: string[];
   messageThreadId: string | null;
 } {
@@ -59,7 +64,11 @@ function validateBatchInput(input: CreateMemoryExtractionBatchInput): {
     !input.schemaVersion.trim() ||
     input.extractorVersion.length > MEMORY_EXTRACTION_VERSION_MAX_CHARACTERS ||
     input.schemaVersion.length > MEMORY_EXTRACTION_VERSION_MAX_CHARACTERS ||
-    !input.turnId.trim()
+    !input.turnId.trim() ||
+    (input.batchKind === "turn" &&
+      (input.applicationSessionId === null || input.eveSessionId === null || !input.eveSessionId.trim())) ||
+    (input.batchKind === "catchup" &&
+      (input.applicationSessionId !== null || input.eveSessionId !== null))
   ) {
     throw new AppError(
       "AGENT_MEMORY_EXTRACTION_BATCH_INVALID",
@@ -88,7 +97,7 @@ function snapshotPayload(entries: readonly TimelineSnapshotRow[]): unknown[] {
 }
 
 function requestIdentityHash(
-  input: CreateMemoryExtractionBatchInput,
+  input: PersistedMemoryExtractionBatchInput,
   entryIds: readonly string[],
   messageThreadId: string | null,
 ): string {
@@ -104,7 +113,7 @@ function requestIdentityHash(
 }
 
 async function createBatch(
-  input: CreateMemoryExtractionBatchInput,
+  input: PersistedMemoryExtractionBatchInput,
   coverageMode: CoverageMode,
 ): Promise<MemoryExtractionBatch | null> {
   const { entryIds, messageThreadId } = validateBatchInput(input);
@@ -123,9 +132,11 @@ async function createBatch(
       request_identity_hash: string;
     }>(
       `SELECT id, request_identity_hash FROM memory_extraction_batches
-       WHERE conversation_id = $1 AND turn_id = $2
-         AND extractor_version = $3 AND schema_version = $4`,
-      [input.conversationId, input.turnId, input.extractorVersion, input.schemaVersion],
+       WHERE conversation_id = $1 AND batch_kind = $2
+         AND eve_session_id IS NOT DISTINCT FROM $3 AND turn_id = $4
+         AND extractor_version = $5 AND schema_version = $6`,
+      [input.conversationId, input.batchKind, input.eveSessionId, input.turnId,
+        input.extractorVersion, input.schemaVersion],
     );
     if (replay.rows[0]) {
       const stored = replay.rows[0];
@@ -313,13 +324,13 @@ async function createBatch(
     const inserted = await client.query<{ id: string }>(
       `INSERT INTO memory_extraction_batches
          (conversation_id, family_id, scope, scope_partition_key, application_session_id,
-          caller_user_id, caller_telegram_user_id, turn_id, extractor_version, schema_version,
-          request_identity_hash, input_payload_hash)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12) RETURNING id`,
+          batch_kind, eve_session_id, caller_user_id, caller_telegram_user_id, turn_id,
+          extractor_version, schema_version, request_identity_hash, input_payload_hash)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) RETURNING id`,
       [input.conversationId, conversation.family_id, conversation.scope,
-        conversation.scope_partition_key, input.applicationSessionId, callerUserId,
-        input.callerTelegramUserId, input.turnId, input.extractorVersion, input.schemaVersion,
-        identityHash, inputPayloadHash],
+        conversation.scope_partition_key, input.applicationSessionId, input.batchKind,
+        input.eveSessionId, callerUserId, input.callerTelegramUserId, input.turnId,
+        input.extractorVersion, input.schemaVersion, identityHash, inputPayloadHash],
     );
     const batchId = inserted.rows[0]!.id;
     const coverage = await client.query(
@@ -389,7 +400,7 @@ export const memoryExtractionBatchRepository = {
   },
 
   async createBatch(input: CreateMemoryExtractionBatchInput): Promise<MemoryExtractionBatch> {
-    const batch = await createBatch(input, "reject");
+    const batch = await createBatch({ ...input, batchKind: "catchup", eveSessionId: null }, "reject");
     if (!batch) {
       throw new AppError(
         "AGENT_MEMORY_EXTRACTION_BATCH_CREATE_FAILED",
@@ -402,10 +413,12 @@ export const memoryExtractionBatchRepository = {
   async createRecoveryBatch(
     input: CreateMemoryExtractionBatchInput,
   ): Promise<MemoryExtractionBatch | null> {
-    return await createBatch(input, "reject");
+    return await createBatch({ ...input, batchKind: "catchup", eveSessionId: null }, "reject");
   },
 
-  async createTurnBatch(input: CreateMemoryExtractionBatchInput): Promise<MemoryExtractionBatch | null> {
-    return await createBatch(input, "skip");
+  async createTurnBatch(
+    input: CreateTurnMemoryExtractionBatchInput,
+  ): Promise<MemoryExtractionBatch | null> {
+    return await createBatch({ ...input, batchKind: "turn" }, "skip");
   },
 };

--- a/agent/lib/memory-extraction-contract.ts
+++ b/agent/lib/memory-extraction-contract.ts
@@ -71,6 +71,12 @@ export interface CreateMemoryExtractionBatchInput {
   turnId: string;
 }
 
+export interface CreateTurnMemoryExtractionBatchInput
+  extends CreateMemoryExtractionBatchInput {
+  applicationSessionId: string;
+  eveSessionId: string;
+}
+
 export interface CompleteMemoryExtractionInput {
   decisions: readonly MemorySemanticDecision[];
   diagnosticCode: string | null;

--- a/agent/lib/memory-upgrade-ledger.integration.test.ts
+++ b/agent/lib/memory-upgrade-ledger.integration.test.ts
@@ -3,7 +3,7 @@
  *
  * Key constructs:
  * - `V0101_LEDGER`: exact production v0.10.1 migration names through release number 048.
- * - `MEMORY_RELEASE_MIGRATIONS`: the only memory migrations applied after the v0.10.1 ledger.
+ * - `MEMORY_RELEASE_MIGRATIONS`: memory migrations and their reliability repair after v0.10.1.
  * - `runMigrationRunner`: executes the real migration entrypoint against an isolated test schema.
  * - Upgrade scenario: verifies ledger delta, unique migration purposes, and representative R0-R7 DB objects.
  */
@@ -84,6 +84,7 @@ const MEMORY_RELEASE_MIGRATIONS = [
   "055_memory_reliability_barriers.sql",
   "056_profile_projection_notice_delivery.sql",
   "057_repair_memory_extraction_sequence_ranges.sql",
+  "058_scope_eve_turn_identity.sql",
 ] as const;
 
 const EXPECTED_R0_R7_TABLES = [
@@ -132,7 +133,7 @@ async function runMigrationRunner(): Promise<void> {
   );
 }
 
-describeWithDatabase("v0.10.1 production ledger upgrade to memory migrations 049-057", () => {
+describeWithDatabase("v0.10.1 production ledger upgrade to memory migrations 049-058", () => {
   afterAll(closeDatabase);
 
   it("applies only the renumbered memory release once and creates the R0-R7 schema", async () => {
@@ -176,7 +177,7 @@ describeWithDatabase("v0.10.1 production ledger upgrade to memory migrations 049
 
       await runMigrationRunner();
 
-      // The ledger delta proves the real runner skipped all shipped migrations and applied 049-057 once.
+      // The ledger delta proves the real runner skipped all shipped migrations and applied 049-058 once.
       const after = await client.query<{ name: string }>(
         "SELECT name FROM schema_migrations ORDER BY name",
       );

--- a/agent/lib/r2b-unified-timeline-extraction.integration.test.ts
+++ b/agent/lib/r2b-unified-timeline-extraction.integration.test.ts
@@ -19,6 +19,7 @@ import { processMemoryExtractionCandidates } from "./memory-extraction-candidate
 import { memoryApprovalNoticeRepository } from "./memory-approval-notice-repository.js";
 import { memoryExtractionRepository } from "./memory-extraction-repository.js";
 import { memorySensitiveApprovalRepository } from "./memory-sensitive-approval-repository.js";
+import { telegramFinalDeliveryRepository } from "./telegram-final-delivery-repository.js";
 import {
   completeExtractionBatch as completeBatch,
   createExtractionFamily as createFamily,
@@ -36,7 +37,7 @@ const describeWithDatabase = process.env.RUN_DATABASE_INTEGRATION_TESTS === "tru
 describeWithDatabase("R2b unified timeline and extraction", () => {
   beforeEach(async () => {
     await database().query(
-      `TRUNCATE memory_extraction_batches, claim_evidence, memory_items,
+      `TRUNCATE telegram_final_deliveries, memory_extraction_batches, claim_evidence, memory_items,
          telegram_group_messages, telegram_groups, family_memberships, users, families CASCADE`,
     );
   });
@@ -177,6 +178,7 @@ describeWithDatabase("R2b unified timeline and extraction", () => {
       callerTelegramUserId: "2",
       conversationId: conversation.id,
       entryIds,
+      eveSessionId: "wrun_catch_up_race",
       omittedBeforeSequence: null,
       turnId: "catch-up-first-turn",
     })).resolves.toBeNull();
@@ -224,6 +226,7 @@ describeWithDatabase("R2b unified timeline and extraction", () => {
       callerTelegramUserId: "2",
       conversationId: conversation.id,
       entryIds,
+      eveSessionId: "wrun_partial_race",
       omittedBeforeSequence: null,
       turnId: "partial-race-turn",
     });
@@ -233,6 +236,7 @@ describeWithDatabase("R2b unified timeline and extraction", () => {
       callerTelegramUserId: "2",
       conversationId: conversation.id,
       entryIds,
+      eveSessionId: "wrun_partial_race",
       omittedBeforeSequence: null,
       turnId: "partial-race-turn",
     })).resolves.toEqual(turnBatch);
@@ -240,6 +244,84 @@ describeWithDatabase("R2b unified timeline and extraction", () => {
       "SELECT 1 FROM memory_extraction_entry_coverage WHERE conversation_id = $1",
       [conversation.id],
     )).resolves.toMatchObject({ rowCount: 2 });
+  });
+
+  it("isolates repeated Eve turn ids by Eve session", async () => {
+    const familyId = await createFamily("Eve turn identity");
+    const groupId = await createGroup({ familyId, idSuffix: "7205", type: "external" });
+    const entryIds = [
+      await insertEntry({ content: "Первая сессия", groupId, messageId: 1, sequence: 1, telegramUserId: "1", userName: "Анна" }),
+      await insertEntry({ content: "Вторая сессия", groupId, messageId: 2, sequence: 2, telegramUserId: "2", userName: "Пётр" }),
+    ];
+    const conversation = await conversationRepository.getByGroupId(groupId);
+    const session = await sessionRepository.prepareTurn({
+      baseContinuationToken: `eve-turn-identity:${groupId}`,
+      familyId,
+      groupId,
+      kind: "canonical",
+      now: new Date(),
+      scope: "group",
+      telegramForumTopicId: null,
+      userId: null,
+    });
+
+    // Eve turn ids restart from zero in each framework session and must not collide durably.
+    await expect(createTurnExtractionBatch({
+      applicationSessionId: session.id,
+      callerTelegramUserId: "1",
+      conversationId: conversation.id,
+      entryIds: [entryIds[0]!],
+      eveSessionId: "wrun_extraction_a",
+      omittedBeforeSequence: null,
+      turnId: "turn_0",
+    })).resolves.not.toBeNull();
+    await expect(createTurnExtractionBatch({
+      applicationSessionId: session.id,
+      callerTelegramUserId: "2",
+      conversationId: conversation.id,
+      entryIds: [entryIds[1]!],
+      eveSessionId: "wrun_extraction_b",
+      omittedBeforeSequence: null,
+      turnId: "turn_0",
+    })).resolves.not.toBeNull();
+
+    await expect(database().query<{ eve_session_id: string }>(
+      `SELECT eve_session_id FROM memory_extraction_batches
+       WHERE conversation_id = $1 ORDER BY eve_session_id`,
+      [conversation.id],
+    )).resolves.toMatchObject({
+      rows: [
+        { eve_session_id: "wrun_extraction_a" },
+        { eve_session_id: "wrun_extraction_b" },
+      ],
+    });
+
+    // The same framework identity also scopes Telegram's no-resend barrier between conversations.
+    const firstDelivery = await telegramFinalDeliveryRepository.start({
+      applicationSessionId: session.id,
+      chunkCount: 1,
+      eveSessionId: "wrun_delivery_a",
+      eveTurnId: "turn_0",
+      outputHash: "a".repeat(64),
+    });
+    const secondDelivery = await telegramFinalDeliveryRepository.start({
+      applicationSessionId: session.id,
+      chunkCount: 1,
+      eveSessionId: "wrun_delivery_b",
+      eveTurnId: "turn_0",
+      outputHash: "b".repeat(64),
+    });
+    expect(firstDelivery.status).toBe("started");
+    expect(secondDelivery.status).toBe("started");
+    await expect(database().query<{ eve_session_id: string }>(
+      `SELECT eve_session_id FROM telegram_final_deliveries
+       WHERE eve_turn_id = 'turn_0' ORDER BY eve_session_id`,
+    )).resolves.toMatchObject({
+      rows: [
+        { eve_session_id: "wrun_delivery_a" },
+        { eve_session_id: "wrun_delivery_b" },
+      ],
+    });
   });
 
   it("attributes Anna when Petr triggers and keeps private extraction personal", async () => {

--- a/agent/lib/telegram-channel-draft-policy.test.ts
+++ b/agent/lib/telegram-channel-draft-policy.test.ts
@@ -46,4 +46,12 @@ describe("Telegram channel draft policy", () => {
     expect(snapshot).toBeLessThan(turnCompleted);
     expect(source.indexOf("await createTurnExtractionBatch(", turnCompleted)).toBe(-1);
   });
+
+  it("skips extraction when the durable timeline projection is empty", async () => {
+    const source = await readFile(TELEGRAM_CHANNEL_PATH, "utf8");
+    const turnStarted = source.indexOf('async "turn.started"');
+    const turnCompleted = source.indexOf('async "turn.completed"');
+
+    expect(source.slice(turnStarted, turnCompleted)).toContain("visibleEntryIds.length > 0");
+  });
 });

--- a/agent/lib/telegram-final-delivery-repository.test.ts
+++ b/agent/lib/telegram-final-delivery-repository.test.ts
@@ -28,15 +28,22 @@ describe("Telegram final-delivery failure suppression", () => {
     query.mockResolvedValue({ rows: [{ status }] });
 
     await expect(
-      telegramFinalDeliveryRepository.shouldSuppressFailureMessage("turn-1"),
+      telegramFinalDeliveryRepository.shouldSuppressFailureMessage("wrun-session-1", "turn-1"),
     ).resolves.toBe(expected);
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("eve_session_id = $1 AND eve_turn_id = $2"),
+      ["wrun-session-1", "turn-1"],
+    );
   });
 
   it("does not suppress failure when no final-delivery intent exists", async () => {
     query.mockResolvedValue({ rows: [] });
 
     await expect(
-      telegramFinalDeliveryRepository.shouldSuppressFailureMessage("turn-missing"),
+      telegramFinalDeliveryRepository.shouldSuppressFailureMessage(
+        "wrun-session-missing",
+        "turn-missing",
+      ),
     ).resolves.toBe(false);
   });
 });

--- a/agent/lib/telegram-final-delivery-repository.ts
+++ b/agent/lib/telegram-final-delivery-repository.ts
@@ -18,6 +18,7 @@ export const telegramFinalDeliveryRepository = {
   async start(input: {
     applicationSessionId: string;
     chunkCount: number;
+    eveSessionId: string;
     eveTurnId: string;
     outputHash: string;
   }): Promise<TelegramFinalDeliveryStart> {
@@ -26,9 +27,10 @@ export const telegramFinalDeliveryRepository = {
       await client.query("BEGIN");
       await client.query(
         `INSERT INTO telegram_final_deliveries
-           (eve_turn_id, application_session_id, output_hash, expected_chunk_count)
-         VALUES ($1, $2, $3, $4) ON CONFLICT (eve_turn_id) DO NOTHING`,
-        [input.eveTurnId, input.applicationSessionId, input.outputHash, input.chunkCount],
+           (eve_session_id, eve_turn_id, application_session_id, output_hash, expected_chunk_count)
+         VALUES ($1, $2, $3, $4, $5) ON CONFLICT (eve_session_id, eve_turn_id) DO NOTHING`,
+        [input.eveSessionId, input.eveTurnId, input.applicationSessionId,
+          input.outputHash, input.chunkCount],
       );
       const current = await client.query<{
         diagnostic_code: string | null;
@@ -38,8 +40,9 @@ export const telegramFinalDeliveryRepository = {
         status: "ambiguous" | "delivered" | "failed" | "pending" | "started";
       }>(
         `SELECT id, output_hash, expected_chunk_count, status, diagnostic_code
-         FROM telegram_final_deliveries WHERE eve_turn_id = $1 FOR UPDATE`,
-        [input.eveTurnId],
+         FROM telegram_final_deliveries
+         WHERE eve_session_id = $1 AND eve_turn_id = $2 FOR UPDATE`,
+        [input.eveSessionId, input.eveTurnId],
       );
       const delivery = current.rows[0]!;
       if (delivery.output_hash !== input.outputHash || delivery.expected_chunk_count !== input.chunkCount) {
@@ -164,10 +167,11 @@ export const telegramFinalDeliveryRepository = {
     );
   },
 
-  async shouldSuppressFailureMessage(eveTurnId: string): Promise<boolean> {
+  async shouldSuppressFailureMessage(eveSessionId: string, eveTurnId: string): Promise<boolean> {
     const result = await database().query<{ status: string }>(
-      "SELECT status FROM telegram_final_deliveries WHERE eve_turn_id = $1",
-      [eveTurnId],
+      `SELECT status FROM telegram_final_deliveries
+       WHERE eve_session_id = $1 AND eve_turn_id = $2`,
+      [eveSessionId, eveTurnId],
     );
     const status = result.rows[0]?.status;
     return status === "started" || status === "delivered" || status === "ambiguous";

--- a/agent/lib/telegram-final-delivery.test.ts
+++ b/agent/lib/telegram-final-delivery.test.ts
@@ -24,6 +24,7 @@ import { deliverTelegramFinalOutput } from "./telegram-final-delivery.js";
 const base = {
   applicationSessionId: "00000000-0000-4000-8000-000000000001",
   deliveryIdentity: { chatId: "101" },
+  eveSessionId: "wrun_session_1",
   eveTurnId: "turn-1",
   markdown: "Готово",
 };
@@ -41,6 +42,13 @@ describe("Telegram final delivery", () => {
     await expect(deliverTelegramFinalOutput({ ...base, sendChunk })).resolves.toEqual([
       { chatType: "private", messageId: "501" },
     ]);
+    expect(repository.start).toHaveBeenCalledWith({
+      applicationSessionId: base.applicationSessionId,
+      chunkCount: 1,
+      eveSessionId: base.eveSessionId,
+      eveTurnId: base.eveTurnId,
+      outputHash: expect.any(String),
+    });
     expect(sendChunk).not.toHaveBeenCalled();
   });
 

--- a/agent/lib/telegram-final-delivery.ts
+++ b/agent/lib/telegram-final-delivery.ts
@@ -25,6 +25,7 @@ function terminalDeliveryError(code: string): AppError {
 export async function deliverTelegramFinalOutput(input: {
   applicationSessionId: string;
   deliveryIdentity: unknown;
+  eveSessionId: string;
   eveTurnId: string;
   markdown: string;
   sendChunk(chunk: string, ordinal: number): Promise<SentTelegramMessage>;
@@ -37,6 +38,7 @@ export async function deliverTelegramFinalOutput(input: {
   const start = await telegramFinalDeliveryRepository.start({
     applicationSessionId: input.applicationSessionId,
     chunkCount: chunks.length,
+    eveSessionId: input.eveSessionId,
     eveTurnId: input.eveTurnId,
     outputHash,
   });

--- a/docs/releases/v0.11.7.md
+++ b/docs/releases/v0.11.7.md
@@ -1,0 +1,45 @@
+# Osinara v0.11.7
+
+Срочное исправление доставки Telegram и извлечения памяти после установки `v0.11.6`.
+
+## Причина patch-релиза
+
+Eve начинает нумерацию ходов заново в каждой framework session, поэтому значения `turn_0`,
+`turn_1` и следующие не являются глобально уникальными. Osinara ошибочно использовала один
+`eve_turn_id` как глобальный ключ durable Telegram delivery. Ответы группы «Остриков пилит агентов»
+столкнулись с уже сохранёнными ключами личной session: модель завершила ход, ingress был отмечен
+завершённым, но финальный ответ не отправился из-за
+`AGENT_TELEGRAM_FINAL_DELIVERY_REPLAY_MISMATCH`.
+
+Та же неполная identity использовалась для turn-owned memory extraction batches внутри разговора и
+могла вызвать ложный `AGENT_MEMORY_EXTRACTION_REPLAY_MISMATCH` после ротации Eve session.
+
+## Что исправлено
+
+- Durable execution identity теперь состоит из `(eve_session_id, eve_turn_id)`.
+- Telegram delivery repository использует composite identity для intent, replay и failure-message
+  suppression.
+- Turn-owned extraction batches отделены от sessionless catch-up batches явным `batch_kind`.
+- Migration `058_scope_eve_turn_identity.sql` backfill-ит `eve_session_id` только через проверенную
+  связь с `conversation_sessions` и останавливается с диагностикой при недоказанной строке.
+- Старые global unique constraints заменены отдельными session-scoped и catch-up identities.
+- Пустая timeline projection при восстановлении старого Eve run больше не создаёт некорректный
+  extraction batch.
+
+## Проверка
+
+- Production preflight не обнаружил extraction batches или Telegram deliveries без доказуемой Eve
+  session для backfill.
+- Migration integration test проверяет backfill, разрешённый одинаковый `turn_0` в разных sessions и
+  запрет дубля внутри одной session.
+- Repository integration test проводит одинаковый `turn_0` двух Eve sessions через реальный
+  extraction и Telegram delivery persistence.
+- Полный Docker Compose gate: `244` test files passed, `1270` tests passed, `1` skipped; typecheck и
+  `eve build` завершились успешно.
+
+## Production
+
+- Release использует существующий exact deployment controller, один rolling backup и отдельное owner
+  approval.
+- После deployment новый turn в группе должен создать delivery под текущей Eve session, не конфликтуя
+  с историческими личными turn ids.

--- a/migrations/058_scope_eve_turn_identity.sql
+++ b/migrations/058_scope_eve_turn_identity.sql
@@ -1,0 +1,75 @@
+-- Eve turn ids restart inside each framework session. Backfill the stable session component from
+-- the application session before replacing the incorrect globally unique turn-only identities.
+ALTER TABLE memory_extraction_batches
+  ADD COLUMN batch_kind text,
+  ADD COLUMN eve_session_id text CHECK (
+    eve_session_id IS NULL OR char_length(eve_session_id) > 0
+  );
+
+UPDATE memory_extraction_batches AS batch
+SET batch_kind = CASE
+      WHEN batch.application_session_id IS NULL THEN 'catchup'
+      ELSE 'turn'
+    END,
+    eve_session_id = session.eve_session_id
+FROM conversation_sessions AS session
+WHERE session.id = batch.application_session_id;
+
+UPDATE memory_extraction_batches
+SET batch_kind = 'catchup'
+WHERE application_session_id IS NULL;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM memory_extraction_batches
+    WHERE batch_kind IS NULL OR (batch_kind = 'turn' AND eve_session_id IS NULL)
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'AGENT_EVE_TURN_IDENTITY_BACKFILL_FAILED: Extraction batch has no verified Eve session';
+  END IF;
+END
+$$;
+
+ALTER TABLE memory_extraction_batches
+  ALTER COLUMN batch_kind SET NOT NULL,
+  ADD CONSTRAINT memory_extraction_batches_execution_shape CHECK (
+    (batch_kind = 'turn' AND eve_session_id IS NOT NULL) OR
+    (batch_kind = 'catchup' AND application_session_id IS NULL AND eve_session_id IS NULL)
+  ),
+  DROP CONSTRAINT memory_extraction_batches_conversation_id_turn_id_extractor_key;
+
+CREATE UNIQUE INDEX memory_extraction_batches_turn_identity
+  ON memory_extraction_batches
+    (conversation_id, eve_session_id, turn_id, extractor_version, schema_version)
+  WHERE batch_kind = 'turn';
+
+CREATE UNIQUE INDEX memory_extraction_batches_catchup_identity
+  ON memory_extraction_batches
+    (conversation_id, turn_id, extractor_version, schema_version)
+  WHERE batch_kind = 'catchup';
+
+ALTER TABLE telegram_final_deliveries
+  ADD COLUMN eve_session_id text CHECK (char_length(eve_session_id) > 0);
+
+UPDATE telegram_final_deliveries AS delivery
+SET eve_session_id = session.eve_session_id
+FROM conversation_sessions AS session
+WHERE session.id = delivery.application_session_id;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM telegram_final_deliveries WHERE eve_session_id IS NULL) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'AGENT_EVE_TURN_IDENTITY_BACKFILL_FAILED: Telegram delivery has no verified Eve session';
+  END IF;
+END
+$$;
+
+ALTER TABLE telegram_final_deliveries
+  ALTER COLUMN eve_session_id SET NOT NULL,
+  DROP CONSTRAINT telegram_final_deliveries_eve_turn_id_key,
+  ADD CONSTRAINT telegram_final_deliveries_eve_session_turn_key
+    UNIQUE (eve_session_id, eve_turn_id);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.11.6",
+      "version": "0.11.7",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- scope Telegram final-delivery replay keys by Eve session and turn
- separate turn-owned extraction batches from sessionless catch-up batches
- backfill persisted execution identities with migration 058 and skip empty recovered timeline projections

## Production evidence
- group session wrun_01KZGXAHD7KD5JXCXVDHFDWVQ8 reused turn_0 and turn_1 already occupied by personal session wrun_01KZGX7QEZSPKHZKJPTN62CXQP
- production preflight found zero extraction batches and zero deliveries without a provable conversation_sessions binding

## Verification
- docker compose -f compose.test.yaml up --build --abort-on-container-exit --exit-code-from tests
- 244 test files passed, 1270 tests passed, 1 skipped
- npm run typecheck
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Идентичность Telegram-доставки теперь определяется парой `eveSessionId` и `eveTurnId`.
- Ключи повторной доставки изолированы между Eve-сессиями.
- Пакеты извлечения разделены на `turn` и `catchup`.
- Для `turn`-пакетов обязательны `applicationSessionId` и `eveSessionId`.
- Миграция `058_scope_eve_turn_identity.sql` заполняет новые поля и обновляет уникальные ограничения.
- Извлечение памяти пропускается при пустой видимой проекции timeline.
- Версия пакета обновлена до `0.11.7`.
- Добавлены интеграционные и регрессионные тесты для миграции, изоляции идентификаторов и повторной доставки.

## Проверка

- 1 270 тестов прошли в 244 файлах.
- Один тест пропущен.
- Проверка типов и сборка завершились успешно.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->