### PR TITLE
Release v0.12.2: keep memory thread notices private

### DIFF
--- a/agent/lib/memory-agent-write.integration-fixtures.ts
+++ b/agent/lib/memory-agent-write.integration-fixtures.ts
@@ -3,6 +3,7 @@
  *
  * Exports:
  * - `createMainAgentMemoryFixture`: verified family conversation, author, source, and authorization.
+ * - `createMainAgentPrivateMemoryFixture`: verified private conversation and personal source.
  */
 import { database } from "./database.js";
 import type { MemoryAuthorization } from "./memory-context.js";
@@ -54,6 +55,52 @@ export async function createMainAgentMemoryFixture() {
     auth,
     conversationId: conversation.rows[0]!.id,
     groupId: group.rows[0]!.id,
+    timelineEntryId: message.rows[0]!.id,
+    userId: user.rows[0]!.id,
+  };
+}
+
+export async function createMainAgentPrivateMemoryFixture() {
+  const family = await database().query<{ id: string }>(
+    "INSERT INTO families (name) VALUES ('Private agent memory') RETURNING id",
+  );
+  const user = await database().query<{ id: string }>(
+    "INSERT INTO users (telegram_user_id, display_name) VALUES ('private-memory-author', 'Анна') RETURNING id",
+  );
+  await database().query(
+    "INSERT INTO family_memberships (family_id, user_id, role) VALUES ($1, $2, 'owner')",
+    [family.rows[0]!.id, user.rows[0]!.id],
+  );
+  const conversation = await database().query<{ id: string }>(
+    "SELECT id FROM application_conversations WHERE owner_user_id = $1",
+    [user.rows[0]!.id],
+  );
+  await database().query(
+    `INSERT INTO conversation_participants
+       (conversation_id, family_id, scope, scope_partition_key, telegram_user_id,
+        linked_user_id, display_name_snapshot, first_observed_at, last_observed_at)
+     VALUES ($1, $2, 'personal', $3, 'private-memory-author', $3, 'Анна', now(), now())`,
+    [conversation.rows[0]!.id, family.rows[0]!.id, user.rows[0]!.id],
+  );
+  const message = await database().query<{ id: string }>(
+    `INSERT INTO telegram_group_messages
+       (conversation_id, telegram_message_id, sequence_id, actor_kind, actor_id,
+        telegram_user_id, sender_display_name, sender_is_bot, message_kind, content_text, sent_at)
+     VALUES ($1, 903, 1, 'user', 'telegram:private-memory-author', 'private-memory-author',
+             'Анна', false, 'text', 'Я начинаю готовиться к марафону', now()) RETURNING id`,
+    [conversation.rows[0]!.id],
+  );
+  const auth: MemoryAuthorization = {
+    familyId: family.rows[0]!.id,
+    groupId: null,
+    role: "owner",
+    scopes: ["personal", "family"],
+    telegramUserId: "private-memory-author",
+    userId: user.rows[0]!.id,
+  };
+  return {
+    auth,
+    conversationId: conversation.rows[0]!.id,
     timelineEntryId: message.rows[0]!.id,
     userId: user.rows[0]!.id,
   };

--- a/agent/lib/memory-agent-write.integration.test.ts
+++ b/agent/lib/memory-agent-write.integration.test.ts
@@ -108,7 +108,7 @@ describeWithDatabase("main-agent memory write", () => {
       consolidation_jobs: 0,
       discovery_jobs: 0,
       extraction_jobs: 0,
-      pending_notices: 1,
+      pending_notices: 0,
     }] });
   });
 

