### PR TITLE
Fix memory review sandbox recovery

### DIFF
--- a/agent/lib/memory-review/memory-review-owner-alert-repository.ts
+++ b/agent/lib/memory-review/memory-review-owner-alert-repository.ts
@@ -42,7 +42,10 @@ export async function enqueueMemoryReviewOwnerAlert(
   );
   if (result.rowCount !== 1) {
     const existing = await client.query(
-      "SELECT 1 FROM memory_review_owner_alerts WHERE batch_id = $1",
+      `SELECT 1 FROM memory_review_owner_alerts AS alert
+        JOIN memory_review_batches AS batch ON batch.id = alert.batch_id
+       WHERE alert.batch_id = $1
+         AND alert.recovery_generation = batch.recovery_attempts`,
       [batchId],
     );
     if (!existing.rows[0]) throw new AppError(

--- a/agent/lib/memory-review/memory-review-owner-alert-repository.ts
+++ b/agent/lib/memory-review/memory-review-owner-alert-repository.ts
@@ -30,14 +30,14 @@ export async function enqueueMemoryReviewOwnerAlert(
   const result = await client.query(
     `INSERT INTO memory_review_owner_alerts
        (batch_id, family_id, group_id, group_title_snapshot, from_sequence,
-        through_sequence, batch_diagnostic_code)
+         through_sequence, batch_diagnostic_code, recovery_generation)
      SELECT batch.id, conversation.family_id, telegram_group.id, telegram_group.title,
-            batch.from_sequence, batch.through_sequence, $2
+             batch.from_sequence, batch.through_sequence, $2, batch.recovery_attempts
        FROM memory_review_batches AS batch
        JOIN application_conversations AS conversation ON conversation.id = batch.conversation_id
        JOIN telegram_groups AS telegram_group ON telegram_group.id = conversation.telegram_group_id
       WHERE batch.id = $1 AND batch.status IN ('failed', 'ambiguous')
-     ON CONFLICT (batch_id) DO NOTHING`,
+     ON CONFLICT (batch_id, recovery_generation) DO NOTHING`,
     [batchId, diagnosticCode],
   );
   if (result.rowCount !== 1) {

--- a/agent/lib/memory-review/memory-review-sandbox-recovery-migration.integration.test.ts
+++ b/agent/lib/memory-review/memory-review-sandbox-recovery-migration.integration.test.ts
@@ -18,17 +18,30 @@ const describeWithDatabase = process.env.RUN_DATABASE_INTEGRATION_TESTS === "tru
   ? describe
   : describe.skip;
 const MIGRATION_NAME = "069_memory_review_sandbox_recovery.sql";
+const MIGRATION_ORDINAL = 69;
 const TEST_SCHEMA = "test_memory_review_sandbox_recovery";
 const BATCH_ID = "18329b3e-9563-4762-bc77-11641e8cbac1";
 const ORIGINAL_APPLICATION_SESSION_ID = "61b08325-2147-4047-9cb1-01d8210b89b4";
 const RECOVERY_APPLICATION_SESSION_ID = "26942f0e-76a7-4240-b241-ff866fc084b4";
 const ORIGINAL_EVE_SESSION_ID = "wrun_01KZWTTV5XAJY71V8DW3E7EM4X";
 const RECOVERY_EVE_SESSION_ID = "wrun_01KZZN63ATNDJSP336AVRKE1XW";
+const MIGRATION_NAME_PATTERN = /^(\d+)_.*\.sql$/u;
+
+function migrationOrdinal(name: string): number | null {
+  const match = MIGRATION_NAME_PATTERN.exec(name);
+  return match ? Number.parseInt(match[1]!, 10) : null;
+}
 
 async function applyMigrationsBefore069(client: import("pg").PoolClient): Promise<void> {
   const names = (await readdir(resolve("migrations")))
-    .filter((name) => name.endsWith(".sql") && name < MIGRATION_NAME)
-    .sort();
+    .filter((name) => {
+      const ordinal = migrationOrdinal(name);
+      return ordinal !== null && ordinal < MIGRATION_ORDINAL;
+    })
+    .sort((left, right) => {
+      const difference = migrationOrdinal(left)! - migrationOrdinal(right)!;
+      return difference || left.localeCompare(right);
+    });
   for (const name of names) {
     await client.query(await readFile(resolve("migrations", name), "utf8"));
   }
@@ -182,6 +195,7 @@ describeWithDatabase("069 memory review sandbox recovery migration", () => {
       ] });
     } finally {
       await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+      await client.query("RESET search_path");
       client.release();
     }
   });

--- a/agent/lib/memory-review/memory-review-sandbox-recovery-migration.integration.test.ts
+++ b/agent/lib/memory-review/memory-review-sandbox-recovery-migration.integration.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Migration 069 memory-review sandbox incident recovery tests.
+ *
+ * Constructs covered:
+ * - The exact twice-failed pre-model production batch is requeued with intact source evidence.
+ * - Existing owner-alert history remains durable across an operator-authorized recovery.
+ * - A later terminal outcome receives a distinct alert generation instead of being suppressed.
+ */
+import { readFile, readdir } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { closeDatabase, database } from "../database.js";
+import { enqueueMemoryReviewOwnerAlert } from "./memory-review-owner-alert-repository.js";
+
+const describeWithDatabase = process.env.RUN_DATABASE_INTEGRATION_TESTS === "true"
+  ? describe
+  : describe.skip;
+const MIGRATION_NAME = "069_memory_review_sandbox_recovery.sql";
+const TEST_SCHEMA = "test_memory_review_sandbox_recovery";
+const BATCH_ID = "18329b3e-9563-4762-bc77-11641e8cbac1";
+const ORIGINAL_APPLICATION_SESSION_ID = "61b08325-2147-4047-9cb1-01d8210b89b4";
+const RECOVERY_APPLICATION_SESSION_ID = "26942f0e-76a7-4240-b241-ff866fc084b4";
+const ORIGINAL_EVE_SESSION_ID = "wrun_01KZWTTV5XAJY71V8DW3E7EM4X";
+const RECOVERY_EVE_SESSION_ID = "wrun_01KZZN63ATNDJSP336AVRKE1XW";
+
+async function applyMigrationsBefore069(client: import("pg").PoolClient): Promise<void> {
+  const names = (await readdir(resolve("migrations")))
+    .filter((name) => name.endsWith(".sql") && name < MIGRATION_NAME)
+    .sort();
+  for (const name of names) {
+    await client.query(await readFile(resolve("migrations", name), "utf8"));
+  }
+}
+
+describeWithDatabase("069 memory review sandbox recovery migration", () => {
+  afterAll(closeDatabase);
+
+  it("requeues only the exact source-complete pre-model incident and advances alert generation", async () => {
+    const client = await database().connect();
+    try {
+      await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+      await client.query(`CREATE SCHEMA ${TEST_SCHEMA}`);
+      await client.query(`SET search_path TO ${TEST_SCHEMA}, public`);
+      await applyMigrationsBefore069(client);
+
+      // Build the exact durable identity and source range verified from the production trace.
+      const family = await client.query<{ id: string }>(
+        "INSERT INTO families (name) VALUES ('Sandbox recovery') RETURNING id",
+      );
+      const owner = await client.query<{ id: string }>(
+        `INSERT INTO users (telegram_user_id, display_name)
+         VALUES ('sandbox-recovery-owner', 'Владелец') RETURNING id`,
+      );
+      await client.query(
+        "INSERT INTO family_memberships (family_id, user_id, role) VALUES ($1, $2, 'owner')",
+        [family.rows[0]!.id, owner.rows[0]!.id],
+      );
+      const group = await client.query<{ id: string }>(
+        `INSERT INTO telegram_groups (family_id, telegram_chat_id, title, type, message_mode)
+         VALUES ($1, '-100-sandbox-recovery', 'Остриков пилит агентов',
+                 'family_private', 'addressed_only') RETURNING id`,
+        [family.rows[0]!.id],
+      );
+      const conversation = await client.query<{ id: string }>(
+        "SELECT id FROM application_conversations WHERE telegram_group_id = $1",
+        [group.rows[0]!.id],
+      );
+      await client.query(
+        `INSERT INTO telegram_group_messages
+           (conversation_id, group_id, telegram_message_id, sequence_id, actor_kind, actor_id,
+            telegram_user_id, sender_display_name, sender_is_bot, message_kind, content_text,
+            sent_at)
+         SELECT $1, $2, sequence, sequence, 'user', 'telegram:sandbox-recovery-owner',
+                'sandbox-recovery-owner', 'Владелец', false, 'text',
+                'Сообщение ' || sequence, now()
+           FROM generate_series(5540, 5589) AS sequence`,
+        [conversation.rows[0]!.id, group.rows[0]!.id],
+      );
+      const lane = await client.query<{ id: string }>(
+        `INSERT INTO memory_review_lanes
+           (conversation_id, processed_through_sequence)
+         VALUES ($1, 5539) RETURNING id`,
+        [conversation.rows[0]!.id],
+      );
+      await client.query(
+        `INSERT INTO memory_review_batches
+           (id, lane_id, conversation_id, batch_kind, status, predecessor_sequence,
+            from_sequence, through_sequence, source_count, eve_session_id, eve_turn_id,
+            diagnostic_code, recovery_attempts, last_recovery_diagnostic_code,
+            last_recovered_at, started_at, completed_at)
+         VALUES ($1, $2, $3, 'background', 'ambiguous', 5539, 5540, 5589, 50,
+                 $4, 'turn_0', 'AGENT_MEMORY_REVIEW_SESSION_FAILED_AMBIGUOUS', 1,
+                 'AGENT_MEMORY_REVIEW_SESSION_FAILED_AMBIGUOUS', now(), now(), now())`,
+        [BATCH_ID, lane.rows[0]!.id, conversation.rows[0]!.id, RECOVERY_EVE_SESSION_ID],
+      );
+
+      // Preserve both failed roots exactly as observed; neither root has a memory mutation row.
+      await client.query(
+        `INSERT INTO conversation_sessions
+           (id, thread_id, generation, family_id, group_id, scope, kind, task_state,
+            conversation_key, continuation_token, eve_session_id, started_at,
+            last_activity_at, retired_at, delete_after, memory_review_batch_id)
+         VALUES ($1::uuid, gen_random_uuid(), 0, $2, $3, 'family', 'proactive', 'failed',
+                 $4, $5, $6, now(), now(), now(), now() + interval '90 days', NULL)`,
+        [ORIGINAL_APPLICATION_SESSION_ID, family.rows[0]!.id, group.rows[0]!.id,
+          BATCH_ID, `retired-memory-review:${ORIGINAL_APPLICATION_SESSION_ID}`,
+          ORIGINAL_EVE_SESSION_ID],
+      );
+      await client.query(
+        `INSERT INTO conversation_sessions
+           (id, thread_id, generation, family_id, group_id, scope, kind, task_state,
+            conversation_key, continuation_token, eve_session_id, started_at,
+            last_activity_at, retired_at, delete_after, memory_review_batch_id)
+         VALUES ($1::uuid, gen_random_uuid(), 1, $2, $3, 'family', 'proactive', 'failed',
+                 $4, $5, $6, now(), now(), now(), now() + interval '90 days', $7::uuid)`,
+        [RECOVERY_APPLICATION_SESSION_ID, family.rows[0]!.id, group.rows[0]!.id,
+          BATCH_ID, `memory-review:${BATCH_ID}`, RECOVERY_EVE_SESSION_ID, BATCH_ID],
+      );
+      await client.query(
+        "UPDATE memory_review_batches SET application_session_id = $2 WHERE id = $1",
+        [BATCH_ID, RECOVERY_APPLICATION_SESSION_ID],
+      );
+      await client.query(
+        `INSERT INTO memory_review_batch_sources
+           (batch_id, conversation_id, timeline_entry_id, timeline_sequence)
+         SELECT $1, message.conversation_id, message.id, message.sequence_id
+           FROM telegram_group_messages AS message
+          WHERE message.conversation_id = $2
+            AND message.sequence_id BETWEEN 5540 AND 5589`,
+        [BATCH_ID, conversation.rows[0]!.id],
+      );
+      await client.query(
+        `INSERT INTO memory_review_owner_alerts
+           (batch_id, family_id, group_id, group_title_snapshot, from_sequence,
+            through_sequence, batch_diagnostic_code, status, delivery_started_at, completed_at)
+         VALUES ($1, $2, $3, 'Остриков пилит агентов', 5540, 5589,
+                 'AGENT_MEMORY_REVIEW_SESSION_FAILED_AMBIGUOUS', 'delivered', now(), now())`,
+        [BATCH_ID, family.rows[0]!.id, group.rows[0]!.id],
+      );
+
+      await client.query(await readFile(resolve("migrations", MIGRATION_NAME), "utf8"));
+
+      await expect(client.query(
+        `SELECT status::text, recovery_attempts, application_session_id, eve_session_id,
+                diagnostic_code FROM memory_review_batches WHERE id = $1`,
+        [BATCH_ID],
+      )).resolves.toMatchObject({ rows: [{
+        application_session_id: null,
+        diagnostic_code: null,
+        eve_session_id: null,
+        recovery_attempts: 2,
+        status: "pending",
+      }] });
+      await expect(client.query(
+        `SELECT count(*)::integer AS count, min(timeline_sequence)::text AS first,
+                max(timeline_sequence)::text AS last
+           FROM memory_review_batch_sources WHERE batch_id = $1`,
+        [BATCH_ID],
+      )).resolves.toMatchObject({ rows: [{ count: 50, first: "5540", last: "5589" }] });
+
+      // A later terminal outcome must not be hidden by the already-delivered generation-one alert.
+      await client.query(
+        `UPDATE memory_review_batches SET status = 'failed',
+                diagnostic_code = 'AGENT_MEMORY_REVIEW_TEST_TERMINAL', completed_at = now()
+          WHERE id = $1`,
+        [BATCH_ID],
+      );
+      await enqueueMemoryReviewOwnerAlert(
+        client,
+        BATCH_ID,
+        "AGENT_MEMORY_REVIEW_TEST_TERMINAL",
+      );
+      await expect(client.query(
+        `SELECT recovery_generation FROM memory_review_owner_alerts
+          WHERE batch_id = $1 ORDER BY recovery_generation`,
+        [BATCH_ID],
+      )).resolves.toMatchObject({ rows: [
+        { recovery_generation: 1 },
+        { recovery_generation: 2 },
+      ] });
+    } finally {
+      await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+      client.release();
+    }
+  });
+});

--- a/agent/lib/memory-upgrade-ledger.integration.test.ts
+++ b/agent/lib/memory-upgrade-ledger.integration.test.ts
@@ -100,6 +100,7 @@ const POST_V0101_MIGRATIONS = [
   "066_turn_bound_memory_delta_sources.sql",
   "067_durable_memory_review_batches.sql",
   "068_memory_review_recovery.sql",
+  "069_memory_review_sandbox_recovery.sql",
 ] as const;
 
 const EXPECTED_R0_R7_TABLES = [

--- a/agent/lib/sandbox-runner/runner-sandbox-backend.test.ts
+++ b/agent/lib/sandbox-runner/runner-sandbox-backend.test.ts
@@ -7,6 +7,7 @@
  * - Stable thread-scoped compute identity across changing Eve workflow roots.
  * - Reconnect metadata recreates disposable compute without rerunning `onSession`.
  * - Automatic trusted/restricted classification from workspace scopes.
+ * - Disabled internal sessions persist no mounts and cannot start sandbox compute.
  * - Shell and binary file delegation with workspace mutation indexing.
  * - Authored stop and server shutdown independently stop reattachable compute.
  */
@@ -74,6 +75,51 @@ afterEach(async () => {
 });
 
 describe("scopedWorkspaceRunner", () => {
+  it("persists a disabled session without creating sandbox compute", async () => {
+    const appRoot = await mkdtemp(join(tmpdir(), "osinara-runner-backend-"));
+    roots.push(appRoot);
+    const engine = fakeEngine();
+    const backend = scopedWorkspaceRunner({ baseUrl: await runnerUrl(engine) });
+    const initial = await backend.create({
+      runtimeContext: { appRoot },
+      sessionKey: BACKEND_SESSION_ID,
+      templateKey: null,
+      tags: { sessionId: SESSION_ID },
+    });
+
+    await initial.useSessionFn({ mounts: [], sandboxSessionId: SANDBOX_SESSION_ID });
+    const captured = await initial.captureState();
+
+    expect(captured.metadata).toEqual({
+      disabled: true,
+      mounts: [],
+      sandboxSessionId: SANDBOX_SESSION_ID,
+      version: 3,
+    });
+    expect(initial.session.id).toBe(SANDBOX_SESSION_ID);
+    await expect(initial.session.run({ command: "true" })).rejects.toThrowError(
+      /AGENT_SANDBOX_RUNNER_SESSION_DISABLED/,
+    );
+    await initial.stop();
+    await initial.shutdown();
+    expect(engine.createSession).not.toHaveBeenCalled();
+    expect(engine.stopSession).not.toHaveBeenCalled();
+
+    // Reconnect keeps the same disabled state and still cannot reach the runner.
+    const restored = await backend.create({
+      existingMetadata: captured.metadata,
+      runtimeContext: { appRoot },
+      sessionKey: BACKEND_SESSION_ID,
+      templateKey: null,
+      tags: { sessionId: SESSION_ID },
+    });
+    expect(restored.session.id).toBe(SANDBOX_SESSION_ID);
+    await expect(restored.session.readTextFile({ path: "note.txt" })).rejects.toThrowError(
+      /AGENT_SANDBOX_RUNNER_SESSION_DISABLED/,
+    );
+    expect(engine.createSession).not.toHaveBeenCalled();
+  });
+
   it("delegates a trusted persistent workspace after mounts are known", async () => {
     const appRoot = await mkdtemp(join(tmpdir(), "osinara-runner-backend-"));
     roots.push(appRoot);

--- a/agent/lib/sandbox-runner/runner-sandbox-backend.ts
+++ b/agent/lib/sandbox-runner/runner-sandbox-backend.ts
@@ -29,6 +29,7 @@ import type {
 import {
   parseCreateSandboxRequest,
   parseSandboxEveSessionId,
+  parseWorkspaceSandboxUseOptions,
   sandboxSeedDigest,
 } from "./sandbox-runner-contract.js";
 import { SandboxRunnerClient } from "./runner-client.js";
@@ -38,6 +39,7 @@ import {
   ROOT_RUNNER_PROFILE,
   sandboxHome,
 } from "./runner-sandbox-profile.js";
+import { parseStoredSandboxMetadata } from "./runner-sandbox-state.js";
 
 const TEMPLATE_SCHEMA_VERSION = 1;
 
@@ -48,37 +50,6 @@ interface BackendOptions {
 interface StoredTemplate {
   files: Array<{ contentBase64: string; path: string }>;
   version: number;
-}
-
-interface StoredBackendMetadata {
-  access: SandboxAccess;
-  mounts: WorkspaceSandboxMount[];
-  sandboxSessionId: string;
-  version: number;
-}
-
-function parseBackendMetadata(
-  value: Record<string, unknown> | undefined,
-  eveSessionId: string,
-  profile: BackendProfile,
-): StoredBackendMetadata | null {
-  if (!value) return null;
-  if (value.version !== profile.stateSchemaVersion) {
-    throw new Error("AGENT_SANDBOX_RUNNER_STATE_INVALID: Reconnect schema mismatch");
-  }
-  const request = parseCreateSandboxRequest({
-    access: value.access,
-    eveSessionId,
-    mounts: value.mounts,
-    sandboxSessionId: value.sandboxSessionId,
-    seedDigest: sandboxSeedDigest([]),
-  });
-  return {
-    access: request.access,
-    mounts: request.mounts,
-    sandboxSessionId: request.sandboxSessionId,
-    version: profile.stateSchemaVersion,
-  };
 }
 
 function templatePath(appRoot: string, cacheDirectory: string, templateKey: string): string {
@@ -310,8 +281,12 @@ function workspaceRunner(
         : await loadTemplate(input.runtimeContext.appRoot, input.templateKey, profile);
       // A thread ID survives normal context rotation while a trust-zone replacement gets a new ID.
       const eveSessionId = parseSandboxEveSessionId(input.tags?.sessionId);
-      const restored = parseBackendMetadata(input.existingMetadata, eveSessionId, profile);
-      let request: SandboxRunnerCreateRequest | null = restored
+      const restored = parseStoredSandboxMetadata(
+        input.existingMetadata,
+        eveSessionId,
+        profile.stateSchemaVersion,
+      );
+      let request: SandboxRunnerCreateRequest | null = restored && !restored.disabled
         ? parseCreateSandboxRequest({
           access: restored.access,
           eveSessionId,
@@ -320,7 +295,15 @@ function workspaceRunner(
           ...seedManifest(template, restored.access, restored.mounts),
         })
         : null;
+      let disabledSandboxSessionId = restored?.disabled
+        ? restored.sandboxSessionId
+        : null;
       const requireRequest = (): SandboxRunnerCreateRequest => {
+        if (disabledSandboxSessionId) {
+          throw new Error(
+            "AGENT_SANDBOX_RUNNER_SESSION_DISABLED: Sandbox access is disabled for this session",
+          );
+        }
         if (!request) {
           throw new Error(
             "AGENT_SANDBOX_RUNNER_SESSION_MISSING: Sandbox session is not mounted",
@@ -329,6 +312,7 @@ function workspaceRunner(
         return request;
       };
       const runnerSessionId = () => {
+        if (disabledSandboxSessionId) return disabledSandboxSessionId;
         return requireRequest().sandboxSessionId;
       };
       const ensureRunner = async (): Promise<string> => {
@@ -356,26 +340,50 @@ function workspaceRunner(
         session,
         async useSessionFn(useOptions) {
           if (!useOptions) throw new Error("AGENT_SANDBOX_RUNNER_MOUNTS_MISSING: Mounts are required");
+          const parsedOptions = parseWorkspaceSandboxUseOptions(useOptions);
+          if (parsedOptions.mounts.length === 0) {
+            if (request || (disabledSandboxSessionId &&
+                disabledSandboxSessionId !== parsedOptions.sandboxSessionId)) {
+              throw new Error("AGENT_SANDBOX_RUNNER_REMOUNT_DENIED: Session mounts are immutable");
+            }
+            disabledSandboxSessionId = parsedOptions.sandboxSessionId;
+            return session;
+          }
+          if (disabledSandboxSessionId) {
+            throw new Error("AGENT_SANDBOX_RUNNER_REMOUNT_DENIED: Session mounts are immutable");
+          }
           if (request) {
             if (
-              request.sandboxSessionId !== useOptions.sandboxSessionId ||
-              JSON.stringify(request.mounts) !== JSON.stringify(useOptions.mounts)
+              request.sandboxSessionId !== parsedOptions.sandboxSessionId ||
+              JSON.stringify(request.mounts) !== JSON.stringify(parsedOptions.mounts)
             ) {
               throw new Error("AGENT_SANDBOX_RUNNER_REMOUNT_DENIED: Session mounts are immutable");
             }
             return session;
           }
-          const access = accessForMounts(useOptions.mounts);
+          const access = accessForMounts(parsedOptions.mounts);
           request = parseCreateSandboxRequest({
             access,
             eveSessionId,
-            mounts: useOptions.mounts,
-            sandboxSessionId: useOptions.sandboxSessionId,
-            ...seedManifest(template, access, useOptions.mounts),
+            mounts: parsedOptions.mounts,
+            sandboxSessionId: parsedOptions.sandboxSessionId,
+            ...seedManifest(template, access, parsedOptions.mounts),
           });
           return session;
         },
         async captureState() {
+          if (disabledSandboxSessionId) {
+            return {
+              backendName: profile.name,
+              metadata: {
+                disabled: true,
+                mounts: [],
+                sandboxSessionId: disabledSandboxSessionId,
+                version: profile.stateSchemaVersion,
+              },
+              sessionKey: input.sessionKey,
+            };
+          }
           const current = requireRequest();
           return {
             backendName: profile.name,

--- a/agent/lib/sandbox-runner/runner-sandbox-state.test.ts
+++ b/agent/lib/sandbox-runner/runner-sandbox-state.test.ts
@@ -30,6 +30,20 @@ describe("persisted sandbox state", () => {
     });
   });
 
+  it("accepts an explicitly disabled state without mounts", () => {
+    expect(parseStoredSandboxMetadata({
+      disabled: true,
+      mounts: [],
+      sandboxSessionId: SANDBOX_SESSION_ID,
+      version: STATE_SCHEMA_VERSION,
+    }, EVE_SESSION_ID, STATE_SCHEMA_VERSION)).toEqual({
+      disabled: true,
+      mounts: [],
+      sandboxSessionId: SANDBOX_SESSION_ID,
+      version: STATE_SCHEMA_VERSION,
+    });
+  });
+
   it("rejects a workspace mount hidden inside disabled metadata", () => {
     expect(() => parseStoredSandboxMetadata({
       disabled: true,
@@ -38,6 +52,29 @@ describe("persisted sandbox state", () => {
       version: STATE_SCHEMA_VERSION,
     }, EVE_SESSION_ID, STATE_SCHEMA_VERSION)).toThrowError(
       /AGENT_SANDBOX_RUNNER_STATE_INVALID/,
+    );
+  });
+
+  it("rejects reconnect metadata from another state schema", () => {
+    expect(() => parseStoredSandboxMetadata({
+      disabled: true,
+      mounts: [],
+      sandboxSessionId: SANDBOX_SESSION_ID,
+      version: STATE_SCHEMA_VERSION - 1,
+    }, EVE_SESSION_ID, STATE_SCHEMA_VERSION)).toThrowError(
+      /AGENT_SANDBOX_RUNNER_STATE_INVALID: Reconnect schema mismatch/,
+    );
+  });
+
+  it("rejects a non-boolean disabled discriminator", () => {
+    expect(() => parseStoredSandboxMetadata({
+      access: "trusted",
+      disabled: "true",
+      mounts: [{ mountPoint: "personal", workspaceId: WORKSPACE_ID }],
+      sandboxSessionId: SANDBOX_SESSION_ID,
+      version: STATE_SCHEMA_VERSION,
+    }, EVE_SESSION_ID, STATE_SCHEMA_VERSION)).toThrowError(
+      /AGENT_SANDBOX_RUNNER_STATE_INVALID: Sandbox state discriminator is malformed/,
     );
   });
 });

--- a/agent/lib/sandbox-runner/runner-sandbox-state.test.ts
+++ b/agent/lib/sandbox-runner/runner-sandbox-state.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Persisted sandbox backend state validation tests.
+ *
+ * Constructs covered:
+ * - Existing mounted metadata without the new discriminator remains readable.
+ * - Disabled metadata cannot smuggle a workspace mount into an internal session.
+ */
+import { describe, expect, it } from "vitest";
+
+import { parseStoredSandboxMetadata } from "./runner-sandbox-state.js";
+
+const EVE_SESSION_ID = "wrun_01JZ8K4R0W6G73VTHX9NF2QABC";
+const SANDBOX_SESSION_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const WORKSPACE_ID = "11111111-1111-4111-8111-111111111111";
+const STATE_SCHEMA_VERSION = 3;
+
+describe("persisted sandbox state", () => {
+  it("accepts the existing mounted metadata shape", () => {
+    expect(parseStoredSandboxMetadata({
+      access: "trusted",
+      mounts: [{ mountPoint: "personal", workspaceId: WORKSPACE_ID }],
+      sandboxSessionId: SANDBOX_SESSION_ID,
+      version: STATE_SCHEMA_VERSION,
+    }, EVE_SESSION_ID, STATE_SCHEMA_VERSION)).toEqual({
+      access: "trusted",
+      disabled: false,
+      mounts: [{ mountPoint: "personal", workspaceId: WORKSPACE_ID }],
+      sandboxSessionId: SANDBOX_SESSION_ID,
+      version: STATE_SCHEMA_VERSION,
+    });
+  });
+
+  it("rejects a workspace mount hidden inside disabled metadata", () => {
+    expect(() => parseStoredSandboxMetadata({
+      disabled: true,
+      mounts: [{ mountPoint: "personal", workspaceId: WORKSPACE_ID }],
+      sandboxSessionId: SANDBOX_SESSION_ID,
+      version: STATE_SCHEMA_VERSION,
+    }, EVE_SESSION_ID, STATE_SCHEMA_VERSION)).toThrowError(
+      /AGENT_SANDBOX_RUNNER_STATE_INVALID/,
+    );
+  });
+});

--- a/agent/lib/sandbox-runner/runner-sandbox-state.ts
+++ b/agent/lib/sandbox-runner/runner-sandbox-state.ts
@@ -1,0 +1,82 @@
+/**
+ * Persisted Eve sandbox backend state validation.
+ *
+ * Exports:
+ * - `StoredSandboxMetadata`: mounted legacy/current state or disabled internal-session state.
+ * - `parseStoredSandboxMetadata`: validates reconnect metadata before backend reuse.
+ */
+import type {
+  SandboxAccess,
+  WorkspaceSandboxMount,
+} from "./sandbox-runner-contract.js";
+import {
+  parseCreateSandboxRequest,
+  parseWorkspaceSandboxUseOptions,
+  sandboxSeedDigest,
+} from "./sandbox-runner-contract.js";
+
+interface StoredMountedSandboxMetadata {
+  access: SandboxAccess;
+  disabled: false;
+  mounts: WorkspaceSandboxMount[];
+  sandboxSessionId: string;
+  version: number;
+}
+
+interface StoredDisabledSandboxMetadata {
+  disabled: true;
+  mounts: [];
+  sandboxSessionId: string;
+  version: number;
+}
+
+export type StoredSandboxMetadata =
+  | StoredDisabledSandboxMetadata
+  | StoredMountedSandboxMetadata;
+
+export function parseStoredSandboxMetadata(
+  value: Record<string, unknown> | undefined,
+  eveSessionId: string,
+  stateSchemaVersion: number,
+): StoredSandboxMetadata | null {
+  if (!value) return null;
+  if (value.version !== stateSchemaVersion) {
+    throw new Error("AGENT_SANDBOX_RUNNER_STATE_INVALID: Reconnect schema mismatch");
+  }
+
+  // Both variants retain the same stable compute identity; disabled state has no workspace mounts.
+  const useOptions = parseWorkspaceSandboxUseOptions({
+    mounts: value.mounts,
+    sandboxSessionId: value.sandboxSessionId,
+  });
+  if (value.disabled === true) {
+    if (useOptions.mounts.length !== 0 || value.access !== undefined) {
+      throw new Error("AGENT_SANDBOX_RUNNER_STATE_INVALID: Disabled sandbox metadata is malformed");
+    }
+    return {
+      disabled: true,
+      mounts: [],
+      sandboxSessionId: useOptions.sandboxSessionId,
+      version: stateSchemaVersion,
+    };
+  }
+  if (value.disabled !== undefined && value.disabled !== false) {
+    throw new Error("AGENT_SANDBOX_RUNNER_STATE_INVALID: Sandbox state discriminator is malformed");
+  }
+
+  // Existing mounted state remains compatible and reuses the runner's strict trust-zone parser.
+  const request = parseCreateSandboxRequest({
+    access: value.access,
+    eveSessionId,
+    mounts: useOptions.mounts,
+    sandboxSessionId: useOptions.sandboxSessionId,
+    seedDigest: sandboxSeedDigest([]),
+  });
+  return {
+    access: request.access,
+    disabled: false,
+    mounts: request.mounts,
+    sandboxSessionId: request.sandboxSessionId,
+    version: stateSchemaVersion,
+  };
+}

--- a/agent/lib/sandbox-runner/sandbox-runner-contract.ts
+++ b/agent/lib/sandbox-runner/sandbox-runner-contract.ts
@@ -5,6 +5,7 @@
  * - Runner request/response types for sessions, atomic seed bundles, processes, files, and GWS.
  * - `sandboxSeedDigest`: canonical content identity used by both agent and runner policy checks.
  * - `parseCreateSandboxRequest`: enforces the trusted/restricted scope boundary.
+ * - `parseWorkspaceSandboxUseOptions`: validates mounted or explicitly disabled Eve session state.
  * - Other `parse*` helpers: validate every untrusted HTTP payload fail-closed.
  * - Runner endpoint, execution-limit, and transport-timeout constants.
  */
@@ -32,6 +33,15 @@ const mountPointSchema = z.enum(["family", "group", "personal"]);
 const workspaceMountSchema = z.strictObject({
   mountPoint: mountPointSchema,
   workspaceId: workspaceIdSchema,
+});
+const workspaceSandboxUseOptionsSchema = z.strictObject({
+  mounts: z.array(workspaceMountSchema).max(2),
+  sandboxSessionId: sessionIdSchema,
+}).superRefine((options, context) => {
+  const points = options.mounts.map((mount) => mount.mountPoint);
+  if (new Set(points).size !== points.length) {
+    context.addIssue({ code: "custom", message: "Duplicate mount point", path: ["mounts"] });
+  }
 });
 const seedFileSchema = z.strictObject({
   contentBase64: z.base64().max(Math.ceil(SANDBOX_RUNNER_SEED_FILE_MAX_BYTES * 4 / 3) + 4),
@@ -169,6 +179,14 @@ function parseOrThrow<T>(schema: z.ZodType<T>, value: unknown, code: string): T 
 
 export function parseCreateSandboxRequest(value: unknown): SandboxRunnerCreateRequest {
   return parseOrThrow(createSandboxRequestSchema, value, "AGENT_SANDBOX_RUNNER_SCOPE_INVALID");
+}
+
+export function parseWorkspaceSandboxUseOptions(value: unknown): WorkspaceSandboxUseOptions {
+  return parseOrThrow(
+    workspaceSandboxUseOptionsSchema,
+    value,
+    "AGENT_SANDBOX_RUNNER_SESSION_OPTIONS_INVALID",
+  );
 }
 
 export function parseGoogleWorkspaceExecutionRequest(

--- a/agent/sandbox.test.ts
+++ b/agent/sandbox.test.ts
@@ -4,8 +4,9 @@
  * Constructs covered:
  * - Explicit selection of the isolated runner backend.
  * - Auth-scoped persistent mounts are installed at session start.
+ * - Background memory review receives a disabled sandbox without workspace mounts.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import sandbox from "./sandbox.js";
 
@@ -16,5 +17,36 @@ describe("agent sandbox", () => {
 
   it("installs verified workspace mounts on each Eve session", () => {
     expect(sandbox.onSession).toBeTypeOf("function");
+  });
+
+  it("disables workspace access for background memory review sessions", async () => {
+    const use = vi.fn().mockResolvedValue(undefined);
+    if (!sandbox.onSession) {
+      throw new Error("AGENT_TEST_SANDBOX_SESSION_HOOK_MISSING: Sandbox onSession hook is required");
+    }
+
+    await sandbox.onSession({
+      ctx: {
+        session: {
+          auth: {
+            current: {
+              attributes: {
+                memoryReviewMode: "background",
+                sandboxSessionId: "00000000-0000-4000-8000-000000000070",
+              },
+              authenticator: "memory-review",
+              principalId: "00000000-0000-4000-8000-000000000030",
+              principalType: "user",
+            },
+          },
+        },
+      },
+      use,
+    } as never);
+
+    expect(use).toHaveBeenCalledWith({
+      mounts: [],
+      sandboxSessionId: "00000000-0000-4000-8000-000000000070",
+    });
   });
 });

--- a/agent/sandbox.ts
+++ b/agent/sandbox.ts
@@ -8,6 +8,7 @@
 import { defineSandbox } from "eve/sandbox";
 
 import { scopedWorkspaceRunner } from "./lib/sandbox-runner/runner-sandbox-backend.js";
+import { isMemoryReviewSession } from "./lib/memory-review/memory-review-session.js";
 import { sandboxSessionId } from "./lib/sessions/session-context.js";
 import { requireWorkspaceAuthorization } from "./lib/workspaces/workspace-context.js";
 import { workspaceRepository } from "./lib/workspaces/workspace-repository.js";
@@ -15,7 +16,15 @@ import { workspaceRepository } from "./lib/workspaces/workspace-repository.js";
 export default defineSandbox({
   backend: scopedWorkspaceRunner(),
   async onSession({ ctx, use }) {
+    const sessionId = sandboxSessionId(ctx);
+    if (isMemoryReviewSession(ctx)) {
+      // Silent review has no file tools or skills. Keep a durable Eve sandbox state without
+      // materializing any workspace capability in the isolated runner.
+      await use({ mounts: [], sandboxSessionId: sessionId });
+      return;
+    }
+
     const mounts = await workspaceRepository.mounts(requireWorkspaceAuthorization(ctx));
-    await use({ mounts, sandboxSessionId: sandboxSessionId(ctx) });
+    await use({ mounts, sandboxSessionId: sessionId });
   },
 });

--- a/docs/releases/v0.15.6.md
+++ b/docs/releases/v0.15.6.md
@@ -1,0 +1,28 @@
+# Osinara v0.15.6
+
+Patch-релиз восстановления background memory review после доказанного pre-model sandbox failure.
+
+## Причина
+
+- Internal memory-review session использует authenticator `memory-review`, а обычный sandbox bootstrap
+  принимал только Telegram workspace authorization.
+- Eve materializes dynamic skills до первого model call, поэтому пустой review skill surface всё равно
+  запускал `sandbox.onSession` и завершался `AGENT_WORKSPACE_CONTEXT_INVALID`.
+- Общий `session.failed` скрывал исходный pre-model cause и консервативно переводил batch в `ambiguous`.
+
+## Исправление
+
+- Background memory review получает durable disabled sandbox state без personal, family или group mounts.
+- Любая попытка sandbox operation в disabled session завершается стабильной ошибкой до обращения к
+  sandbox-runner; persisted mounted sessions остаются совместимыми.
+- Owner alerts разделены по recovery generation, поэтому новый terminal outcome после operator recovery
+  не скрывается уже доставленным уведомлением.
+- Migration `069` повторно открывает только exact batch `5540-5589` после проверки обоих failed Eve roots,
+  полного набора из 50 источников и отсутствия memory mutation operations.
+
+## Проверка
+
+- Unit tests проверяют disabled session bootstrap, reconnect и запрет runner operations.
+- PostgreSQL integration tests проверяют exact incident recovery, сохранение source evidence и alert
+  generations.
+- Production-equivalent Docker Compose gate выполняется перед публикацией immutable release.

--- a/migrations/069_memory_review_sandbox_recovery.sql
+++ b/migrations/069_memory_review_sandbox_recovery.sql
@@ -1,0 +1,124 @@
+-- Background review previously initialized a workspace sandbox before the model call even though
+-- its tool surface denies every file capability. Preserve alert history by recovery generation,
+-- then requeue only the exact twice-observed pre-model production incident authorized by operator.
+ALTER TABLE memory_review_batches
+  DROP CONSTRAINT memory_review_batches_recovery_attempts_check,
+  DROP CONSTRAINT memory_review_batches_recovery_audit,
+  ADD CONSTRAINT memory_review_batches_recovery_attempts_check
+    CHECK (recovery_attempts BETWEEN 0 AND 2),
+  ADD CONSTRAINT memory_review_batches_recovery_audit CHECK (
+    (recovery_attempts = 0 AND last_recovery_diagnostic_code IS NULL
+      AND last_recovered_at IS NULL) OR
+    (recovery_attempts BETWEEN 1 AND 2 AND last_recovery_diagnostic_code IS NOT NULL
+      AND last_recovered_at IS NOT NULL)
+  );
+
+ALTER TABLE memory_review_owner_alerts
+  ADD COLUMN recovery_generation integer NOT NULL DEFAULT 0 CHECK (recovery_generation >= 0);
+
+UPDATE memory_review_owner_alerts AS alert
+   SET recovery_generation = batch.recovery_attempts
+  FROM memory_review_batches AS batch
+ WHERE batch.id = alert.batch_id;
+
+ALTER TABLE memory_review_owner_alerts
+  DROP CONSTRAINT memory_review_owner_alerts_batch_id_key,
+  ADD CONSTRAINT memory_review_owner_alerts_batch_generation_key
+    UNIQUE (batch_id, recovery_generation);
+
+DO $$
+DECLARE
+  incident_batch_id constant uuid := '18329b3e-9563-4762-bc77-11641e8cbac1';
+  original_application_session_id constant uuid := '61b08325-2147-4047-9cb1-01d8210b89b4';
+  recovery_application_session_id constant uuid := '26942f0e-76a7-4240-b241-ff866fc084b4';
+  original_eve_session_id constant text := 'wrun_01KZWTTV5XAJY71V8DW3E7EM4X';
+  recovery_eve_session_id constant text := 'wrun_01KZZN63ATNDJSP336AVRKE1XW';
+  incident memory_review_batches%ROWTYPE;
+  retained_count integer;
+  retained_first bigint;
+  retained_last bigint;
+BEGIN
+  SELECT * INTO incident FROM memory_review_batches WHERE id = incident_batch_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  -- Every durable identity must match the operator-inspected Eve traces before state is reopened.
+  IF incident.batch_kind <> 'background' OR incident.status <> 'ambiguous'
+    OR incident.predecessor_sequence <> 5539 OR incident.from_sequence <> 5540
+    OR incident.through_sequence <> 5589 OR incident.source_count <> 50
+    OR incident.recovery_attempts <> 1
+    OR incident.diagnostic_code <> 'AGENT_MEMORY_REVIEW_SESSION_FAILED_AMBIGUOUS'
+    OR incident.last_recovery_diagnostic_code <> 'AGENT_MEMORY_REVIEW_SESSION_FAILED_AMBIGUOUS'
+    OR incident.application_session_id <> recovery_application_session_id
+    OR incident.eve_session_id <> recovery_eve_session_id
+    OR incident.eve_turn_id <> 'turn_0' THEN
+    RAISE EXCEPTION
+      'AGENT_MEMORY_REVIEW_SANDBOX_RECOVERY_STATE_INVALID: Incident batch state changed';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM conversation_sessions
+     WHERE id = original_application_session_id AND eve_session_id = original_eve_session_id
+       AND kind = 'proactive' AND task_state = 'failed' AND retired_at IS NOT NULL
+  ) OR NOT EXISTS (
+    SELECT 1 FROM conversation_sessions
+     WHERE id = recovery_application_session_id AND eve_session_id = recovery_eve_session_id
+       AND memory_review_batch_id = incident_batch_id
+       AND kind = 'proactive' AND task_state = 'failed' AND retired_at IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION
+      'AGENT_MEMORY_REVIEW_SANDBOX_RECOVERY_SESSION_INVALID: Incident sessions changed';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM memory_mutation_operations
+     WHERE eve_session_id IN (original_eve_session_id, recovery_eve_session_id)
+  ) THEN
+    RAISE EXCEPTION
+      'AGENT_MEMORY_REVIEW_SANDBOX_RECOVERY_SIDE_EFFECT_FOUND: Recovery is not safe';
+  END IF;
+
+  SELECT count(*)::integer, min(timeline_sequence), max(timeline_sequence)
+    INTO retained_count, retained_first, retained_last
+    FROM memory_review_batch_sources WHERE batch_id = incident_batch_id;
+  IF retained_count <> 50 OR retained_first <> 5540 OR retained_last <> 5589 THEN
+    RAISE EXCEPTION
+      'AGENT_MEMORY_REVIEW_SANDBOX_RECOVERY_SOURCES_INVALID: Source evidence changed';
+  END IF;
+
+  -- The failed root remains retired audit history and can no longer own the batch continuation.
+  DELETE FROM memory_turn_source_sets WHERE memory_review_batch_id = incident_batch_id;
+  UPDATE conversation_sessions
+     SET continuation_token = 'retired-memory-review:' || id,
+         memory_review_batch_id = NULL,
+         pending_operation = false,
+         task_state = 'failed',
+         retired_at = coalesce(retired_at, now()),
+         delete_after = coalesce(delete_after, now() + interval '90 days')
+   WHERE id = recovery_application_session_id;
+
+  UPDATE memory_review_batches
+     SET status = 'pending', application_session_id = NULL, eve_session_id = NULL,
+         eve_turn_id = NULL, lease_token = NULL, lease_expires_at = NULL,
+         diagnostic_code = NULL, started_at = NULL, completed_at = NULL,
+         recovery_attempts = 2,
+         last_recovery_diagnostic_code = 'AGENT_MEMORY_REVIEW_SANDBOX_CONTEXT_INVALID',
+         last_recovered_at = now(), updated_at = now()
+   WHERE id = incident_batch_id;
+
+  INSERT INTO audit_events (family_id, event_type, subject_id, metadata)
+  SELECT conversation.family_id, 'memory_review.operator_recovered', incident_batch_id,
+         jsonb_build_object(
+           'diagnosticCode', 'AGENT_MEMORY_REVIEW_SANDBOX_CONTEXT_INVALID',
+           'fromSequence', 5540,
+           'throughSequence', 5589,
+           'recoveryAttempt', 2,
+           'originalEveSessionId', original_eve_session_id,
+           'recoveryEveSessionId', recovery_eve_session_id,
+           'retiredApplicationSessionId', recovery_application_session_id
+         )
+    FROM application_conversations AS conversation
+   WHERE conversation.id = incident.conversation_id;
+END;
+$$;

--- a/migrations/069_memory_review_sandbox_recovery.sql
+++ b/migrations/069_memory_review_sandbox_recovery.sql
@@ -44,15 +44,20 @@ BEGIN
   END IF;
 
   -- Every durable identity must match the operator-inspected Eve traces before state is reopened.
-  IF incident.batch_kind <> 'background' OR incident.status <> 'ambiguous'
-    OR incident.predecessor_sequence <> 5539 OR incident.from_sequence <> 5540
-    OR incident.through_sequence <> 5589 OR incident.source_count <> 50
-    OR incident.recovery_attempts <> 1
-    OR incident.diagnostic_code <> 'AGENT_MEMORY_REVIEW_SESSION_FAILED_AMBIGUOUS'
-    OR incident.last_recovery_diagnostic_code <> 'AGENT_MEMORY_REVIEW_SESSION_FAILED_AMBIGUOUS'
-    OR incident.application_session_id <> recovery_application_session_id
-    OR incident.eve_session_id <> recovery_eve_session_id
-    OR incident.eve_turn_id <> 'turn_0' THEN
+  IF incident.batch_kind IS DISTINCT FROM 'background'
+    OR incident.status IS DISTINCT FROM 'ambiguous'
+    OR incident.predecessor_sequence IS DISTINCT FROM 5539
+    OR incident.from_sequence IS DISTINCT FROM 5540
+    OR incident.through_sequence IS DISTINCT FROM 5589
+    OR incident.source_count IS DISTINCT FROM 50
+    OR incident.recovery_attempts IS DISTINCT FROM 1
+    OR incident.diagnostic_code
+      IS DISTINCT FROM 'AGENT_MEMORY_REVIEW_SESSION_FAILED_AMBIGUOUS'
+    OR incident.last_recovery_diagnostic_code
+      IS DISTINCT FROM 'AGENT_MEMORY_REVIEW_SESSION_FAILED_AMBIGUOUS'
+    OR incident.application_session_id IS DISTINCT FROM recovery_application_session_id
+    OR incident.eve_session_id IS DISTINCT FROM recovery_eve_session_id
+    OR incident.eve_turn_id IS DISTINCT FROM 'turn_0' THEN
     RAISE EXCEPTION
       'AGENT_MEMORY_REVIEW_SANDBOX_RECOVERY_STATE_INVALID: Incident batch state changed';
   END IF;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.15.5",
+      "version": "0.15.6",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- give background memory review a durable disabled sandbox with no workspace mounts or runner access
- preserve owner alerts by recovery generation and add exact audited recovery for batch 5540-5589
- release as v0.15.6

## Verification
- clean npm ci
- 1451 local unit tests
- targeted PostgreSQL migration integrations
- canonical Docker Compose gate: 1709 tests, typecheck, migrations, Eve build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Добавлена фоновая memory review-сессия с отключённым Eve sandbox без workspace mounts и runner access.
- Добавлена строгая валидация параметров и сохранённых метаданных sandbox.
- Реализовано восстановление повреждённых sandbox-контекстов через миграцию `069_memory_review_sandbox_recovery.sql`.
- Добавлен точный аудит восстановления для batch `5540–5589`.
- Owner alerts теперь сохраняются по паре `(batch_id, recovery_generation)`.
- Добавлены интеграционные и unit-тесты для sandbox recovery и отключённых сессий.
- Версия пакета обновлена до `v0.15.6`.

## Проверка

- Выполнен чистый `npm ci`.
- Пройдены 1 451 локальный unit-тест.
- Пройдены целевые PostgreSQL migration integration tests.
- Пройден canonical Docker Compose gate: 1 709 тестов, typechecking, migrations и Eve build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->