### PR TITLE
Release v0.15.8

### DIFF
--- a/docs/releases/v0.15.8.md
+++ b/docs/releases/v0.15.8.md
@@ -1,0 +1,31 @@
+# Osinara v0.15.8
+
+Релиз переводит настройки общения на один prompt для каждого Telegram-чата и устраняет premature
+timeout локальной Workflow queue, заблокировавший production memory review.
+
+## Настройки общения
+
+- Разрозненные typed preferences заменены одним revisioned prompt на точный application conversation.
+- Инструмент поддерживает `get`, `append`, `replace` и `clear`; mutation authorization выводится только
+  из текущего verified Telegram source.
+- Scheduled runs получают только read-доступ и обязаны предъявить совпадающий `scheduledRunId` активного
+  caller, чтобы metadata одного principal нельзя было объединить с actor другого.
+- Migration `071` проецирует существующие personal, family и group preferences в соответствующие чаты,
+  не выдаёт family-настройки external groups и fail-closed перечисляет каждую unmapped legacy-строку.
+
+## Workflow queue
+
+- Version-pinned Eve `0.32.0` patch увеличивает default body и headers timeout local Workflow transport
+  с 30 секунд до 5 минут, то есть дольше четырёхминутного replay window.
+- Queue retry semantics не изменены: исправление предотвращает только premature self-delivery failure и
+  последующий redelivery storm, пока исходный agent turn продолжает выполняться.
+- Migration `072` восстанавливает только проверенный side-effect-free incident batch `7609`, переводит
+  его в isolated background review `7609-7659` и не ротирует активную canonical Telegram session.
+- Recovery проверяет exact incident, successor, lane, alert, source ownership и отсутствие memory
+  mutations; любое расхождение атомарно останавливает migration.
+
+## Проверка
+
+- Migration integration tests требуют отдельную базу с суффиксом `_test` до выполнения `DROP SCHEMA`.
+- Проверены invalid и unmapped legacy preferences, overlapping successor ownership и rollback recovery.
+- Production-equivalent Docker Compose gate: 309 test files, 1739 tests, typecheck и `eve build`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.15.7",
+      "version": "0.15.8",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- bump the package and lockfile version to `0.15.8`
- add release notes for chat communication prompts and the local Workflow queue recovery
- unblock immutable production publishing after PR #87

## Verification
- PR #87 production-equivalent gate passed: 309 test files, 1739 tests, typecheck and `eve build`
- no existing GitHub release or tag uses `v0.15.8`