### PR TITLE
Prepare v0.11.8 capacity recovery release

### DIFF
--- a/docs/releases/v0.11.8.md
+++ b/docs/releases/v0.11.8.md
@@ -1,0 +1,47 @@
+# Osinara v0.11.8
+
+Повторный immutable release исправления Eve turn identity после безопасного pre-migration отказа
+`v0.11.7`.
+
+## Почему нужна новая версия
+
+Production controller успешно проверил release `v0.11.7` и скачал exact candidate images, но
+остановился на backup capacity preflight с кодом `DEPLOY_BACKUP_SPACE_INSUFFICIENT`. Application
+writers не останавливались, backup и migration не начинались, current symlink остался на healthy
+`v0.11.6`.
+
+Proposal `v0.11.7` является terminal `failed` audit record и не переиспользуется. Для новой owner
+approval публикуется отдельный immutable release `v0.11.8`.
+
+## Что входит в release
+
+- Telegram final-delivery identity использует пару `(eve_session_id, eve_turn_id)` вместо глобального
+  `eve_turn_id`.
+- Turn-owned memory extraction batches изолированы по Eve session и отделены от sessionless catch-up
+  batches.
+- Migration `058_scope_eve_turn_identity.sql` backfill-ит только доказуемые связи с
+  `conversation_sessions` и fail-fast останавливается при недоказанной persisted строке.
+- Empty timeline projection восстановленного Eve run не создаёт пустой extraction batch.
+- Regression tests проверяют одинаковый `turn_0` в разных framework sessions через реальный
+  extraction и Telegram delivery persistence.
+
+## Capacity recovery
+
+- Удалены только Docker images, не используемые ни одним production container; volumes и active
+  `v0.11.6` images не затронуты.
+- После cleanup доступно `15,509,123,072` bytes при рассчитанной controller потребности
+  `13,511,937,750` bytes, запас составляет `1,997,185,322` bytes до загрузки нового candidate.
+- Production содержит `129` extraction batches и `18` final deliveries; для backfill нет строк без
+  доказуемой Eve session.
+
+## Проверка
+
+- Код совпадает с проверенным `v0.11.7`; изменены только SemVer и этот release audit record.
+- Предыдущий полный Docker Compose gate: `244` test files passed, `1270` tests passed, `1` skipped;
+  typecheck и `eve build` завершились успешно.
+- Новый canonical merge повторно пройдёт обязательный CI и соберёт отдельные exact image digests.
+
+## Production
+
+- Release требует нового proposal и отдельной owner approval в привязанном личном Telegram-чате.
+- Deployment продолжит использовать один rolling backup и current+previous local release retention.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.11.7",
+      "version": "0.11.8",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- publish a new immutable patch version because v0.11.7 is terminal failed and cannot be reused
- retain the already-tested Eve session-scoped turn identity fix unchanged
- record the pre-migration backup capacity failure and safe unused-image cleanup

## Production evidence
- v0.11.7 failed before backup, writer shutdown, or migration with DEPLOY_BACKUP_SPACE_INSUFFICIENT
- v0.11.6 remains current and all production services are healthy
- exact capacity after cleanup: 15,509,123,072 bytes available vs 13,511,937,750 bytes required
- backfill preflight: 0 unresolved extraction batches and 0 unresolved deliveries

## Verification
- npm run typecheck
- v0.11.7 full gate: 244 test files passed, 1270 tests passed, 1 skipped
- canonical main CI will rerun the full Docker gate and publish fresh exact image digests