### PR TITLE
Fix memory review agent collision

### DIFF
--- a/agent/lib/eve-memory-review-agent-policy-patch.test.ts
+++ b/agent/lib/eve-memory-review-agent-policy-patch.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Eve implicit-agent policy patch tests for background memory review.
+ *
+ * Constructs covered:
+ * - The patched runtime removes only Eve's implicit root `agent` from verified background review.
+ * - Interactive and non-review root sessions retain native delegation.
+ * - Authored tools and non-root subagent lookalikes are never removed by the review policy.
+ * - The reproducible installer owns the exact Eve 0.32.0 runtime patch.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const TOOL_LOOP_PATH = "node_modules/eve/dist/src/harness/tool-loop.js";
+const AUTH_KEY = Symbol("eve.auth.test");
+
+interface RuntimeTool {
+  readonly name: string;
+  readonly runtimeAction?: {
+    readonly kind: "remote-agent-call" | "subagent-call";
+    readonly nodeId: string;
+    readonly subagentName: string;
+  };
+}
+
+interface RuntimeAuth {
+  readonly attributes: Readonly<Record<string, unknown>>;
+  readonly authenticator: string;
+}
+
+type RuntimeToolBuilder = (
+  tools: ReadonlyMap<string, RuntimeTool>,
+  context: { get(key: symbol): RuntimeAuth | undefined },
+) => Map<string, RuntimeTool>;
+
+const implicitRootAgent: RuntimeTool = {
+  name: "agent",
+  runtimeAction: {
+    kind: "subagent-call",
+    nodeId: "__root__",
+    subagentName: "agent",
+  },
+};
+
+function extractRuntimeToolBuilder(source: string): RuntimeToolBuilder {
+  const definition = source.match(
+    /function buildHarnessToolsWithDynamicSubagents\(e,t\)\{[\s\S]*?return n\}/u,
+  )?.[0];
+  if (!definition) {
+    throw new Error(
+      "AGENT_EVE_MEMORY_REVIEW_PATCH_INVALID: Не найдена функция сборки runtime tools Eve",
+    );
+  }
+
+  // Execute the installed function with inert dynamic subagents so this test proves behavior,
+  // rather than merely asserting that a patch marker exists in a minified artifact.
+  const factory = new Function(
+    "buildDynamicSubagentTools",
+    "AuthKey",
+    `"use strict";${definition};return buildHarnessToolsWithDynamicSubagents;`,
+  ) as (buildDynamicSubagentTools: () => never[], authKey: symbol) => RuntimeToolBuilder;
+  return factory(() => [], AUTH_KEY);
+}
+
+function context(authenticator: string, memoryReviewMode?: string) {
+  const auth: RuntimeAuth = {
+    attributes: memoryReviewMode === undefined ? {} : { memoryReviewMode },
+    authenticator,
+  };
+  return {
+    get(key: symbol) {
+      return key === AUTH_KEY ? auth : undefined;
+    },
+  };
+}
+
+describe("Eve memory-review implicit agent policy patch", () => {
+  it("removes native root delegation only from verified background review", async () => {
+    const runtime = await readFile(TOOL_LOOP_PATH, "utf8");
+    const buildTools = extractRuntimeToolBuilder(runtime);
+
+    const tools = buildTools(
+      new Map([
+        ["agent", implicitRootAgent],
+        ["remember", { name: "remember" }],
+      ]),
+      context("memory-review", "background"),
+    );
+
+    expect([...tools.keys()]).toEqual(["remember"]);
+  });
+
+  it.each([
+    ["ordinary root session", "telegram", undefined],
+    ["interactive review marker", "memory-review", "interactive"],
+    ["unverified background marker", "telegram", "background"],
+  ])("retains native root delegation for %s", async (_case, authenticator, mode) => {
+    const runtime = await readFile(TOOL_LOOP_PATH, "utf8");
+    const buildTools = extractRuntimeToolBuilder(runtime);
+
+    const tools = buildTools(
+      new Map([["agent", implicitRootAgent]]),
+      context(authenticator, mode),
+    );
+
+    expect(tools.get("agent")).toBe(implicitRootAgent);
+  });
+
+  it.each([
+    ["authored tool", { name: "agent" }],
+    ["non-root subagent", {
+      name: "agent",
+      runtimeAction: {
+        kind: "subagent-call" as const,
+        nodeId: "review-specialist",
+        subagentName: "agent",
+      },
+    }],
+  ])("does not remove an %s lookalike", async (_case, agentTool) => {
+    const runtime = await readFile(TOOL_LOOP_PATH, "utf8");
+    const buildTools = extractRuntimeToolBuilder(runtime);
+
+    const tools = buildTools(
+      new Map([["agent", agentTool]]),
+      context("memory-review", "background"),
+    );
+
+    expect(tools.get("agent")).toBe(agentTool);
+  });
+
+  it("keeps the policy in the reproducible Eve patch installer", async () => {
+    const [patchSource, runtime] = await Promise.all([
+      readFile("scripts/apply-eve-patches.ts", "utf8"),
+      readFile(TOOL_LOOP_PATH, "utf8"),
+    ]);
+
+    expect(patchSource).toContain("memoryReviewMode===`background`");
+    expect(runtime.match(/memoryReviewMode===`background`/gu)).toHaveLength(1);
+  });
+});

