### PR TITLE
Download pinned GWS artifact from official release

### DIFF
--- a/docs/releases/v0.15.1.md
+++ b/docs/releases/v0.15.1.md
@@ -11,6 +11,8 @@ reply context после безопасного pre-migration отказа deplo
   turn-bound evidence и восстановление текста недоступной reply-цели из проверенного Telegram update.
 - Root-owned deployment controller на production отдельно синхронизирован с canonical release
   commit до нового owner approval. Текущая `v0.14.4` оставалась запущенной и healthy.
+- Checksum-pinned архив Google Workspace CLI теперь загружается напрямую из официального GitHub
+  Release. Нестабильный third-party proxy удалён; SHA-256 validation остаётся обязательной.
 
 ## Причина повторного релиза
 
@@ -21,6 +23,7 @@ controller scripts. Proposal сохранил terminal `failed` audit trail и �
 
 ## Проверка
 
-- Изменены только package version metadata и этот changelog.
+- Кроме package version metadata изменён только источник checksum-pinned Google Workspace CLI archive:
+  официальный GitHub Release вместо нестабильного third-party proxy.
 - Полный production-equivalent Docker gate и immutable image publication выполняются заново из
   canonical `main` commit.

--- a/docs/releases/v0.15.1.md
+++ b/docs/releases/v0.15.1.md
@@ -11,8 +11,9 @@ reply context после безопасного pre-migration отказа deplo
   turn-bound evidence и восстановление текста недоступной reply-цели из проверенного Telegram update.
 - Root-owned deployment controller на production отдельно синхронизирован с canonical release
   commit до нового owner approval. Текущая `v0.14.4` оставалась запущенной и healthy.
-- Checksum-pinned архив Google Workspace CLI теперь загружается напрямую из официального GitHub
-  Release. Нестабильный third-party proxy удалён; SHA-256 validation остаётся обязательной.
+- Checksum-pinned архив Google Workspace CLI теперь загружается по immutable asset ID через
+  официальный GitHub Releases API. Нестабильный third-party proxy удалён; SHA-256 validation
+  остаётся обязательной.
 
 ## Причина повторного релиза
 
@@ -24,6 +25,6 @@ controller scripts. Proposal сохранил terminal `failed` audit trail и �
 ## Проверка
 
 - Кроме package version metadata изменён только источник checksum-pinned Google Workspace CLI archive:
-  официальный GitHub Release вместо нестабильного third-party proxy.
+  официальный GitHub Releases API вместо нестабильного third-party proxy.
 - Полный production-equivalent Docker gate и immutable image publication выполняются заново из
   canonical `main` commit.

