### PR TITLE
Release v0.15.1 after deployment controller cutover

### DIFF
--- a/docs/releases/v0.15.1.md
+++ b/docs/releases/v0.15.1.md
@@ -1,0 +1,26 @@
+# Osinara v0.15.1
+
+Повторный immutable release обновления Eve `0.32.0`, durable memory review и исправления Telegram
+reply context после безопасного pre-migration отказа deployment `v0.15.0`.
+
+## Что изменилось
+
+- Версия приложения повышена до `0.15.1`, чтобы создать новое предложение обновления вместо
+  запрещённого повтора terminal `failed` proposal `v0.15.0`.
+- Runtime-функциональность соответствует `v0.15.0`: Eve `0.32.0`, групповые memory-review batches,
+  turn-bound evidence и восстановление текста недоступной reply-цели из проверенного Telegram update.
+- Root-owned deployment controller на production отдельно синхронизирован с canonical release
+  commit до нового owner approval. Текущая `v0.14.4` оставалась запущенной и healthy.
+
+## Причина повторного релиза
+
+Первый deployment `v0.15.0` был остановлен до migration и до остановки приложения: установленный
+controller корректно отклонил новый Compose capability до обязательной двухфазной синхронизации
+controller scripts. Proposal сохранил terminal `failed` audit trail и не сбрасывался, не клонировался
+и не подтверждался повторно.
+
+## Проверка
+
+- Изменены только package version metadata и этот changelog.
+- Полный production-equivalent Docker gate и immutable image publication выполняются заново из
+  canonical `main` commit.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- publish a new immutable patch release after the terminal pre-migration v0.15.0 deployment refusal
- preserve the v0.15.0 runtime changes without resetting or replaying the failed proposal
- document the separately completed canonical production controller synchronization

## Verification
- production release contract: 19 tests passed
- diff contains only package version metadata and v0.15.1 changelog

## Deployment state
- production remains healthy on v0.14.4
- root-owned controller scripts match canonical main commit 07d50b4 and the timer is active

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Выпущена версия `v0.15.1`.
- Сохранены runtime-изменения `v0.15.0`.
- Исключены сброс и повторное воспроизведение неудачного proposal.
- Обновлена версия пакета в `package.json` с `0.15.0` до `0.15.1`.
- Добавлен changelog для `v0.15.1`.

## Проверки

- Контракт релиза подтверждён 19 успешно пройденными тестами.
- Production остаётся в стабильном состоянии на `v0.14.4`.
- Root-owned controller scripts соответствуют canonical main commit `07d50b4`.
- Timer активен.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->