--- a/agent/lib/memory-review/memory-review-agent-collision-recovery-migration.integration.test.ts
+++ b/agent/lib/memory-review/memory-review-agent-collision-recovery-migration.integration.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Migration 070 memory-review implicit-agent collision recovery tests.
+ *
+ * Constructs covered:
+ * - Only the exact third pre-model production root is retired and requeued.
+ * - The immutable 50-source batch survives while its failed turn binding is removed.
+ * - Recovery and owner-alert generations advance without erasing prior incident history.
+ * - Recovery remains bounded after the operator-authorized third attempt.
+ */
+import { readFile, readdir } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { closeDatabase, database } from "../database.js";
+
+const describeWithDatabase = process.env.RUN_DATABASE_INTEGRATION_TESTS === "true"
+  ? describe
+  : describe.skip;
+const MIGRATION_NAME = "070_memory_review_agent_collision_recovery.sql";
+const MIGRATION_ORDINAL = 70;
+const TEST_SCHEMA = "test_memory_review_agent_collision_recovery";
+const BATCH_ID = "18329b3e-9563-4762-bc77-11641e8cbac1";
+const ORIGINAL_APPLICATION_SESSION_ID = "61b08325-2147-4047-9cb1-01d8210b89b4";
+const SANDBOX_APPLICATION_SESSION_ID = "26942f0e-76a7-4240-b241-ff866fc084b4";
+const COLLISION_APPLICATION_SESSION_ID = "ced56a9b-e788-41e5-82fb-ac46e8b20168";
+const ORIGINAL_EVE_SESSION_ID = "wrun_01KZWTTV5XAJY71V8DW3E7EM4X";
+const SANDBOX_EVE_SESSION_ID = "wrun_01KZZN63ATNDJSP336AVRKE1XW";
+const COLLISION_EVE_SESSION_ID = "wrun_01KZZW3MVCRG9D57A0TWQ06M8D";
+const MIGRATION_NAME_PATTERN = /^(\d+)_.*\.sql$/u;
+
+function migrationOrdinal(name: string): number | null {
+  const match = MIGRATION_NAME_PATTERN.exec(name);
+  return match ? Number.parseInt(match[1]!, 10) : null;
+}
+
+async function applyMigrationsBefore070(client: import("pg").PoolClient): Promise<void> {
+  const names = (await readdir(resolve("migrations")))
+    .filter((name) => {
+      const ordinal = migrationOrdinal(name);
+      return ordinal !== null && ordinal < MIGRATION_ORDINAL;
+    })
+    .sort((left, right) => {
+      const difference = migrationOrdinal(left)! - migrationOrdinal(right)!;
+      return difference || left.localeCompare(right);
+    });
+  for (const name of names) {
+    await client.query(await readFile(resolve("migrations", name), "utf8"));
+  }
+}
+
+describeWithDatabase("070 memory review agent collision recovery migration", () => {
+  afterAll(closeDatabase);
+
+  it("requeues the exact side-effect-free collision root with generation-three audit", async () => {
+    const client = await database().connect();
+    try {
+      await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+      await client.query(`CREATE SCHEMA ${TEST_SCHEMA}`);
+      await client.query(`SET search_path TO ${TEST_SCHEMA}, public`);
+      await applyMigrationsBefore070(client);
+
+      // Reconstruct the exact production identity and retained source interval.
+      const family = await client.query<{ id: string }>(
+        "INSERT INTO families (name) VALUES ('Agent collision recovery') RETURNING id",
+      );
+      const owner = await client.query<{ id: string }>(
+        `INSERT INTO users (telegram_user_id, display_name)
+         VALUES ('agent-collision-owner', 'Владелец') RETURNING id`,
+      );
+      await client.query(
+        "INSERT INTO family_memberships (family_id, user_id, role) VALUES ($1, $2, 'owner')",
+        [family.rows[0]!.id, owner.rows[0]!.id],
+      );
+      const group = await client.query<{ id: string }>(
+        `INSERT INTO telegram_groups (family_id, telegram_chat_id, title, type, message_mode)
+         VALUES ($1, '-100-agent-collision', 'Остриков пилит агентов',
+                 'family_private', 'addressed_only') RETURNING id`,
+        [family.rows[0]!.id],
+      );
+      const conversation = await client.query<{ id: string }>(
+        "SELECT id FROM application_conversations WHERE telegram_group_id = $1",
+        [group.rows[0]!.id],
+      );
+      await client.query(
+        `INSERT INTO telegram_group_messages
+           (conversation_id, group_id, telegram_message_id, sequence_id, actor_kind, actor_id,
+            telegram_user_id, sender_display_name, sender_is_bot, message_kind, content_text,
+            sent_at)
+         SELECT $1, $2, sequence, sequence, 'user', 'telegram:agent-collision-owner',
+                'agent-collision-owner', 'Владелец', false, 'text',
+                'Сообщение ' || sequence, now()
+           FROM generate_series(5540, 5589) AS sequence`,
+        [conversation.rows[0]!.id, group.rows[0]!.id],
+      );
+      const lane = await client.query<{ id: string }>(
+        `INSERT INTO memory_review_lanes (conversation_id, processed_through_sequence)
+         VALUES ($1, 5539) RETURNING id`,
+        [conversation.rows[0]!.id],
+      );
+      await client.query(
+        `INSERT INTO memory_review_batches
+           (id, lane_id, conversation_id, batch_kind, status, predecessor_sequence,
+            from_sequence, through_sequence, source_count, eve_session_id, eve_turn_id,
+            diagnostic_code, recovery_attempts, last_recovery_diagnostic_code,
+            last_recovered_at, started_at, completed_at)
+         VALUES ($1, $2, $3, 'background', 'ambiguous', 5539, 5540, 5589, 50,
+                 $4, 'turn_0', 'AGENT_MEMORY_REVIEW_SESSION_FAILED_AMBIGUOUS', 2,
+                 'AGENT_MEMORY_REVIEW_SANDBOX_CONTEXT_INVALID', now(), now(), now())`,
+        [BATCH_ID, lane.rows[0]!.id, conversation.rows[0]!.id, COLLISION_EVE_SESSION_ID],
+      );
+
+      // All earlier roots remain immutable retired history; only the current root owns the batch.
+      const sessionValues = [
+        [ORIGINAL_APPLICATION_SESSION_ID, ORIGINAL_EVE_SESSION_ID, null],
+        [SANDBOX_APPLICATION_SESSION_ID, SANDBOX_EVE_SESSION_ID, null],
+        [COLLISION_APPLICATION_SESSION_ID, COLLISION_EVE_SESSION_ID, BATCH_ID],
+      ] as const;
+      for (const [id, eveSessionId, memoryReviewBatchId] of sessionValues) {
+        await client.query(
+          `INSERT INTO conversation_sessions
+             (id, thread_id, generation, family_id, group_id, scope, kind, task_state,
+              conversation_key, continuation_token, eve_session_id, started_at,
+              last_activity_at, retired_at, delete_after, memory_review_batch_id)
+           VALUES ($1::uuid, gen_random_uuid(), 0, $2, $3, 'family', 'proactive', 'failed',
+                   $4, $5, $6, now(), now(), now(), now() + interval '90 days', $7::uuid)`,
+          [id, family.rows[0]!.id, group.rows[0]!.id, `memory-review:${BATCH_ID}`,
+            memoryReviewBatchId === null ? `retired-memory-review:${id}` : `memory-review:${BATCH_ID}`,
+            eveSessionId, memoryReviewBatchId],
+        );
+      }
+      await client.query(
+        "UPDATE memory_review_batches SET application_session_id = $2 WHERE id = $1",
+        [BATCH_ID, COLLISION_APPLICATION_SESSION_ID],
+      );
+      await client.query(
+        `INSERT INTO memory_review_batch_sources
+           (batch_id, conversation_id, timeline_entry_id, timeline_sequence)
+         SELECT $1, message.conversation_id, message.id, message.sequence_id
+           FROM telegram_group_messages AS message
+          WHERE message.conversation_id = $2 AND message.sequence_id BETWEEN 5540 AND 5589`,
+        [BATCH_ID, conversation.rows[0]!.id],
+      );
+      await client.query(
+        `INSERT INTO memory_turn_source_sets
+           (eve_session_id, eve_turn_id, application_session_id, conversation_id,
+            current_timeline_entry_id, invoking_telegram_user_id, binding_hash,
+            memory_review_batch_id)
+         VALUES ($1, 'turn_0', $2, $3, NULL, 'agent-collision-owner', $4, $5)`,
+        [COLLISION_EVE_SESSION_ID, COLLISION_APPLICATION_SESSION_ID,
+          conversation.rows[0]!.id, "a".repeat(64), BATCH_ID],
+      );
+      await client.query(
+        `INSERT INTO memory_turn_sources
+           (eve_session_id, eve_turn_id, conversation_id, timeline_entry_id,
+            timeline_sequence, is_current)
+         SELECT $1, 'turn_0', source.conversation_id, source.timeline_entry_id,
+                source.timeline_sequence, false
+           FROM memory_review_batch_sources AS source WHERE source.batch_id = $2`,
+        [COLLISION_EVE_SESSION_ID, BATCH_ID],
+      );
+      await client.query(
+        `INSERT INTO memory_review_owner_alerts
+           (batch_id, recovery_generation, family_id, group_id, group_title_snapshot,
+            from_sequence, through_sequence, batch_diagnostic_code, status, completed_at)
+         VALUES
+           ($1, 1, $2, $3, 'Остриков пилит агентов', 5540, 5589,
+            'AGENT_MEMORY_REVIEW_SESSION_FAILED_AMBIGUOUS', 'delivered', now()),
+           ($1, 2, $2, $3, 'Остриков пилит агентов', 5540, 5589,
+            'AGENT_MEMORY_REVIEW_SESSION_FAILED_AMBIGUOUS', 'delivered', now())`,
+        [BATCH_ID, family.rows[0]!.id, group.rows[0]!.id],
+      );
+
+      const migration = await readFile(resolve("migrations", MIGRATION_NAME), "utf8");
+
+      // A mismatched binding must abort the entire migration, including its constraint widening.
+      await client.query(
+        `UPDATE memory_turn_source_sets SET application_session_id = $2
+          WHERE memory_review_batch_id = $1`,
+        [BATCH_ID, SANDBOX_APPLICATION_SESSION_ID],
+      );
+      await expect(client.query(migration)).rejects.toThrow(
+        "AGENT_MEMORY_REVIEW_AGENT_COLLISION_RECOVERY_BINDING_INVALID",
+      );
+      await expect(client.query(
+        "UPDATE memory_review_batches SET recovery_attempts = 3 WHERE id = $1",
+        [BATCH_ID],
+      )).rejects.toThrow();
+      await client.query(
+        `UPDATE memory_turn_source_sets SET application_session_id = $2
+          WHERE memory_review_batch_id = $1`,
+        [BATCH_ID, COLLISION_APPLICATION_SESSION_ID],
+      );
+
+      await client.query(migration);
+
+      await expect(client.query(
+        `SELECT status::text, recovery_attempts, last_recovery_diagnostic_code,
+                application_session_id, eve_session_id, diagnostic_code
+           FROM memory_review_batches WHERE id = $1`,
+        [BATCH_ID],
+      )).resolves.toMatchObject({ rows: [{
+        application_session_id: null,
+        diagnostic_code: null,
+        eve_session_id: null,
+        last_recovery_diagnostic_code: "AGENT_MEMORY_REVIEW_IMPLICIT_AGENT_COLLISION",
+        recovery_attempts: 3,
+        status: "pending",
+      }] });
+      await expect(client.query(
+        `SELECT continuation_token, memory_review_batch_id
+           FROM conversation_sessions WHERE id = $1`,
+        [COLLISION_APPLICATION_SESSION_ID],
+      )).resolves.toMatchObject({ rows: [{
+        continuation_token: `retired-memory-review:${COLLISION_APPLICATION_SESSION_ID}`,
+        memory_review_batch_id: null,
+      }] });
+      await expect(client.query(
+        `SELECT count(*)::integer AS source_count,
+                min(timeline_sequence)::text AS first, max(timeline_sequence)::text AS last
+           FROM memory_review_batch_sources WHERE batch_id = $1`,
+        [BATCH_ID],
+      )).resolves.toMatchObject({ rows: [{ source_count: 50, first: "5540", last: "5589" }] });
+      await expect(client.query(
+        "SELECT count(*)::integer AS count FROM memory_turn_source_sets WHERE memory_review_batch_id = $1",
+        [BATCH_ID],
+      )).resolves.toMatchObject({ rows: [{ count: 0 }] });
+      await expect(client.query(
+        `SELECT recovery_generation FROM memory_review_owner_alerts
+          WHERE batch_id = $1 ORDER BY recovery_generation`,
+        [BATCH_ID],
+      )).resolves.toMatchObject({ rows: [{ recovery_generation: 1 }, { recovery_generation: 2 }] });
+      await expect(client.query(
+        `SELECT metadata FROM audit_events
+          WHERE event_type = 'memory_review.operator_recovered' AND subject_id = $1
+          ORDER BY created_at DESC LIMIT 1`,
+        [BATCH_ID],
+      )).resolves.toMatchObject({ rows: [{ metadata: {
+        collisionEveSessionId: COLLISION_EVE_SESSION_ID,
+        recoveryAttempt: 3,
+      } }] });
+      await expect(client.query(
+        `UPDATE memory_review_batches SET recovery_attempts = 4 WHERE id = $1`,
+        [BATCH_ID],
+      )).rejects.toThrow();
+    } finally {
+      await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+      await client.query("RESET search_path");
+      client.release();
+    }
+  });
+});