--- a/scripts/install-google-workspace-cli.test.ts
+++ b/scripts/install-google-workspace-cli.test.ts
@@ -17,10 +17,12 @@ describe("Google Workspace CLI installer", () => {
   it("pins the exact x64 and arm64 release artifacts", () => {
     expect(resolveGoogleWorkspaceCliArtifact("linux", "x64")).toEqual({
       archiveName: "google-workspace-cli-x86_64-unknown-linux-musl.tar.gz",
+      releaseAssetId: 385726987,
       sha256: "4db473dde4b1ab872e4ff35d769b0d4af1f1a6441a605e79d5cf8ada9c87e920",
     });
     expect(resolveGoogleWorkspaceCliArtifact("linux", "arm64")).toEqual({
       archiveName: "google-workspace-cli-aarch64-unknown-linux-musl.tar.gz",
+      releaseAssetId: 385726968,
       sha256: "e700fe63524932b10ec2130b47ece90aa850e66005fe52ccfc4cf8767bf9919a",
     });
   });
@@ -29,8 +31,7 @@ describe("Google Workspace CLI installer", () => {
     const artifact = resolveGoogleWorkspaceCliArtifact("linux", "x64");
 
     expect(resolveGoogleWorkspaceCliDownloadUrl(artifact)).toBe(
-      "https://github.com/googleworkspace/cli/releases/download/v0.22.5/" +
-        "google-workspace-cli-x86_64-unknown-linux-musl.tar.gz",
+      "https://api.github.com/repos/googleworkspace/cli/releases/assets/385726987",
     );
   });
 

--- a/scripts/install-google-workspace-cli.test.ts
+++ b/scripts/install-google-workspace-cli.test.ts
@@ -3,11 +3,15 @@
  *
  * Constructs covered:
  * - Supported Docker architectures resolve exact official artifacts and SHA-256 digests.
+ * - Release downloads use the official GitHub origin without a third-party proxy.
  * - Unsupported platforms fail before any download occurs.
  */
 import { describe, expect, it } from "vitest";
 
-import { resolveGoogleWorkspaceCliArtifact } from "./install-google-workspace-cli.js";
+import {
+  resolveGoogleWorkspaceCliArtifact,
+  resolveGoogleWorkspaceCliDownloadUrl,
+} from "./install-google-workspace-cli.js";
 
 describe("Google Workspace CLI installer", () => {
   it("pins the exact x64 and arm64 release artifacts", () => {
@@ -19,6 +23,15 @@ describe("Google Workspace CLI installer", () => {
       archiveName: "google-workspace-cli-aarch64-unknown-linux-musl.tar.gz",
       sha256: "e700fe63524932b10ec2130b47ece90aa850e66005fe52ccfc4cf8767bf9919a",
     });
+  });
+
+  it("downloads a pinned artifact directly from the official GitHub release", () => {
+    const artifact = resolveGoogleWorkspaceCliArtifact("linux", "x64");
+
+    expect(resolveGoogleWorkspaceCliDownloadUrl(artifact)).toBe(
+      "https://github.com/googleworkspace/cli/releases/download/v0.22.5/" +
+        "google-workspace-cli-x86_64-unknown-linux-musl.tar.gz",
+    );
   });
 
   it("rejects non-Linux and unsupported CPU targets", () => {

--- a/scripts/install-google-workspace-cli.ts
+++ b/scripts/install-google-workspace-cli.ts
@@ -19,22 +19,25 @@ export const GWS_VERSION = "0.22.5";
 
 const DOWNLOAD_TIMEOUT_MILLISECONDS = 120_000;
 const GWS_PACKAGE_DIRECTORY = resolve("node_modules/@googleworkspace/cli");
-const GWS_RELEASE_BASE_URL =
-  `https://github.com/googleworkspace/cli/releases/download/v${GWS_VERSION}`;
+const GWS_RELEASE_ASSET_API_BASE_URL =
+  "https://api.github.com/repos/googleworkspace/cli/releases/assets";
 const execFileAsync = promisify(execFile);
 
 interface GoogleWorkspaceCliArtifact {
   archiveName: string;
+  releaseAssetId: number;
   sha256: string;
 }
 
 const LINUX_ARTIFACTS: Readonly<Record<string, GoogleWorkspaceCliArtifact>> = {
   arm64: {
     archiveName: "google-workspace-cli-aarch64-unknown-linux-musl.tar.gz",
+    releaseAssetId: 385726968,
     sha256: "e700fe63524932b10ec2130b47ece90aa850e66005fe52ccfc4cf8767bf9919a",
   },
   x64: {
     archiveName: "google-workspace-cli-x86_64-unknown-linux-musl.tar.gz",
+    releaseAssetId: 385726987,
     sha256: "4db473dde4b1ab872e4ff35d769b0d4af1f1a6441a605e79d5cf8ada9c87e920",
   },
 };
@@ -55,11 +58,15 @@ export function resolveGoogleWorkspaceCliArtifact(
 export function resolveGoogleWorkspaceCliDownloadUrl(
   artifact: GoogleWorkspaceCliArtifact,
 ): string {
-  return `${GWS_RELEASE_BASE_URL}/${artifact.archiveName}`;
+  return `${GWS_RELEASE_ASSET_API_BASE_URL}/${artifact.releaseAssetId}`;
 }
 
 async function downloadVerifiedArchive(artifact: GoogleWorkspaceCliArtifact): Promise<Buffer> {
   const response = await fetch(resolveGoogleWorkspaceCliDownloadUrl(artifact), {
+    headers: {
+      Accept: "application/octet-stream",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
     signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MILLISECONDS),
   });
   if (!response.ok) {

--- a/scripts/install-google-workspace-cli.ts
+++ b/scripts/install-google-workspace-cli.ts
@@ -4,7 +4,8 @@
  * Exports:
  * - `GWS_VERSION`: exact npm package and release version.
  * - `resolveGoogleWorkspaceCliArtifact`: Linux architecture to official artifact/checksum mapping.
- * - `installGoogleWorkspaceCli`: verified mirror download and package-local extraction.
+ * - `resolveGoogleWorkspaceCliDownloadUrl`: official GitHub release URL for a pinned artifact.
+ * - `installGoogleWorkspaceCli`: verified official download and package-local extraction.
  */
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
@@ -20,7 +21,6 @@ const DOWNLOAD_TIMEOUT_MILLISECONDS = 120_000;
 const GWS_PACKAGE_DIRECTORY = resolve("node_modules/@googleworkspace/cli");
 const GWS_RELEASE_BASE_URL =
   `https://github.com/googleworkspace/cli/releases/download/v${GWS_VERSION}`;
-const GWS_VERIFIED_MIRROR_PREFIX = "https://ghproxy.net/";
 const execFileAsync = promisify(execFile);
 
 interface GoogleWorkspaceCliArtifact {
@@ -52,14 +52,19 @@ export function resolveGoogleWorkspaceCliArtifact(
   return artifact;
 }
 
+export function resolveGoogleWorkspaceCliDownloadUrl(
+  artifact: GoogleWorkspaceCliArtifact,
+): string {
+  return `${GWS_RELEASE_BASE_URL}/${artifact.archiveName}`;
+}
+
 async function downloadVerifiedArchive(artifact: GoogleWorkspaceCliArtifact): Promise<Buffer> {
-  const officialUrl = `${GWS_RELEASE_BASE_URL}/${artifact.archiveName}`;
-  const response = await fetch(`${GWS_VERIFIED_MIRROR_PREFIX}${officialUrl}`, {
+  const response = await fetch(resolveGoogleWorkspaceCliDownloadUrl(artifact), {
     signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MILLISECONDS),
   });
   if (!response.ok) {
     throw new Error(
-      `AGENT_GWS_DOWNLOAD_FAILED: Mirror returned HTTP ${response.status} for gws ${GWS_VERSION}`,
+      `AGENT_GWS_DOWNLOAD_FAILED: Official release returned HTTP ${response.status} for gws ${GWS_VERSION}`,
     );
   }
   const archive = Buffer.from(await response.arrayBuffer());


### PR DESCRIPTION
## Summary
- remove the unstable third-party gws release proxy from the checksum-pinned installer
- pin the exact official GitHub Releases asset IDs for gws 0.22.5 on x64 and arm64
- download through the official Releases Assets API with mandatory SHA-256 validation
- keep timeout and exact npm version validation fail-closed, without fallback or hidden retries
- correct the unpublished v0.15.1 changelog before any tag or release assets exist

## Root cause
The v0.15.1 main release run passed its production-equivalent gate but immutable image publication repeatedly failed because ghproxy.net alternated HTTP 500/502 responses. The browser release endpoint also closed Node fetch connections from GitHub-hosted Docker builds. The official Releases Assets API succeeds and redirects to the official release asset storage.

No v0.15.1 tag, draft, release, or assets exist yet.

## Verification
- test-first regression for the official download contract
- installer, runtime, and production release contract: 24 targeted tests passed
- npm run typecheck
- npm run build
- production-equivalent Docker Compose CI passed
- exact x64 API asset downloaded as 6,876,771 bytes with SHA-256 4db473dde4b1ab872e4ff35d769b0d4af1f1a6441a605e79d5cf8ada9c87e920
- git diff --check