--- a/agent/lib/memory-r6-trust-zone-cascade.integration.test.ts
+++ b/agent/lib/memory-r6-trust-zone-cascade.integration.test.ts
@@ -157,8 +157,11 @@ async function createZone(input: {
     [brief.rows[0]!.id, thread.rows[0]!.id, claimEntry.id],
   );
   await database().query(
-    "INSERT INTO memory_thread_creation_notices (thread_id, family_id) VALUES ($1, $2)",
-    [thread.rows[0]!.id, input.familyId],
+    `INSERT INTO memory_thread_creation_notices
+       (thread_id, family_id, status, origin_conversation_id, delivery_started_at,
+        delivery_diagnostic_code)
+     VALUES ($1, $2, 'failed', $3, now(), 'AGENT_MEMORY_THREAD_NOTICE_PRIVATE_ONLY')`,
+    [thread.rows[0]!.id, input.familyId, conversation.rows[0]!.id],
   );
   const job = await database().query<{ id: string }>(
     `INSERT INTO memory_thread_discovery_jobs
@@ -330,7 +333,7 @@ describeWithDatabase("complete R6 trust-zone cascade", () => {
         brief_survives: false,
         claim_entries: 0,
         completion_outcome_id: null,
-        creation_notices: 1,
+        creation_notices: 0,
         discovery_coverage: 1,
         discovery_existing: 1,
         discovery_sources: 1,

--- a/agent/lib/memory-thread-notice-policy-migration.integration.test.ts
+++ b/agent/lib/memory-thread-notice-policy-migration.integration.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Private-only memory-thread notice policy migration test.
+ *
+ * Constructs covered:
+ * - Migration 061 terminally suppresses pending group-origin notices only.
+ */
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { closeDatabase, database } from "./database.js";
+
+const TEST_SCHEMA = "thread_notice_policy_migration_test";
+const describeWithDatabase = process.env.RUN_DATABASE_INTEGRATION_TESTS === "true"
+  ? describe
+  : describe.skip;
+
+describeWithDatabase("private-only thread notice migration", () => {
+  afterAll(closeDatabase);
+
+  it("suppresses pending group origins without changing private or presented notices", async () => {
+    const client = await database().connect();
+    try {
+      await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+      await client.query(`CREATE SCHEMA ${TEST_SCHEMA}`);
+      await client.query(`SET search_path TO ${TEST_SCHEMA}, public`);
+      await client.query(`
+        CREATE TABLE application_conversations (
+          id uuid PRIMARY KEY,
+          telegram_group_id uuid
+        );
+        CREATE TABLE memory_thread_entries (
+          id uuid PRIMARY KEY,
+          thread_id uuid NOT NULL,
+          source_claim_id uuid,
+          created_at timestamptz NOT NULL
+        );
+        CREATE TABLE claim_evidence (
+          claim_id uuid NOT NULL,
+          evidence_role text NOT NULL,
+          origin_conversation_id uuid NOT NULL
+        );
+        CREATE TABLE memory_thread_creation_notices (
+          thread_id uuid PRIMARY KEY,
+          status text NOT NULL,
+          delivery_token uuid,
+          delivery_started_at timestamptz,
+          delivery_diagnostic_code text,
+          presented_at timestamptz,
+          created_at timestamptz NOT NULL DEFAULT now()
+        );
+      `);
+      await client.query(`
+        INSERT INTO application_conversations (id, telegram_group_id) VALUES
+          ('10000000-0000-4000-8000-000000000001', NULL),
+          ('10000000-0000-4000-8000-000000000002', '20000000-0000-4000-8000-000000000001');
+        INSERT INTO memory_thread_entries (id, thread_id, source_claim_id, created_at) VALUES
+          ('30000000-0000-4000-8000-000000000001', '40000000-0000-4000-8000-000000000001',
+           '50000000-0000-4000-8000-000000000001', now()),
+          ('30000000-0000-4000-8000-000000000002', '40000000-0000-4000-8000-000000000002',
+           '50000000-0000-4000-8000-000000000002', now()),
+          ('30000000-0000-4000-8000-000000000003', '40000000-0000-4000-8000-000000000003',
+           '50000000-0000-4000-8000-000000000003', now());
+        INSERT INTO claim_evidence (claim_id, evidence_role, origin_conversation_id) VALUES
+          ('50000000-0000-4000-8000-000000000001', 'primary',
+           '10000000-0000-4000-8000-000000000001'),
+          ('50000000-0000-4000-8000-000000000002', 'primary',
+           '10000000-0000-4000-8000-000000000002'),
+          ('50000000-0000-4000-8000-000000000003', 'primary',
+           '10000000-0000-4000-8000-000000000002');
+        INSERT INTO memory_thread_creation_notices
+          (thread_id, status, delivery_started_at, presented_at) VALUES
+          ('40000000-0000-4000-8000-000000000001', 'pending', NULL, NULL),
+          ('40000000-0000-4000-8000-000000000002', 'pending', NULL, NULL),
+          ('40000000-0000-4000-8000-000000000003', 'presented', now(), now()),
+          ('40000000-0000-4000-8000-000000000004', 'pending', NULL, NULL);
+      `);
+
+      await client.query(await readFile(
+        resolve("migrations/061_private_memory_thread_notices.sql"),
+        "utf8",
+      ));
+
+      await expect(client.query(
+        `SELECT status, delivery_diagnostic_code, delivery_started_at IS NOT NULL AS started
+         FROM memory_thread_creation_notices ORDER BY thread_id`,
+      )).resolves.toMatchObject({ rows: [
+        { delivery_diagnostic_code: null, started: false, status: "pending" },
+        {
+          delivery_diagnostic_code: "AGENT_MEMORY_THREAD_NOTICE_PRIVATE_ONLY",
+          started: true,
+          status: "failed",
+        },
+        { delivery_diagnostic_code: null, started: true, status: "presented" },
+        {
+          delivery_diagnostic_code: "AGENT_MEMORY_THREAD_NOTICE_PRIVATE_ONLY",
+          started: true,
+          status: "failed",
+        },
+      ] });
+    } finally {
+      await client.query("RESET search_path");
+      await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+      client.release();
+    }
+  });
+});

--- a/agent/lib/memory-thread-notice-repository.integration.test.ts
+++ b/agent/lib/memory-thread-notice-repository.integration.test.ts
@@ -36,7 +36,7 @@ describeWithDatabase("memory thread notice durable recovery", () => {
     await database().query(
       `UPDATE memory_thread_creation_notices
        SET status = 'started', delivery_token = gen_random_uuid(),
-           delivery_started_at = $2
+           delivery_started_at = $2, delivery_diagnostic_code = NULL
        WHERE thread_id = $1`,
       [thread.rows[0]!.id, new Date(Date.now() - THREAD_NOTICE_DELIVERY_LEASE_MILLISECONDS - 1)],
     );

--- a/agent/lib/memory-thread-notice-repository.ts
+++ b/agent/lib/memory-thread-notice-repository.ts
@@ -2,7 +2,7 @@
  * Durable exactly-once memory-thread creation notice boundary.
  *
  * Export:
- * - `memoryThreadNoticeRepository.takePending`: atomically takes one notice on an authorized turn.
+ * - `memoryThreadNoticeRepository.takePending`: takes one notice in its verified private conversation.
  */
 import { database } from "./database.js";
 import { THREAD_NOTICE_DELIVERY_LEASE_MILLISECONDS } from "./memory-config.js";
@@ -43,9 +43,13 @@ export const memoryThreadNoticeRepository = {
       }>(
         `WITH candidate AS (
           SELECT notice.thread_id
-         FROM memory_thread_creation_notices AS notice
-         JOIN memory_threads AS thread ON thread.id = notice.thread_id
-         WHERE notice.family_id = $1 AND notice.status = 'pending' AND (
+          FROM memory_thread_creation_notices AS notice
+          JOIN memory_threads AS thread ON thread.id = notice.thread_id
+          JOIN application_conversations AS origin
+            ON origin.id = notice.origin_conversation_id
+           AND origin.telegram_group_id IS NULL
+          WHERE notice.family_id = $1 AND notice.status = 'pending'
+            AND notice.origin_conversation_id = $5 AND (
            (thread.scope = 'personal' AND 'personal' = ANY($2::memory_scope[])
              AND thread.scope_partition_key = $3) OR
            (thread.scope = 'family' AND 'family' = ANY($2::memory_scope[])) OR
@@ -61,7 +65,7 @@ export const memoryThreadNoticeRepository = {
         )
          SELECT updated.thread_id, updated.delivery_token, thread.thread_ref, thread.title, thread.purpose
          FROM updated JOIN memory_threads AS thread ON thread.id = updated.thread_id`,
-        [auth.familyId, auth.scopes, auth.userId, auth.groupId],
+        [auth.familyId, auth.scopes, auth.userId, auth.groupId, conversationId],
       );
       await client.query("COMMIT");
       const row = result.rows[0];

--- a/agent/lib/memory-thread-notice.test.ts
+++ b/agent/lib/memory-thread-notice.test.ts
@@ -52,9 +52,14 @@ describe("memory thread creation notice", () => {
     );
   });
 
-  it.each(["family_private", "external"] as const)(
-    "does not inspect pending notices in a %s group turn",
-    async (groupType) => {
+  it.each([
+    { groupType: "family_private" as const, telegramChatType: "group" as const },
+    { groupType: "family_private" as const, telegramChatType: "supergroup" as const },
+    { groupType: "external" as const, telegramChatType: "group" as const },
+    { groupType: "external" as const, telegramChatType: "supergroup" as const },
+  ])(
+    "does not inspect pending notices in a $groupType Telegram $telegramChatType turn",
+    async ({ groupType, telegramChatType }) => {
       const repository = repositories();
       repository.telegram.findGroup.mockResolvedValue({
         familyId: "family-1",
@@ -79,8 +84,12 @@ describe("memory thread creation notice", () => {
       });
       const telegram = telegramContext();
       const handler = createTelegramMessageHandler(repository);
+      const message = groupMessage(`@${BOT_USERNAME} продолжим`);
 
-      await handler(telegram.context, groupMessage(`@${BOT_USERNAME} продолжим`));
+      await handler(telegram.context, {
+        ...message,
+        chat: { ...message.chat, type: telegramChatType },
+      });
 
       expect(repository.threadNotices.takePending).not.toHaveBeenCalled();
       expect(repository.threadNotices.complete).not.toHaveBeenCalled();

--- a/agent/lib/memory-thread-notice.test.ts
+++ b/agent/lib/memory-thread-notice.test.ts
@@ -3,12 +3,19 @@
  *
  * Constructs covered:
  * - A committed background thread notice appears on the next authorized turn exactly as stored.
+ * - Family and external group turns never inspect or send thread creation notices.
  * - The notice is informational Russian text and never asks for confirmation.
  */
 import { describe, expect, it } from "vitest";
 
 import { createTelegramMessageHandler } from "./telegram-on-message.js";
-import { privateMessage, repositories, telegramContext } from "./telegram-on-message.test-fixtures.js";
+import {
+  BOT_USERNAME,
+  groupMessage,
+  privateMessage,
+  repositories,
+  telegramContext,
+} from "./telegram-on-message.test-fixtures.js";
 
 describe("memory thread creation notice", () => {
   it("shows the pending title and purpose on the next authorized turn", async () => {
@@ -44,4 +51,40 @@ describe("memory thread creation notice", () => {
       expect.any(String),
     );
   });
+
+  it.each(["family_private", "external"] as const)(
+    "does not inspect pending notices in a %s group turn",
+    async (groupType) => {
+      const repository = repositories();
+      repository.telegram.findGroup.mockResolvedValue({
+        familyId: "family-1",
+        groupId: "group-1",
+        messageMode: "addressed_only",
+        telegramChatId: "group-101",
+        toolAllowlist: [],
+        type: groupType,
+      });
+      repository.telegram.findIdentity.mockResolvedValue({
+        familyId: "family-1",
+        role: "member",
+        userId: "user-1",
+      });
+      repository.threadNotices.takePending.mockResolvedValue({
+        deliveryToken: "00000000-0000-4000-8000-000000000002",
+        purpose: "Скрытое системное уведомление.",
+        text: "Начата новая нить памяти: «Скрытая».",
+        threadId: "00000000-0000-4000-8000-000000000001",
+        threadRef: "thread_0123456789abcdef0123456789abcdef",
+        title: "Скрытая",
+      });
+      const telegram = telegramContext();
+      const handler = createTelegramMessageHandler(repository);
+
+      await handler(telegram.context, groupMessage(`@${BOT_USERNAME} продолжим`));
+
+      expect(repository.threadNotices.takePending).not.toHaveBeenCalled();
+      expect(repository.threadNotices.complete).not.toHaveBeenCalled();
+      expect(telegram.sendMessage).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/agent/lib/memory-thread-private-notice.integration.test.ts
+++ b/agent/lib/memory-thread-private-notice.integration.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Private-origin memory-thread notice integration tests.
+ *
+ * Constructs covered:
+ * - A thread created from verified private Telegram evidence queues one private-chat notice.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./memory-embedding-client.js", async (importOriginal) => ({
+  ...await importOriginal<typeof import("./memory-embedding-client.js")>(),
+  embedMemoryPassages: vi.fn(async () => [
+    [1, ...Array.from({ length: 383 }, () => 0)],
+  ]),
+}));
+
+import { closeDatabase, database } from "./database.js";
+import { createMainAgentPrivateMemoryFixture } from "./memory-agent-write.integration-fixtures.js";
+import { memoryRepository } from "./memory-repository.js";
+import { memoryThreadNoticeRepository } from "./memory-thread-notice-repository.js";
+
+const describeWithDatabase = process.env.RUN_DATABASE_INTEGRATION_TESTS === "true"
+  ? describe
+  : describe.skip;
+
+describeWithDatabase("private memory thread notice", () => {
+  beforeEach(async () => {
+    await database().query("TRUNCATE users, families CASCADE");
+  });
+
+  afterAll(closeDatabase);
+
+  it("queues and takes a notice for a private-origin personal thread", async () => {
+    const fixture = await createMainAgentPrivateMemoryFixture();
+
+    await memoryRepository.create(fixture.auth, {
+      confirmation: "model_high",
+      content: "Анна начала готовиться к марафону",
+      explicitSource: {
+        conversationId: fixture.conversationId,
+        timelineEntryId: fixture.timelineEntryId,
+      },
+      kind: "fact",
+      operationKey: "private-personal-thread-notice",
+      scope: "personal",
+      sensitivity: "normal",
+      source: "eve:private-thread-notice",
+      thread: {
+        action: "create",
+        purpose: "Сохранять цели, решения и результаты подготовки",
+        role: "goal",
+        title: "Марафон",
+      },
+    });
+
+    await expect(database().query(
+      "SELECT status, origin_conversation_id FROM memory_thread_creation_notices",
+    )).resolves.toMatchObject({ rows: [{
+      origin_conversation_id: fixture.conversationId,
+      status: "pending",
+    }] });
+    await expect(memoryThreadNoticeRepository.takePending(
+      fixture.auth,
+      fixture.conversationId,
+    )).resolves.toMatchObject({ title: "Марафон" });
+  });
+});

--- a/agent/lib/memory-thread-repository.integration-fixtures.ts
+++ b/agent/lib/memory-thread-repository.integration-fixtures.ts
@@ -129,8 +129,11 @@ export async function createBroadThread(fixture: ThreadRepositoryFixture) {
     [thread.rows[0]!.id, fixture.claimId],
   );
   await database().query(
-    "INSERT INTO memory_thread_creation_notices (thread_id, family_id) VALUES ($1, $2)",
-    [thread.rows[0]!.id, fixture.familyId],
+    `INSERT INTO memory_thread_creation_notices
+       (thread_id, family_id, status, origin_conversation_id, delivery_started_at,
+        delivery_diagnostic_code)
+     VALUES ($1, $2, 'failed', $3, now(), 'AGENT_MEMORY_THREAD_NOTICE_PRIVATE_ONLY')`,
+    [thread.rows[0]!.id, fixture.familyId, fixture.conversationId],
   );
   return await memoryThreadQueryRepository.list(fixture.auth, { limit: 20 });
 }

--- a/agent/lib/memory-thread-repository.integration.test.ts
+++ b/agent/lib/memory-thread-repository.integration.test.ts
@@ -90,12 +90,6 @@ describeWithDatabase("memory thread repositories", () => {
       outcomeRef: outcome.outcomeRef,
     })).resolves.toEqual({ outcomeRef: outcome.outcomeRef, status: "retracted" });
 
-    const firstNotice = await memoryThreadNoticeRepository.takePending(fixture.auth, fixture.conversationId);
-    expect(firstNotice).toMatchObject({
-      purpose: "Сохранять цели, решения и результаты ремонта",
-      title: "Ремонт",
-    });
-    expect(firstNotice!.text).toContain("Начата новая нить памяти: «Ремонт»");
     await expect(memoryThreadNoticeRepository.takePending(fixture.auth, fixture.conversationId))
       .resolves.toBeNull();
 

--- a/agent/lib/memory-thread-write.ts
+++ b/agent/lib/memory-thread-write.ts
@@ -427,10 +427,12 @@ export async function materializeMemoryThreadWrite(
      ON CONFLICT (thread_id, source_claim_id, source_outcome_id) DO NOTHING`,
     [prepared.threadId, prepared.role, claimId],
   );
-  if (prepared.result.action === "created") {
+  // Group-origin threads are fully materialized but remain silent in every shared chat.
+  if (prepared.result.action === "created" && prepared.preparedEvidence.telegramGroupId === null) {
     await client.query(
-      "INSERT INTO memory_thread_creation_notices (thread_id, family_id) VALUES ($1, $2)",
-      [prepared.threadId, auth.familyId],
+      `INSERT INTO memory_thread_creation_notices
+         (thread_id, family_id, origin_conversation_id) VALUES ($1, $2, $3)`,
+      [prepared.threadId, auth.familyId, prepared.preparedEvidence.conversationId],
     );
   }
   await client.query(

--- a/agent/lib/memory-upgrade-ledger.integration.test.ts
+++ b/agent/lib/memory-upgrade-ledger.integration.test.ts
@@ -87,6 +87,7 @@ const MEMORY_RELEASE_MIGRATIONS = [
   "058_scope_eve_turn_identity.sql",
   "059_main_agent_owned_memory.sql",
   "060_memory_thread_creation_attempts.sql",
+  "061_private_memory_thread_notices.sql",
 ] as const;
 
 const EXPECTED_R0_R7_TABLES = [

--- a/agent/lib/telegram-on-message.ts
+++ b/agent/lib/telegram-on-message.ts
@@ -308,8 +308,11 @@ export function createTelegramMessageHandler(repositories: TelegramMessageReposi
     // Context snapshots and one-time notices are consumed only after reply/HITL authorization has
     // proved that this accepted message will continue into an agent turn.
     const profileSignals = verifiedTelegramProfileSignals(message);
-    await deliverPendingMemoryThreadNotice(memoryAuthorization, conversation.id,
-      repositories.threadNotices, (text) => ctx.telegram.sendMessage(text));
+    // Thread lifecycle is silent in shared chats; only a verified private turn may consume notices.
+    if (message.chat.type === "private") {
+      await deliverPendingMemoryThreadNotice(memoryAuthorization, conversation.id,
+        repositories.threadNotices, (text) => ctx.telegram.sendMessage(text));
+    }
     if (group) {
       const policyNotice = await repositories.profilePolicies.claimPendingGroupNotice(group.groupId);
       if (policyNotice) {

--- a/docs/memory-system-full.md
+++ b/docs/memory-system-full.md
@@ -164,6 +164,9 @@ replay не зависит от обычного timeline pruning, но удал
 source-level advisory lock. Успешный attach, успешный retry и второй candidate outcome являются
 terminal для новых create решений по тому же source entry. Второй candidate outcome сохраняет один
 terminal attach к одному из выданных refs, после которого новые attach также запрещены.
+Создание и активация нитей в family/external Telegram-группах происходят без системных сообщений.
+Creation notice ставится в durable queue и доставляется только для нити, созданной из verified
+private conversation; Telegram handler дополнительно не читает эту queue на group/supergroup turns.
 
 ## 6. Retrieval и автоматическая activation
 

--- a/docs/releases/v0.12.2.md
+++ b/docs/releases/v0.12.2.md
@@ -1,0 +1,46 @@
+# Osinara v0.12.2
+
+Исправлена утечка служебных уведомлений о создании нитей долговременной памяти в общие
+Telegram-чаты. Создание, прикрепление и активация нитей продолжают работать во всех разрешённых
+областях памяти, но lifecycle-сообщения теперь видит только пользователь в исходном личном чате.
+
+## Private-only уведомления
+
+- Новый creation notice ставится в durable queue только для нити, созданной из verified private
+  Telegram conversation.
+- Notice привязан к точному `origin_conversation_id`; его нельзя получить из другого личного чата
+  той же семьи или из общей группы.
+- Repository повторно проверяет, что исходная conversation не связана с Telegram group.
+- Telegram handler не читает очередь notices на `group` и `supergroup` turns, поэтому групповой turn
+  не может потребить или показать личное системное сообщение.
+- Family и external group threads сохраняют прежнюю семантику создания и retrieval, но работают
+  полностью бесшумно.
+
+## Migration 061
+
+- `061_private_memory_thread_notices.sql` добавляет к notice точный verified origin conversation.
+- Legacy origin восстанавливается только по primary evidence entry, созданной не позже самого notice;
+  более позднее или отсутствующее evidence не считается доказательством происхождения.
+- Pending notices из group conversations и notices без доказанного origin терминально переводятся в
+  `failed` с диагностикой `AGENT_MEMORY_THREAD_NOTICE_PRIVATE_ONLY`.
+- Уже показанные notices не переотправляются и не переписываются в другой terminal status.
+- Constraint запрещает новые pending rows без origin, а partial index поддерживает точную выборку по
+  conversation.
+
+## Проверка
+
+- Unit regression tests подтверждают, что family и external group turns не обращаются к notice queue.
+- Database integration подтверждает создание и получение notice для private-origin personal thread.
+- Migration integration проверяет сохранение private pending и presented rows, suppression group rows
+  и fail-closed обработку notices без доказанного origin.
+- Обновлены trust-zone cascade и thread repository integration fixtures под private-only contract.
+- Production-equivalent Docker Compose gate, TypeScript typecheck, runtime build и `git diff --check`
+  прошли.
+
+## Production deployment
+
+- Compose graph, service/image/mount allowlist и root-owned deployment controller не менялись.
+- Migration `061` выполняется внутри release migration container до запуска нового приложения.
+- Release публикуется только из canonical `main` через GitHub Actions с immutable GHCR digests,
+  attestations и exact release assets.
+- Установка требует отдельного owner approval в привязанном личном Telegram-чате.

--- a/migrations/061_private_memory_thread_notices.sql
+++ b/migrations/061_private_memory_thread_notices.sql
@@ -1,0 +1,41 @@
+-- Bind every new notice to the exact private conversation allowed to present it. Legacy creation
+-- provenance is accepted only from the entry written no later than the notice itself; deleted or
+-- otherwise ambiguous creation evidence fails closed instead of leaking a delayed group notice.
+ALTER TABLE memory_thread_creation_notices
+  ADD COLUMN origin_conversation_id uuid REFERENCES application_conversations(id) ON DELETE CASCADE;
+
+UPDATE memory_thread_creation_notices AS notice
+SET origin_conversation_id = (
+  SELECT evidence.origin_conversation_id
+  FROM memory_thread_entries AS entry
+  JOIN claim_evidence AS evidence
+    ON evidence.claim_id = entry.source_claim_id AND evidence.evidence_role = 'primary'
+  WHERE entry.thread_id = notice.thread_id
+    AND entry.created_at <= notice.created_at
+  ORDER BY entry.created_at, entry.id
+  LIMIT 1
+)
+WHERE notice.origin_conversation_id IS NULL;
+
+UPDATE memory_thread_creation_notices AS notice
+SET status = 'failed',
+    delivery_started_at = now(),
+    delivery_diagnostic_code = 'AGENT_MEMORY_THREAD_NOTICE_PRIVATE_ONLY'
+WHERE notice.status = 'pending'
+  AND (
+    notice.origin_conversation_id IS NULL OR EXISTS (
+      SELECT 1
+      FROM application_conversations AS conversation
+      WHERE conversation.id = notice.origin_conversation_id
+        AND conversation.telegram_group_id IS NOT NULL
+    )
+  );
+
+ALTER TABLE memory_thread_creation_notices
+  ADD CONSTRAINT memory_thread_creation_notices_pending_origin CHECK (
+    status <> 'pending' OR origin_conversation_id IS NOT NULL
+  );
+
+CREATE INDEX memory_thread_creation_notices_origin_conversation
+  ON memory_thread_creation_notices(origin_conversation_id)
+  WHERE origin_conversation_id IS NOT NULL;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- queue memory-thread creation notices only for verified private Telegram origins
- prevent group and supergroup turns from consuming thread notices
- migrate legacy pending group or unproven notices to a terminal failed state
- release the fix as v0.12.2 with detailed deployment notes

## Verification
- production-equivalent Docker Compose gate
- targeted unit and database integration tests
- npm run typecheck
- npm run build:runtime
- git diff --check

## Deployment
- migration 061 runs in the release migration container
- Compose graph and production controller contract are unchanged
- deployment still requires owner approval in the bound private Telegram chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Итоги

- Выпущена версия `0.12.2`.
- Уведомления о создании memory thread создаются только для подтверждённых приватных Telegram-диалогов.
- Групповые и супергрупповые сообщения не получают и не потребляют такие уведомления.
- Метод `takePending` теперь принимает `conversationId` и проверяет приватное происхождение диалога.
- Миграция `061_private_memory_thread_notices.sql` восстанавливает происхождение уведомлений и переводит неподтверждённые или групповые pending-записи в `failed`.
- Для уведомлений добавлено поле `origin_conversation_id` с каскадным удалением и частичным индексом.
- Добавлены интеграционные фикстуры и тесты для приватных уведомлений и миграции.
- Обновлены тесты репозитория, обработки Telegram-сообщений и ledger миграций.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->