### PR TITLE
Release v0.15.3 memory tool hotfix

### DIFF
--- a/agent/lib/group-skills/group-load-skill-tool.ts
+++ b/agent/lib/group-skills/group-load-skill-tool.ts
@@ -2,10 +2,10 @@
  * Live-authorized Eve `load_skill` wrapper for external Telegram groups.
  *
  * Exports:
- * - `createExternalGroupLoadSkillTool`: injectable wrapper for isolated authorization tests.
- * - `externalGroupLoadSkillTool`: production wrapper over Eve's native skill loader.
+ * - `createExternalGroupLoadSkillTool`: injectable Eve-branded wrapper for authorization tests.
+ * - `externalGroupLoadSkillTool`: production `defineTool` wrapper over Eve's native skill loader.
  */
-import { type ToolContext, type ToolDefinition } from "eve/tools";
+import { defineTool, type ToolContext, type ToolDefinition } from "eve/tools";
 import { loadSkill } from "eve/tools/defaults";
 
 import { AppError } from "../app-error.js";
@@ -29,7 +29,7 @@ function forbidden(): AppError {
 export function createExternalGroupLoadSkillTool(
   dependencies: ExternalGroupLoadSkillDependencies,
 ): AnyToolDefinition {
-  return {
+  return defineTool({
     ...(loadSkill as AnyToolDefinition),
     async execute(input, ctx) {
       const skill = (input as { skill?: unknown } | null)?.skill;
@@ -47,7 +47,7 @@ export function createExternalGroupLoadSkillTool(
       if (!allowed.has(skill)) throw forbidden();
       return await dependencies.executeNative(input, ctx);
     },
-  };
+  });
 }
 
 const nativeLoadSkill = loadSkill as AnyToolDefinition;

--- a/agent/lib/memory-critical-flow.integration.test.ts
+++ b/agent/lib/memory-critical-flow.integration.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Critical main-agent memory path integration tests.
+ *
+ * Constructs covered:
+ * - Step-scoped capability resolution returns Eve-branded `remember` and `load_skill` definitions.
+ * - `bindMemoryTurnSources` freezes the current verified Telegram source for the Eve turn.
+ * - The emitted `remember` tool persists one group claim, evidence, operation, audit, and index job.
+ * - Turn completion releases the source binding, and subagents never receive `remember`.
+ * - A durable background review writes from its exact batch source and retires cleanly.
+ */
+import type { ToolContext } from "eve/tools";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import capabilities from "../tools/capabilities.js";
+import { closeDatabase, database } from "./database.js";
+import { createMainAgentMemoryFixture } from "./memory-agent-write.integration-fixtures.js";
+import { memoryReviewDispatchRepository } from "./memory-review/memory-review-dispatch-repository.js";
+import { memoryReviewRepository } from "./memory-review/memory-review-repository.js";
+import { memoryReviewSessionRepository } from "./memory-review/memory-review-session-repository.js";
+import {
+  bindMemoryTurnSources,
+  releaseMemoryTurnSources,
+  resolveMemoryTurnSource,
+} from "./memory-turn-source.js";
+
+const describeWithDatabase = process.env.RUN_DATABASE_INTEGRATION_TESTS === "true"
+  ? describe
+  : describe.skip;
+const EVE_TOOL_BRAND = Symbol.for("eve:tool-brand");
+
+function sessionContext(input: {
+  applicationSessionId: string;
+  conversationId: string;
+  familyId: string;
+  groupId: string;
+  timelineEntryId: string;
+}) {
+  const attributes = {
+    applicationSessionId: input.applicationSessionId,
+    familyId: input.familyId,
+    groupId: input.groupId,
+    groupType: "external",
+    memoryScopes: ["group"],
+    role: "external",
+    skillAllowlist: ["pohuy"],
+    telegramChatType: "supergroup",
+    telegramConversationId: input.conversationId,
+    telegramTimelineEntryId: input.timelineEntryId,
+    telegramTimelineVisibleEntryIds: [input.timelineEntryId],
+    telegramUserId: "external-memory-author",
+    toolAllowlist: ["remember"],
+  };
+  const auth = {
+    current: {
+      attributes,
+      authenticator: "telegram",
+      principalId: "telegram:external-memory-author",
+      principalType: "user",
+    },
+    initiator: null,
+  };
+  return {
+    channel: { kind: "telegram" },
+    messages: [],
+    session: {
+      auth,
+      id: "eve-critical-memory-session",
+      turn: { id: "eve-critical-memory-turn" },
+    },
+  };
+}
+
+function reviewContext(input: {
+  applicationSessionId: string;
+  batchId: string;
+  conversationId: string;
+  familyId: string;
+  groupId: string;
+  sourceEntryIds: string[];
+  userId: string;
+}) {
+  return {
+    channel: { kind: "memory-review" },
+    messages: [],
+    session: {
+      auth: {
+        current: {
+          attributes: {
+            applicationSessionId: input.applicationSessionId,
+            familyId: input.familyId,
+            groupId: input.groupId,
+            groupType: "family_private",
+            memoryReviewBatchId: input.batchId,
+            memoryReviewMode: "background",
+            memoryReviewSourceEntryIds: input.sourceEntryIds,
+            memoryScopes: ["family"],
+            role: "owner",
+            telegramChatType: "supergroup",
+            telegramConversationId: input.conversationId,
+            telegramUserId: "agent-memory-author",
+          },
+          authenticator: "memory-review",
+          principalId: input.userId,
+          principalType: "user",
+        },
+        initiator: null,
+      },
+      id: "eve-background-memory-session",
+      turn: { id: "eve-background-memory-turn" },
+    },
+  };
+}
+
+describeWithDatabase("critical main-agent memory paths", () => {
+  beforeEach(async () => {
+    await database().query("TRUNCATE users, families CASCADE");
+  });
+
+  afterAll(closeDatabase);
+
+  it("resolves, binds, writes, audits, and releases one source-backed memory", async () => {
+    const family = await database().query<{ id: string }>(
+      "INSERT INTO families (name) VALUES ('Critical memory flow') RETURNING id",
+    );
+    const group = await database().query<{ id: string }>(
+      `INSERT INTO telegram_groups
+         (family_id, telegram_chat_id, title, type, message_mode, tool_allowlist, skill_allowlist)
+       VALUES ($1, '-100-critical-memory', 'Critical memory', 'external', 'addressed_only',
+               ARRAY['remember'], ARRAY['pohuy'])
+       RETURNING id`,
+      [family.rows[0]!.id],
+    );
+    const conversation = await database().query<{ id: string }>(
+      "SELECT id FROM application_conversations WHERE telegram_group_id = $1",
+      [group.rows[0]!.id],
+    );
+    const participant = await database().query<{ id: string }>(
+      `INSERT INTO conversation_participants
+         (conversation_id, family_id, scope, scope_partition_key, telegram_user_id,
+          display_name_snapshot, first_observed_at, last_observed_at)
+       VALUES ($1, $2, 'group', $3, 'external-memory-author', 'Гость', now(), now())
+       RETURNING id`,
+      [conversation.rows[0]!.id, family.rows[0]!.id, group.rows[0]!.id],
+    );
+    const message = await database().query<{ id: string }>(
+      `INSERT INTO telegram_group_messages
+         (conversation_id, group_id, telegram_message_id, sequence_id, actor_kind, actor_id,
+          telegram_user_id, sender_display_name, sender_is_bot, message_kind, content_text, sent_at)
+       VALUES ($1, $2, 7001, 1, 'user', 'telegram:external-memory-author',
+               'external-memory-author', 'Гость', false, 'text',
+               'Запомни: проект использует синий корпус', now())
+       RETURNING id`,
+      [conversation.rows[0]!.id, group.rows[0]!.id],
+    );
+    const appSession = await database().query<{ id: string }>(
+      `INSERT INTO conversation_sessions
+         (thread_id, generation, family_id, group_id, scope, kind, conversation_key,
+          continuation_token, started_at, last_activity_at)
+       VALUES (gen_random_uuid(), 0, $1, $2, 'group', 'canonical', 'critical-memory',
+               'critical-memory:0', now(), now())
+       RETURNING id`,
+      [family.rows[0]!.id, group.rows[0]!.id],
+    );
+    const context = sessionContext({
+      applicationSessionId: appSession.rows[0]!.id,
+      conversationId: conversation.rows[0]!.id,
+      familyId: family.rows[0]!.id,
+      groupId: group.rows[0]!.id,
+      timelineEntryId: message.rows[0]!.id,
+    });
+
+    await bindMemoryTurnSources(context as never);
+    const surface = await capabilities.events["step.started"]?.({} as never, context as never);
+    expect(surface?.remember).toBeDefined();
+    expect(surface?.load_skill).toBeDefined();
+    expect((surface?.remember as unknown as Record<symbol, unknown>)[EVE_TOOL_BRAND]).toBe(true);
+    expect((surface?.load_skill as unknown as Record<symbol, unknown>)[EVE_TOOL_BRAND]).toBe(true);
+
+    const result = await surface!.remember!.execute({
+      basis: "user_requested",
+      content: "Проект использует синий корпус",
+      kind: "fact",
+      scope: "group",
+      sensitivity: "normal",
+      subject: { kind: "current_author" },
+    }, {
+      callId: "critical-memory-call",
+      session: context.session,
+    } as unknown as ToolContext);
+    if (Symbol.asyncIterator in Object(result)) {
+      throw new Error("AGENT_MEMORY_CRITICAL_FLOW_STREAM_UNEXPECTED: remember returned a stream");
+    }
+    expect(result).toMatchObject({
+      item: {
+        content: "Проект использует синий корпус",
+        scope: "group",
+      },
+    });
+
+    await expect(database().query(
+      `SELECT item.content, item.group_id, item.subject_participant_id,
+              evidence.timeline_entry_id, operation.eve_session_id, operation.eve_turn_id,
+              audit.event_type,
+              EXISTS (SELECT 1 FROM memory_embedding_jobs AS job
+                      WHERE job.memory_item_id = item.id) AS embedding_job
+         FROM memory_items AS item
+         JOIN claim_evidence AS evidence ON evidence.claim_id = item.id
+         JOIN memory_mutation_operations AS operation ON operation.memory_item_id = item.id
+         JOIN audit_events AS audit ON audit.subject_id = item.id
+        WHERE operation.operation_key = 'critical-memory-call'`,
+    )).resolves.toMatchObject({ rows: [{
+      content: "Проект использует синий корпус",
+      embedding_job: true,
+      eve_session_id: "eve-critical-memory-session",
+      eve_turn_id: "eve-critical-memory-turn",
+      event_type: "memory.created",
+      group_id: group.rows[0]!.id,
+      subject_participant_id: participant.rows[0]!.id,
+      timeline_entry_id: message.rows[0]!.id,
+    }] });
+
+    const subagentSurface = await capabilities.events["step.started"]?.({} as never, {
+      ...context,
+      channel: { kind: "subagent" },
+    } as never);
+    expect(subagentSurface).not.toHaveProperty("remember");
+
+    await releaseMemoryTurnSources(context as never);
+    await expect(resolveMemoryTurnSource(context as never, {
+      familyId: family.rows[0]!.id,
+      groupId: group.rows[0]!.id,
+      role: "external",
+      scopes: ["group"],
+      telegramUserId: "external-memory-author",
+      userId: null,
+    })).rejects.toMatchObject({ code: "AGENT_MEMORY_EXPLICIT_SOURCE_INVALID" });
+  });
+
+  it("writes and terminalizes one durable background review batch", async () => {
+    const fixture = await createMainAgentMemoryFixture();
+    const sourceEntryIds = [fixture.timelineEntryId];
+
+    // Fifty passive messages cross the configured durable review boundary exactly once.
+    for (let sequence = 2; sequence <= 51; sequence += 1) {
+      const message = await database().query<{ id: string }>(
+        `INSERT INTO telegram_group_messages
+           (conversation_id, group_id, telegram_message_id, sequence_id, actor_kind, actor_id,
+            telegram_user_id, sender_display_name, sender_is_bot, message_kind, content_text, sent_at)
+         VALUES ($1, $2, $3, $3, 'user', 'telegram:agent-memory-author',
+                 'agent-memory-author', 'Анна', false, 'text', $4, now()) RETURNING id`,
+        [fixture.conversationId, fixture.groupId, sequence,
+          sequence === 50 ? "Анна предпочитает утренние тренировки" : `Фоновое сообщение ${sequence}`],
+      );
+      sourceEntryIds.push(message.rows[0]!.id);
+      await memoryReviewRepository.observePassiveMessage({
+        groupId: fixture.groupId,
+        timelineEntryId: message.rows[0]!.id,
+      });
+    }
+
+    // Reproduce the durable dispatcher and channel turn-start boundaries before tool execution.
+    const [batch] = await memoryReviewDispatchRepository.claimPending({
+      leaseMilliseconds: 60_000,
+      limit: 1,
+      now: new Date("2026-08-13T10:00:00.000Z"),
+    });
+    expect(batch?.sourceEntryIds).toEqual(sourceEntryIds.slice(0, 50));
+    const appSession = await memoryReviewSessionRepository.prepare(
+      batch!,
+      new Date("2026-08-13T10:00:01.000Z"),
+    );
+    expect(await memoryReviewDispatchRepository.markDispatchStarted(batch!, appSession.id)).toBe(true);
+    await memoryReviewRepository.bindEveTurn({
+      applicationSessionId: appSession.id,
+      batchId: batch!.batchId,
+      eveSessionId: "eve-background-memory-session",
+      eveTurnId: "eve-background-memory-turn",
+    });
+    const context = reviewContext({
+      applicationSessionId: appSession.id,
+      batchId: batch!.batchId,
+      conversationId: fixture.conversationId,
+      familyId: fixture.familyId,
+      groupId: fixture.groupId,
+      sourceEntryIds: batch!.sourceEntryIds,
+      userId: fixture.userId,
+    });
+    await bindMemoryTurnSources(context as never);
+
+    // The review surface must execute the same source-backed writer used by ordinary main turns.
+    const surface = await capabilities.events["step.started"]?.({} as never, context as never);
+    expect((surface?.remember as unknown as Record<symbol, unknown>)[EVE_TOOL_BRAND]).toBe(true);
+    const result = await surface!.remember!.execute({
+      basis: "agent_inferred",
+      content: "Анна предпочитает утренние тренировки",
+      kind: "preference",
+      scope: "family",
+      sensitivity: "normal",
+      sourceSequence: "50",
+      subject: { kind: "source_author" },
+    }, {
+      callId: "background-memory-call",
+      session: context.session,
+    } as unknown as ToolContext);
+    if (Symbol.asyncIterator in Object(result)) {
+      throw new Error("AGENT_MEMORY_CRITICAL_FLOW_STREAM_UNEXPECTED: remember returned a stream");
+    }
+
+    // Successful lifecycle completion advances the lane and releases all temporary retention rows.
+    await memoryReviewRepository.completeBatch({
+      batchId: batch!.batchId,
+      completedAt: new Date("2026-08-13T10:00:02.000Z"),
+      eveSessionId: "eve-background-memory-session",
+      eveTurnId: "eve-background-memory-turn",
+    });
+    await releaseMemoryTurnSources(context as never);
+    await expect(database().query(
+      `SELECT item.content, evidence.timeline_entry_id, batch.status::text AS batch_status,
+              app_session.task_state::text AS task_state, app_session.retired_at,
+              lane.processed_through_sequence::text AS lane_cursor,
+              count(batch_source.timeline_entry_id)::integer AS retained_batch_sources,
+              count(turn_source.timeline_entry_id)::integer AS retained_turn_sources
+         FROM memory_items AS item
+         JOIN claim_evidence AS evidence ON evidence.claim_id = item.id
+         JOIN memory_mutation_operations AS operation ON operation.memory_item_id = item.id
+         JOIN memory_review_batches AS batch ON batch.id = $1
+         JOIN memory_review_lanes AS lane ON lane.id = batch.lane_id
+         JOIN conversation_sessions AS app_session ON app_session.id = batch.application_session_id
+         LEFT JOIN memory_review_batch_sources AS batch_source ON batch_source.batch_id = batch.id
+         LEFT JOIN memory_turn_sources AS turn_source
+           ON turn_source.eve_session_id = operation.eve_session_id
+          AND turn_source.eve_turn_id = operation.eve_turn_id
+        WHERE operation.operation_key = 'background-memory-call'
+        GROUP BY item.id, evidence.timeline_entry_id, batch.status, app_session.task_state,
+                 app_session.retired_at, lane.processed_through_sequence`,
+      [batch!.batchId],
+    )).resolves.toMatchObject({ rows: [{
+      batch_status: "completed",
+      content: "Анна предпочитает утренние тренировки",
+      lane_cursor: "50",
+      retained_batch_sources: 0,
+      retained_turn_sources: 0,
+      retired_at: expect.any(Date),
+      task_state: "completed",
+      timeline_entry_id: sourceEntryIds[49],
+    }] });
+  });
+});

--- a/agent/lib/tool-policy/dynamic-capabilities.test.ts
+++ b/agent/lib/tool-policy/dynamic-capabilities.test.ts
@@ -2,10 +2,11 @@
  * Eve dynamic capability resolver tests.
  *
  * Constructs covered:
- * - `capabilities`: one turn-scoped map per verified mode instead of static descriptors.
+ * - `capabilities`: one step-scoped map per verified mode instead of replayed helper closures.
  * - An unresolvable mode or failed policy lookup retains only fail-closed baseline wrappers.
  * - Scheduled history is visible only with a successfully resolved application-core policy.
  * - Live policy changes affect visibility on the next turn and execution checks enforce revocation.
+ * - Every returned entry carries Eve's `defineTool` brand required by the runtime lifecycle.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -23,12 +24,14 @@ import {
   FRAMEWORK_TOOLS_DENIED_IN_EXTERNAL_GROUPS,
 } from "./group-tool-catalog.js";
 
+const EVE_TOOL_BRAND = Symbol.for("eve:tool-brand");
+
 function resolve(
   attributes: Record<string, unknown> | null,
   initiatorAttributes: Record<string, unknown> | null = null,
   authenticator = "telegram",
 ) {
-  return capabilities.events["turn.started"]?.({} as never, {
+  return capabilities.events["step.started"]?.({} as never, {
     channel: { kind: "telegram" },
     messages: [],
     session: {
@@ -55,6 +58,11 @@ describe("dynamic capability resolver", () => {
   beforeEach(() => {
     loadCurrentExternalGroupCapabilities.mockReset();
     loadCurrentExternalGroupCapabilities.mockResolvedValue(new Set());
+  });
+
+  it("resolves tools only at step scope so helper closures are rebuilt before every model call", () => {
+    expect(capabilities.events["step.started"]).toBeTypeOf("function");
+    expect(capabilities.events["turn.started"]).toBeUndefined();
   });
 
   it("emits the private surface for a verified private chat", async () => {
@@ -127,6 +135,12 @@ describe("dynamic capability resolver", () => {
       familyId: "family-1",
       groupId: "group-1",
     });
+    for (const [toolName, definition] of Object.entries(surface ?? {})) {
+      expect(
+        (definition as unknown as Record<symbol, unknown>)[EVE_TOOL_BRAND],
+        `${toolName} review tool must be created through defineTool()`,
+      ).toBe(true);
+    }
   });
 
   it("emits load_skill only when the external group has a current skill grant", async () => {
@@ -141,6 +155,47 @@ describe("dynamic capability resolver", () => {
     });
 
     expect(surface).toHaveProperty("load_skill");
+  });
+
+  it.each([
+    ["private", {
+      memoryScopes: ["personal", "family"],
+      telegramChatType: "private",
+    }],
+    ["family", {
+      groupType: "family_private",
+      memoryScopes: ["family"],
+      telegramChatType: "supergroup",
+    }],
+    ["external denied skill", {
+      familyId: "family-1",
+      groupId: "group-1",
+      groupType: "external",
+      memoryScopes: ["group"],
+      telegramChatType: "supergroup",
+      toolAllowlist: ["remember"],
+    }],
+    ["external granted skill", {
+      familyId: "family-1",
+      groupId: "group-1",
+      groupType: "external",
+      memoryScopes: ["group"],
+      skillAllowlist: ["pohuy"],
+      telegramChatType: "supergroup",
+      toolAllowlist: ["remember"],
+    }],
+  ] as const)("returns only Eve-branded tools for %s mode", async (_name, attributes) => {
+    loadCurrentExternalGroupCapabilities.mockResolvedValue(new Set(["remember"]));
+
+    const surface = await resolve(attributes as unknown as Record<string, unknown>);
+
+    expect(Object.keys(surface ?? {}).length).toBeGreaterThan(0);
+    for (const [toolName, definition] of Object.entries(surface ?? {})) {
+      expect(
+        (definition as unknown as Record<symbol, unknown>)[EVE_TOOL_BRAND],
+        `${toolName} must be created through defineTool()`,
+      ).toBe(true);
+    }
   });
 
   it("revokes a capability that is absent from the current database policy", async () => {

--- a/agent/lib/tool-surface.test.ts
+++ b/agent/lib/tool-surface.test.ts
@@ -6,6 +6,7 @@
  * - Exact application tool-module allowlist after CRUD consolidation.
  * - Exact static package directories plus the single dynamic policy resolver.
  * - The opt-in tone skill lives outside static Eve discovery.
+ * - The compiled dynamic resolver stays step-scoped and avoids durable helper-closure replay.
  */
 import { readFile, readdir } from "node:fs/promises";
 import { resolve } from "node:path";
@@ -127,5 +128,12 @@ describe("agent capability surface", () => {
         expect(files).toContain("SKILL.md");
       }),
     );
+  });
+
+  it("authors the whole dynamic tool surface at step scope", async () => {
+    const source = await readFile(`${AGENT_ROOT}/tools/capabilities.ts`, "utf8");
+
+    expect(source).toContain('"step.started": async');
+    expect(source).not.toContain('"turn.started"');
   });
 });

--- a/agent/tools/capabilities.ts
+++ b/agent/tools/capabilities.ts
@@ -7,7 +7,9 @@
  * Key constructs:
  * - One resolver owns the whole application surface: two resolvers emitting the same tool name is
  *   an ambiguity Eve rejects, and a single map keeps mode and capability policy consistent.
- * - Tool and skill visibility share one turn boundary; execution still rechecks live revocation.
+ * - Step-scoped resolution rebuilds helper-defined tools before every model call, so Eve never
+ *   needs to replay non-inline helper closures from turn metadata.
+ * - Tool and skill policy share verified auth; execution still rechecks live revocation.
  * - Each independent policy lookup fails closed for its own application capability class.
  */
 import { defineDynamic } from "eve/tools";
@@ -32,7 +34,7 @@ import { buildMemoryReviewToolSurface } from "../lib/memory-review/memory-review
 
 export default defineDynamic({
   events: {
-    "turn.started": async (_event, ctx) => {
+    "step.started": async (_event, ctx) => {
       if (isMemoryReviewSession(ctx)) {
         if (ctx.session.auth.current?.attributes.groupType !== "external") {
           return buildMemoryReviewToolSurface();

--- a/docs/releases/v0.15.3.md
+++ b/docs/releases/v0.15.3.md
@@ -1,0 +1,49 @@
+# Osinara v0.15.3
+
+Критический patch-релиз восстановления полного dynamic tool surface и записи долговременной памяти.
+
+## Исправления
+
+- External-group `load_skill` wrapper теперь всегда создаётся через публичный Eve `defineTool`.
+  Ранее при активном group skill grant wrapper не имел runtime brand Eve `0.32.0`; framework
+  отклонял весь dynamic resolver, поэтому вместе с `load_skill` исчезали `remember` и остальные
+  разрешённые application tools.
+- Единый mode-scoped capability resolver перенесён с `turn.started` на `step.started`. Helper-defined
+  wrappers пересобираются перед каждым model call и больше не зависят от durable replay metadata,
+  которого у замыканий, созданных вне discovered module, нет.
+- Fail-closed policy сохранена: external capabilities по-прежнему являются пересечением verified
+  session snapshot и актуального PostgreSQL allowlist, а каждый sensitive execution boundary повторно
+  проверяет live registration и revocation.
+- Root-only контракт памяти не изменён: основной агент получает source-backed `remember`, subagent
+  этот инструмент не получает, а background review может сохранять только normal-память из точного
+  `sourceSequence` своего durable batch.
+
+## Защита от регрессии
+
+- Все dynamic surfaces для private, family, external и background review теперь проверяются на
+  обязательный Eve tool brand, включая external mode с активным skill grant.
+- Добавлен PostgreSQL critical-flow для external-группы: verified Telegram source связывается с Eve
+  turn, dynamic `remember` создаёт claim, evidence, operation, audit и embedding job, после чего
+  terminal boundary освобождает временный source binding.
+- Добавлен PostgreSQL critical-flow для background review: durable batch из 50 сообщений проходит
+  binding, source-backed write, completion, продвижение lane cursor, очистку retention и retirement
+  one-shot application session.
+- После `eve build` отдельный validator проверяет compiled capabilities region в
+  `.output/server/index.mjs` и останавливает release, если resolver снова станет session- или
+  turn-scoped.
+
+## Production-аудит
+
+- Проверено 109 существующих memory items: 108 имеют готовый локальный E5 index, одна запись от
+  2 августа сохранилась в PostgreSQL, но имеет terminal provider embedding failure. Потери самой
+  записи нет; автоматический retry не добавлялся без отдельной явной идемпотентной политики.
+- Единственный `ambiguous` background review batch создан до этого hotfix. Repository уже удалил его
+  50 temporary source rows и terminalized one-shot session; повторный model call запрещён, чтобы не
+  дублировать возможную запись памяти.
+
+## Проверка
+
+- Targeted unit tests проверяют Eve brand, step lifecycle и compiled build guard.
+- Targeted PostgreSQL integration tests выполняют обычный external write и полный background review.
+- Полный production-equivalent Docker gate выполняется перед публикацией immutable release.
+- Установка требует отдельного owner approval в привязанном личном Telegram-чате.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "private": true,
   "type": "module",
   "imports": {
@@ -8,7 +8,7 @@
     "#evals/*": "./evals/*"
   },
   "scripts": {
-    "build": "eve build",
+    "build": "eve build && node --experimental-strip-types scripts/validate-eve-tool-surface-build.ts",
     "build:runtime": "esbuild scripts/create-bootstrap-code.ts scripts/migrate.ts scripts/memory-embedding-worker.ts scripts/memory-extraction-worker.ts scripts/telegram-ingress-worker.ts scripts/validate-model-provider-config.ts services/sandbox-runner/main.ts services/sandbox-egress-proxy/main.ts --bundle --platform=node --format=esm --target=node24 --packages=external --outbase=. --outdir=.runtime",
     "bootstrap:code": "node --experimental-strip-types scripts/create-bootstrap-code.ts",
     "dev": "eve dev",

--- a/scripts/validate-eve-tool-surface-build.test.ts
+++ b/scripts/validate-eve-tool-surface-build.test.ts
@@ -33,6 +33,21 @@ describe("compiled Eve dynamic tool surface", () => {
     },
   );
 
+  it("rejects a stray step marker beside an incorrect resolver key", () => {
+    const incorrectResolver = [
+      "prefix",
+      "#region agent/tools/capabilities.ts",
+      `const marker = '"step.started"';`,
+      `defineDynamic({ events: { "message.created": async () => ({}) } });`,
+      "//#endregion",
+      "suffix",
+    ].join("\n");
+
+    expect(() => validateCompiledDynamicToolSurface(incorrectResolver)).toThrow(
+      "AGENT_EVE_DYNAMIC_TOOL_BUILD_INVALID",
+    );
+  });
+
   it("rejects absent and unterminated capabilities regions", () => {
     expect(() => validateCompiledDynamicToolSurface("no capabilities"))
       .toThrow("AGENT_EVE_DYNAMIC_TOOL_BUILD_INVALID");

--- a/scripts/validate-eve-tool-surface-build.test.ts
+++ b/scripts/validate-eve-tool-surface-build.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Post-build Eve dynamic tool validation tests.
+ *
+ * Constructs covered:
+ * - Exact step-scoped capabilities region is accepted.
+ * - Missing, unterminated, and replay-prone resolver regions fail with a stable error code.
+ */
+import { describe, expect, it } from "vitest";
+
+import { validateCompiledDynamicToolSurface } from "./validate-eve-tool-surface-build.js";
+
+function compiled(event: "session.started" | "step.started" | "turn.started"): string {
+  return [
+    "prefix",
+    "#region agent/tools/capabilities.ts",
+    `defineDynamic({ events: { \"${event}\": async () => ({}) } });`,
+    "//#endregion",
+    "suffix",
+  ].join("\n");
+}
+
+describe("compiled Eve dynamic tool surface", () => {
+  it("accepts the step-scoped resolver", () => {
+    expect(() => validateCompiledDynamicToolSurface(compiled("step.started"))).not.toThrow();
+  });
+
+  it.each(["session.started", "turn.started"] as const)(
+    "rejects the replay-prone %s resolver",
+    (event) => {
+      expect(() => validateCompiledDynamicToolSurface(compiled(event))).toThrow(
+        "AGENT_EVE_DYNAMIC_TOOL_BUILD_INVALID",
+      );
+    },
+  );
+
+  it("rejects absent and unterminated capabilities regions", () => {
+    expect(() => validateCompiledDynamicToolSurface("no capabilities"))
+      .toThrow("AGENT_EVE_DYNAMIC_TOOL_BUILD_INVALID");
+    expect(() => validateCompiledDynamicToolSurface(CAPABILITIES_REGION_FIXTURE))
+      .toThrow("AGENT_EVE_DYNAMIC_TOOL_BUILD_INVALID");
+  });
+});
+
+const CAPABILITIES_REGION_FIXTURE = "#region agent/tools/capabilities.ts\nstep.started";

--- a/scripts/validate-eve-tool-surface-build.ts
+++ b/scripts/validate-eve-tool-surface-build.ts
@@ -12,6 +12,8 @@ import { fileURLToPath } from "node:url";
 
 const CAPABILITIES_REGION = "#region agent/tools/capabilities.ts";
 const REGION_END = "//#endregion";
+const DYNAMIC_EVENTS_PATTERN = /defineDynamic\s*\(\s*\{\s*events\s*:\s*\{\s*"([^"]+)"\s*:/gu;
+const REPLAY_PRONE_EVENT_KEY_PATTERN = /"(?:session|turn)\.started"\s*:/u;
 
 function buildContractError(reason: string): Error {
   return new Error(
@@ -29,10 +31,11 @@ export function validateCompiledDynamicToolSurface(compiledServer: string): void
 
   // Helper-created definitions are intentionally rebuilt at every step. A turn-scoped resolver
   // would require AST-generated replay metadata that helper modules cannot provide.
-  if (!region.includes('"step.started"')) {
+  const dynamicEvents = [...region.matchAll(DYNAMIC_EVENTS_PATTERN)];
+  if (dynamicEvents.length !== 1 || dynamicEvents[0]?.[1] !== "step.started") {
     throw buildContractError("отсутствует step.started resolver");
   }
-  if (region.includes('"turn.started"') || region.includes('"session.started"')) {
+  if (REPLAY_PRONE_EVENT_KEY_PATTERN.test(region)) {
     throw buildContractError("обнаружен replay-prone session/turn resolver");
   }
 }

--- a/scripts/validate-eve-tool-surface-build.ts
+++ b/scripts/validate-eve-tool-surface-build.ts
@@ -1,0 +1,47 @@
+/**
+ * Post-build Eve dynamic tool surface validation.
+ *
+ * Exports:
+ * - `validateCompiledDynamicToolSurface`: verifies the generated capabilities resolver contract.
+ *
+ * CLI behavior:
+ * - Reads `.output/server/index.mjs` after `eve build` and fails before release on contract drift.
+ */
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const CAPABILITIES_REGION = "#region agent/tools/capabilities.ts";
+const REGION_END = "//#endregion";
+
+function buildContractError(reason: string): Error {
+  return new Error(
+    `AGENT_EVE_DYNAMIC_TOOL_BUILD_INVALID: Скомпилированный tool resolver нарушает ` +
+      `step-scoped контракт Eve: ${reason}`,
+  );
+}
+
+export function validateCompiledDynamicToolSurface(compiledServer: string): void {
+  const regionStart = compiledServer.indexOf(CAPABILITIES_REGION);
+  if (regionStart < 0) throw buildContractError("не найден capabilities region");
+  const regionEnd = compiledServer.indexOf(REGION_END, regionStart);
+  if (regionEnd < 0) throw buildContractError("capabilities region не завершён");
+  const region = compiledServer.slice(regionStart, regionEnd);
+
+  // Helper-created definitions are intentionally rebuilt at every step. A turn-scoped resolver
+  // would require AST-generated replay metadata that helper modules cannot provide.
+  if (!region.includes('"step.started"')) {
+    throw buildContractError("отсутствует step.started resolver");
+  }
+  if (region.includes('"turn.started"') || region.includes('"session.started"')) {
+    throw buildContractError("обнаружен replay-prone session/turn resolver");
+  }
+}
+
+async function main(): Promise<void> {
+  const compiledServer = await readFile(".output/server/index.mjs", "utf8");
+  validateCompiledDynamicToolSurface(compiledServer);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}


### PR DESCRIPTION
## Что исправлено

- создаёт external `load_skill` wrapper через Eve `defineTool`, чтобы runtime не отбрасывал весь dynamic tool surface
- пересобирает mode-scoped tools на `step.started`, исключая durable replay helper closures
- добавляет compiled Eve build guard и brand regressions для private, family, external и review surfaces
- добавляет PostgreSQL critical flows для external `remember` и полного background memory review lifecycle
- выпускает patch metadata и подробный changelog `v0.15.3`

## Проверка

- `npm run typecheck`
- `npm test`: 1442 passed, 254 DB-gated skipped
- `npm run build`: Eve build и compiled resolver validator прошли
- `docker compose -f compose.test.yaml up --build --abort-on-container-exit --exit-code-from tests`: 1695 passed, 1 skipped, exit 0
- Eve discovery: один `tools/capabilities.ts`, 0 errors, 0 warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Что изменено

- Добавлена внешняя обёртка `load_skill` через Eve `defineTool`.
- Динамические инструменты теперь пересоздаются на каждом `step.started`.
- Исключены долговечные replay-вспомогательные замыкания.
- Добавлена post-build проверка Eve tool surface.
- Добавлены регрессионные проверки брендинга для private, family, external и review поверхностей.
- Добавлено покрытие PostgreSQL для внешнего `remember` и полного жизненного цикла фонового memory review.
- Версия пакета обновлена до `0.15.3`.
- Добавлен changelog для выпуска `v0.15.3`.

## Проверка

- Пройдены type checking и тесты.
- Пройдена сборка Eve и проверка скомпилированного resolver.
- Пройдены Docker-тесты и Eve discovery.
- Основной набор: 1 442 успешных теста и 254 пропуска из-за DB-gated условий.
- Docker: 1 695 успешных тестов и 1 пропуск.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->