### PR TITLE
Prepare v0.11.10 memory recovery release

### DIFF
--- a/docs/releases/v0.11.10.md
+++ b/docs/releases/v0.11.10.md
@@ -1,0 +1,47 @@
+# Osinara v0.11.10
+
+Повторный immutable release исправления structured extraction и создания нитей долговременной памяти
+после безопасного pre-migration отказа `v0.11.9`.
+
+## Почему нужна новая версия
+
+Production controller проверил release `v0.11.9` и скачал все exact candidate images, но остановился
+на backup capacity preflight с кодом `DEPLOY_BACKUP_SPACE_INSUFFICIENT`. Application writers не
+останавливались, backup и migration не начинались, current symlink остался на healthy `v0.11.8`.
+
+Proposal `v0.11.9` является terminal `failed` audit record и не переиспользуется. Target version
+дедуплицируется durable repository, поэтому для новой owner approval публикуется отдельный immutable
+release `v0.11.10`.
+
+## Что входит в release
+
+- Memory extraction, consolidation relations, thread discovery и thread briefs используют один
+  обязательный schema-bearing tool call вместо неподдерживаемого DeepSeek `response_format`.
+- Отдельная `memoryStructuredModel` отключает thinking только для forced structured tool call;
+  основной Eve agent loop сохраняет thinking `high`.
+- Structured boundary остаётся fail-closed и не выполняет скрытые retries или fallback parsing.
+- Firsthand memory subjects всегда связываются server-side с verified primary participant.
+
+## Capacity recovery
+
+- Удалены только unreferenced Osinara images двухрелизной давности и два завершённых transient sandbox
+  container; running `v0.11.8`, его image dependencies, durable volumes и candidate `v0.11.9` images
+  не затронуты.
+- Очищены регенерируемые APT metadata/cache и архивные systemd journal entries; данные приложений не
+  изменялись.
+- После cleanup доступно `14,618,083,328` bytes при рассчитанной controller потребности
+  `13,686,001,730` bytes; запас составляет `932,081,598` bytes до загрузки нового candidate.
+
+## Проверка
+
+- Runtime-код совпадает с проверенным `v0.11.9`; изменены только SemVer и этот release audit record.
+- Предыдущий полный Docker Compose gate: `245` test files passed, `1278` tests passed, `1` skipped;
+  typecheck и `eve build` завершились успешно.
+- Новый canonical merge повторно пройдёт обязательный CI и соберёт отдельные exact image digests.
+
+## Production recovery
+
+- Release требует нового proposal и отдельной owner approval в привязанном личном Telegram-чате.
+- Failed extraction attempt investment message остаётся immutable audit record.
+- После успешного deployment оператор создаст ровно один explicit `new_attempt` для исходного batch
+  sequence `26` и проверит active source-backed thread «Инвестиции».

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.11.9",
+      "version": "0.11.10",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- publish a new immutable SemVer target after the terminal v0.11.9 capacity preflight failure
- retain the verified structured-memory runtime changes unchanged
- document exact production cleanup, capacity, and one-attempt investment recovery procedure

## Verification
- `npm pkg get version`
- `git diff --check origin/main...HEAD`
- runtime code unchanged from v0.11.9, whose full Docker gate passed 245 files / 1278 tests with 1 skipped