### PR TITLE
Prepare v0.11.11 memory recovery release

### DIFF
--- a/docs/releases/v0.11.11.md
+++ b/docs/releases/v0.11.11.md
@@ -1,0 +1,47 @@
+# Osinara v0.11.11
+
+Повторный immutable release исправления structured extraction и создания нитей долговременной памяти
+после безопасного pre-migration отказа `v0.11.10`.
+
+## Почему нужна новая версия
+
+Production controller проверил release `v0.11.10` и скачал все exact candidate images, но backup
+capacity preflight остановил deployment до выключения application writers, backup и migration.
+Current symlink остался на healthy `v0.11.8`, persisted data не изменялись.
+
+Proposal `v0.11.10` является terminal `failed` audit record и не переиспользуется. Для новой owner
+approval публикуется отдельный immutable release `v0.11.11`.
+
+## Что входит в release
+
+- Memory extraction, consolidation relations, thread discovery и thread briefs используют один
+  обязательный schema-bearing tool call вместо неподдерживаемого DeepSeek `response_format`.
+- Отдельная `memoryStructuredModel` отключает thinking только для forced structured tool call;
+  основной Eve agent loop сохраняет thinking `high`.
+- Structured boundary остаётся fail-closed и не выполняет скрытые retries или fallback parsing.
+- Firsthand memory subjects всегда связываются server-side с verified primary participant.
+
+## Capacity recovery
+
+- Предыдущая оценка ошибочно учитывала failed `v0.11.9` candidate images как полезные shared layers.
+  Новый release скачал отдельный image set и исчерпал запас до backup preflight.
+- Удалены оба unreferenced failed candidate image set `v0.11.9` и `v0.11.10`. Running `v0.11.8`
+  images, containers, durable volumes и данные других приложений не затронуты.
+- После cleanup доступно `15,863,824,384` bytes при рассчитанной controller потребности
+  `13,686,001,730` bytes; запас составляет `2,177,822,654` bytes до загрузки нового candidate.
+- Последний candidate pull занял около `1.25 GB`, поэтому текущий запас покрывает тот же полный pull
+  и оставляет дополнительный резерв перед backup preflight.
+
+## Проверка
+
+- Runtime-код совпадает с проверенным `v0.11.9`; изменены только SemVer и этот release audit record.
+- CI `v0.11.10` повторно успешно выполнил полный production-equivalent Docker Compose gate и собрал
+  все exact production images.
+- Новый canonical merge ещё раз пройдёт обязательный CI и image attestation.
+
+## Production recovery
+
+- Release требует нового proposal и отдельной owner approval в привязанном личном Telegram-чате.
+- Failed extraction attempt investment message остаётся immutable audit record.
+- После успешного deployment оператор создаст ровно один explicit `new_attempt` для исходного batch
+  sequence `26` и проверит active source-backed thread «Инвестиции».

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.11.10",
+      "version": "0.11.11",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- publish a new immutable target after the terminal v0.11.10 backup-capacity preflight failure
- retain the verified structured-memory runtime changes unchanged
- document removal of both unreferenced failed candidate image sets and the measured 2.18 GB pre-pull margin

## Verification
- `npm pkg get version`
- `git diff --check origin/main...HEAD`
- runtime code unchanged; v0.11.10 canonical CI passed its full production-equivalent Docker gate