--- a/agent/lib/memory-upgrade-ledger.integration.test.ts
+++ b/agent/lib/memory-upgrade-ledger.integration.test.ts
@@ -101,6 +101,7 @@ const POST_V0101_MIGRATIONS = [
   "067_durable_memory_review_batches.sql",
   "068_memory_review_recovery.sql",
   "069_memory_review_sandbox_recovery.sql",
+  "070_memory_review_agent_collision_recovery.sql",
 ] as const;
 
 const EXPECTED_R0_R7_TABLES = [

--- a/docs/releases/v0.15.7.md
+++ b/docs/releases/v0.15.7.md
@@ -1,0 +1,31 @@
+# Osinara v0.15.7
+
+Patch-релиз устранения pre-model collision между implicit root delegation Eve и dynamic tool surface
+фоновой проверки памяти.
+
+## Причина
+
+- Eve `0.32.0` добавляет root-only tool `agent` до применения step-scoped dynamic tools.
+- Background memory review пытался перекрыть `agent` явным denial tool, поэтому harness останавливался
+  с `Dynamic tool "agent" collides with a runtime-visible subagent` до обращения к модели.
+- Публичный Eve API поддерживает только статическое отключение implicit `agent` для всех root sessions;
+  conditional disable для одной верифицированной internal session отсутствует.
+
+## Исправление
+
+- Reproducible Eve patch удаляет только implicit root `agent` с полным runtime fingerprint и только при
+  сочетании authenticator `memory-review` и mode `background`.
+- Telegram, interactive review и любые не верифицированные root sessions сохраняют native delegation.
+- Authored tools и declared subagents не затрагиваются; dynamic denial остаётся единственным descriptor
+  `agent` внутри background review и не может выполнить делегацию.
+- Migration `070` повторно открывает только exact batch `5540-5589` после проверки трёх failed roots,
+  lane cursor `5539`, двух alert generations, полного набора из 50 источников и отсутствия memory
+  mutation operations.
+
+## Проверка
+
+- Runtime regression test исполняет установленную функцию сборки Eve tools и проверяет verified,
+  interactive, spoofed и lookalike cases.
+- PostgreSQL integration test проверяет exact recovery generation `3`, сохранение source evidence,
+  retirement collision root и неизменность предыдущих owner alerts.
+- Production-equivalent Docker Compose gate выполняется перед публикацией immutable release.

--- a/migrations/070_memory_review_agent_collision_recovery.sql
+++ b/migrations/070_memory_review_agent_collision_recovery.sql
@@ -1,0 +1,234 @@
+-- Eve 0.32 exposed its implicit root delegation tool before applying the dynamic review denial,
+-- causing a proven pre-model collision. Widen recovery by one audited generation, then requeue only
+-- the exact side-effect-free production root authorized by the operator.
+ALTER TABLE memory_review_batches
+  DROP CONSTRAINT memory_review_batches_recovery_attempts_check,
+  DROP CONSTRAINT memory_review_batches_recovery_audit,
+  ADD CONSTRAINT memory_review_batches_recovery_attempts_check
+    CHECK (recovery_attempts BETWEEN 0 AND 3),
+  ADD CONSTRAINT memory_review_batches_recovery_audit CHECK (
+    (recovery_attempts = 0 AND last_recovery_diagnostic_code IS NULL
+      AND last_recovered_at IS NULL) OR
+    (recovery_attempts BETWEEN 1 AND 3 AND last_recovery_diagnostic_code IS NOT NULL
+      AND last_recovered_at IS NOT NULL)
+  );
+
+DO $$
+DECLARE
+  incident_batch_id constant uuid := '18329b3e-9563-4762-bc77-11641e8cbac1';
+  original_application_session_id constant uuid := '61b08325-2147-4047-9cb1-01d8210b89b4';
+  sandbox_application_session_id constant uuid := '26942f0e-76a7-4240-b241-ff866fc084b4';
+  collision_application_session_id constant uuid := 'ced56a9b-e788-41e5-82fb-ac46e8b20168';
+  original_eve_session_id constant text := 'wrun_01KZWTTV5XAJY71V8DW3E7EM4X';
+  sandbox_eve_session_id constant text := 'wrun_01KZZN63ATNDJSP336AVRKE1XW';
+  collision_eve_session_id constant text := 'wrun_01KZZW3MVCRG9D57A0TWQ06M8D';
+  recovery_diagnostic_code constant text := 'AGENT_MEMORY_REVIEW_IMPLICIT_AGENT_COLLISION';
+  incident memory_review_batches%ROWTYPE;
+  retained_count integer;
+  retained_first bigint;
+  retained_last bigint;
+  alert_count integer;
+  alert_first_generation integer;
+  alert_last_generation integer;
+  bound_count integer;
+  bound_first bigint;
+  bound_last bigint;
+  locked_session_count integer;
+  lane_cursor bigint;
+  review_conversation application_conversations%ROWTYPE;
+BEGIN
+  SELECT * INTO incident FROM memory_review_batches WHERE id = incident_batch_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  -- Every mutable batch field must still match the inspected third pre-model failure.
+  IF incident.batch_kind IS DISTINCT FROM 'background'
+    OR incident.status IS DISTINCT FROM 'ambiguous'
+    OR incident.predecessor_sequence IS DISTINCT FROM 5539
+    OR incident.from_sequence IS DISTINCT FROM 5540
+    OR incident.through_sequence IS DISTINCT FROM 5589
+    OR incident.source_count IS DISTINCT FROM 50
+    OR incident.recovery_attempts IS DISTINCT FROM 2
+    OR incident.diagnostic_code
+      IS DISTINCT FROM 'AGENT_MEMORY_REVIEW_SESSION_FAILED_AMBIGUOUS'
+    OR incident.last_recovery_diagnostic_code
+      IS DISTINCT FROM 'AGENT_MEMORY_REVIEW_SANDBOX_CONTEXT_INVALID'
+    OR incident.application_session_id IS DISTINCT FROM collision_application_session_id
+    OR incident.eve_session_id IS DISTINCT FROM collision_eve_session_id
+    OR incident.eve_turn_id IS DISTINCT FROM 'turn_0'
+    OR incident.started_at IS NULL
+    OR incident.completed_at IS NULL THEN
+    RAISE EXCEPTION
+      'AGENT_MEMORY_REVIEW_AGENT_COLLISION_RECOVERY_STATE_INVALID: Incident batch state changed';
+  END IF;
+
+  -- The lane must not have advanced through an unresolved batch, and all three roots remain an
+  -- immutable failure chain with only the newest session still linked to the batch.
+  SELECT processed_through_sequence INTO lane_cursor
+    FROM memory_review_lanes WHERE id = incident.lane_id FOR UPDATE;
+  IF lane_cursor IS DISTINCT FROM 5539 THEN
+    RAISE EXCEPTION
+      'AGENT_MEMORY_REVIEW_AGENT_COLLISION_RECOVERY_LANE_INVALID: Review lane advanced';
+  END IF;
+  SELECT * INTO STRICT review_conversation
+    FROM application_conversations WHERE id = incident.conversation_id;
+
+  -- Lock the full session chain before checking trust-zone and lifecycle identity. Each recovery
+  -- creates a fresh thread at generation zero while retaining the stable conversation key.
+  PERFORM id FROM conversation_sessions
+   WHERE id IN (
+     original_application_session_id,
+     sandbox_application_session_id,
+     collision_application_session_id
+   )
+   ORDER BY id FOR UPDATE;
+  GET DIAGNOSTICS locked_session_count = ROW_COUNT;
+  IF locked_session_count <> 3 THEN
+    RAISE EXCEPTION
+      'AGENT_MEMORY_REVIEW_AGENT_COLLISION_RECOVERY_SESSION_INVALID: Incident sessions missing';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM conversation_sessions
+     WHERE id = original_application_session_id AND eve_session_id = original_eve_session_id
+       AND continuation_token = 'retired-memory-review:' || original_application_session_id
+       AND conversation_key = 'memory-review:' || incident_batch_id AND generation = 0
+       AND family_id = review_conversation.family_id
+       AND group_id IS NOT DISTINCT FROM review_conversation.telegram_group_id
+       AND owner_user_id IS NOT DISTINCT FROM review_conversation.owner_user_id
+       AND scope = review_conversation.scope AND pending_operation = false
+       AND memory_review_batch_id IS NULL AND kind = 'proactive'
+       AND task_state = 'failed' AND retired_at IS NOT NULL
+  ) OR NOT EXISTS (
+    SELECT 1 FROM conversation_sessions
+     WHERE id = sandbox_application_session_id AND eve_session_id = sandbox_eve_session_id
+       AND continuation_token = 'retired-memory-review:' || sandbox_application_session_id
+       AND conversation_key = 'memory-review:' || incident_batch_id AND generation = 0
+       AND family_id = review_conversation.family_id
+       AND group_id IS NOT DISTINCT FROM review_conversation.telegram_group_id
+       AND owner_user_id IS NOT DISTINCT FROM review_conversation.owner_user_id
+       AND scope = review_conversation.scope AND pending_operation = false
+       AND memory_review_batch_id IS NULL AND kind = 'proactive'
+       AND task_state = 'failed' AND retired_at IS NOT NULL
+  ) OR NOT EXISTS (
+    SELECT 1 FROM conversation_sessions
+     WHERE id = collision_application_session_id AND eve_session_id = collision_eve_session_id
+       AND continuation_token = 'memory-review:' || incident_batch_id
+       AND conversation_key = 'memory-review:' || incident_batch_id AND generation = 0
+       AND family_id = review_conversation.family_id
+       AND group_id IS NOT DISTINCT FROM review_conversation.telegram_group_id
+       AND owner_user_id IS NOT DISTINCT FROM review_conversation.owner_user_id
+       AND scope = review_conversation.scope AND pending_operation = false
+       AND memory_review_batch_id = incident_batch_id AND kind = 'proactive'
+       AND task_state = 'failed' AND retired_at IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION
+      'AGENT_MEMORY_REVIEW_AGENT_COLLISION_RECOVERY_SESSION_INVALID: Incident sessions changed';
+  END IF;
+
+  -- Any durable memory mutation would make replay unsafe even if the model trace looked empty.
+  IF EXISTS (
+    SELECT 1 FROM memory_mutation_operations
+     WHERE eve_session_id IN (
+       original_eve_session_id,
+       sandbox_eve_session_id,
+       collision_eve_session_id
+     )
+  ) THEN
+    RAISE EXCEPTION
+      'AGENT_MEMORY_REVIEW_AGENT_COLLISION_RECOVERY_SIDE_EFFECT_FOUND: Recovery is not safe';
+  END IF;
+
+  SELECT count(*)::integer, min(timeline_sequence), max(timeline_sequence)
+    INTO retained_count, retained_first, retained_last
+    FROM memory_review_batch_sources WHERE batch_id = incident_batch_id;
+  IF retained_count <> 50 OR retained_first <> 5540 OR retained_last <> 5589 THEN
+    RAISE EXCEPTION
+      'AGENT_MEMORY_REVIEW_AGENT_COLLISION_RECOVERY_SOURCES_INVALID: Source evidence changed';
+  END IF;
+
+  -- The binding to be deleted must be the inspected collision turn and contain exactly the same
+  -- immutable source IDs as the retained batch snapshot. No unrelated turn may be erased by repair.
+  PERFORM 1 FROM memory_turn_source_sets
+   WHERE memory_review_batch_id = incident_batch_id
+     AND eve_session_id = collision_eve_session_id AND eve_turn_id = 'turn_0'
+     AND application_session_id = collision_application_session_id
+     AND conversation_id = incident.conversation_id AND current_timeline_entry_id IS NULL
+   FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION
+      'AGENT_MEMORY_REVIEW_AGENT_COLLISION_RECOVERY_BINDING_INVALID: Turn binding changed';
+  END IF;
+  PERFORM 1 FROM memory_turn_sources
+   WHERE eve_session_id = collision_eve_session_id AND eve_turn_id = 'turn_0'
+   ORDER BY timeline_sequence FOR UPDATE;
+  SELECT count(*)::integer, min(timeline_sequence), max(timeline_sequence)
+    INTO bound_count, bound_first, bound_last
+    FROM memory_turn_sources
+   WHERE eve_session_id = collision_eve_session_id AND eve_turn_id = 'turn_0';
+  IF bound_count <> 50 OR bound_first <> 5540 OR bound_last <> 5589 OR EXISTS (
+    SELECT timeline_entry_id FROM memory_turn_sources
+     WHERE eve_session_id = collision_eve_session_id AND eve_turn_id = 'turn_0'
+    EXCEPT
+    SELECT timeline_entry_id FROM memory_review_batch_sources
+     WHERE batch_id = incident_batch_id
+  ) OR EXISTS (
+    SELECT timeline_entry_id FROM memory_review_batch_sources
+     WHERE batch_id = incident_batch_id
+    EXCEPT
+    SELECT timeline_entry_id FROM memory_turn_sources
+     WHERE eve_session_id = collision_eve_session_id AND eve_turn_id = 'turn_0'
+  ) OR EXISTS (
+    SELECT 1 FROM memory_turn_sources
+     WHERE eve_session_id = collision_eve_session_id AND eve_turn_id = 'turn_0'
+       AND is_current
+  ) THEN
+    RAISE EXCEPTION
+      'AGENT_MEMORY_REVIEW_AGENT_COLLISION_RECOVERY_BINDING_SOURCES_INVALID: Turn sources changed';
+  END IF;
+
+  -- Alert generations prove both earlier operator recoveries and remain untouched by this repair.
+  SELECT count(*)::integer, min(recovery_generation), max(recovery_generation)
+    INTO alert_count, alert_first_generation, alert_last_generation
+    FROM memory_review_owner_alerts WHERE batch_id = incident_batch_id;
+  IF alert_count <> 2 OR alert_first_generation <> 1 OR alert_last_generation <> 2 THEN
+    RAISE EXCEPTION
+      'AGENT_MEMORY_REVIEW_AGENT_COLLISION_RECOVERY_ALERTS_INVALID: Alert history changed';
+  END IF;
+
+  -- Retire the failed root and clear its turn binding before making the immutable batch claimable.
+  DELETE FROM memory_turn_source_sets WHERE memory_review_batch_id = incident_batch_id;
+  UPDATE conversation_sessions
+     SET continuation_token = 'retired-memory-review:' || id,
+         memory_review_batch_id = NULL,
+         pending_operation = false,
+         task_state = 'failed',
+         retired_at = coalesce(retired_at, now()),
+         delete_after = coalesce(delete_after, now() + interval '90 days')
+   WHERE id = collision_application_session_id;
+
+  UPDATE memory_review_batches
+     SET status = 'pending', application_session_id = NULL, eve_session_id = NULL,
+         eve_turn_id = NULL, lease_token = NULL, lease_expires_at = NULL,
+         diagnostic_code = NULL, started_at = NULL, completed_at = NULL,
+         recovery_attempts = 3,
+         last_recovery_diagnostic_code = recovery_diagnostic_code,
+         last_recovered_at = now(), updated_at = now()
+   WHERE id = incident_batch_id;
+
+  INSERT INTO audit_events (family_id, event_type, subject_id, metadata)
+  SELECT conversation.family_id, 'memory_review.operator_recovered', incident_batch_id,
+         jsonb_build_object(
+           'diagnosticCode', recovery_diagnostic_code,
+           'fromSequence', 5540,
+           'throughSequence', 5589,
+           'recoveryAttempt', 3,
+           'originalEveSessionId', original_eve_session_id,
+           'sandboxEveSessionId', sandbox_eve_session_id,
+           'collisionEveSessionId', collision_eve_session_id,
+           'retiredApplicationSessionId', collision_application_session_id
+         )
+    FROM application_conversations AS conversation
+   WHERE conversation.id = incident.conversation_id;
+END;
+$$;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.15.6",
+      "version": "0.15.7",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.6",
+  "version": "0.15.7",
   "private": true,
   "type": "module",
   "imports": {

--- a/scripts/apply-eve-patches.ts
+++ b/scripts/apply-eve-patches.ts
@@ -5,6 +5,7 @@
  * - `replaceExact`: fail-fast, count-checked, idempotent artifact replacement.
  * - Production startup health wait: permits bounded first-run sandbox preparation.
  * - Model exact-once policy: disables Eve reissues and multi-call compaction recovery.
+ * - Memory review delegation policy: hides only the implicit root agent from verified reviews.
  * - Adapter approval policy: propagates failed `input.requested` persistence.
  * - Telegram durable ingress: verified-update and authenticated internal-drain hooks.
  * - Telegram dispatch extensions: Session return, message/token override, reply routing, and HITL auth.
@@ -99,6 +100,14 @@ await replaceExact(
   runtimePaths.toolLoop,
   "async function attemptUnsupportedProviderToolRecovery(e){let t=extractUnsupportedProviderToolTypes(e.error);if(t.length===0)return{outcome:`skipped`};let n=[];for(let e of t){let t=resolveFrameworkToolFromUpstreamType(e);t!==null&&!n.includes(t)&&n.push(t)}if(n.length===0)return{outcome:`skipped`};log.warn(`disabling unsupported provider tool(s); retrying step once`,{disabled:n,sessionId:e.sessionId,turnId:e.turnId,upstreamTypes:t});let r={disabledProviderTools:new Set(n),extraSystemNote:buildDisabledToolNote(n)};try{return{outcome:`recovered`,result:await e.runOneModelCall({...r,suppressStepStartedEmission:!0})}}catch(e){return{outcome:`failed`,error:e,retryCallOptions:r}}}",
   "async function attemptUnsupportedProviderToolRecovery(e){return{outcome:`skipped`}}",
+);
+
+// The internal review channel is a root session, but it must not inherit delegation. Match the
+// complete implicit-agent fingerprint so authored tools and declared subagents remain untouched.
+await replaceExact(
+  runtimePaths.toolLoop,
+  "function buildHarnessToolsWithDynamicSubagents(e,t){let n=new Map(e);if(t===void 0)return n;",
+  "function buildHarnessToolsWithDynamicSubagents(e,t){let n=new Map(e);if(t===void 0)return n;let r=t.get(AuthKey),i=n.get(`agent`);r?.authenticator===`memory-review`&&r.attributes.memoryReviewMode===`background`&&i?.runtimeAction?.kind===`subagent-call`&&i.runtimeAction.nodeId===`__root__`&&i.runtimeAction.subagentName===`agent`&&n.delete(`agent`);",
 );
 
 // Compaction may shrink the local recent window, but it may not buy another summary model call.


### PR DESCRIPTION
## Summary
- suppress Eve 0.32 implicit root delegation only for verified background memory-review sessions
- add runtime regression coverage without changing interactive or Telegram delegation
- add exact, bounded migration 070 recovery for the pre-model production incident
- release as v0.15.7

## Verification
- clean npm ci
- npm run typecheck
- npm run build
- docker compose -f compose.test.yaml up --build --abort-on-container-exit --exit-code-from tests
- 1722 tests passed, 2 skipped