### PR TITLE
Serialize Eve session retention

### DIFF
--- a/agent/lib/sessions/session-retention.test.ts
+++ b/agent/lib/sessions/session-retention.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Eve terminal session retention job tests.
+ *
+ * Constructs covered:
+ * - A dedicated PostgreSQL advisory lock serializes physical world-local graph deletion.
+ * - A concurrent invocation exits without claiming a second application session.
+ * - Destroying the lock connection releases the session-level lock after the sweep.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const values = vi.hoisted(() => {
+  let lockHeld = false;
+  let resolveDeletion!: () => void;
+  const deletionPromise = new Promise<void>((resolve) => {
+    resolveDeletion = resolve;
+  });
+  const lockRelease = vi.fn((destroy?: boolean) => {
+    if (destroy) lockHeld = false;
+  });
+  const lockQuery = vi.fn(async () => {
+    if (lockHeld) return { rows: [{ acquired: false }] };
+    lockHeld = true;
+    return { rows: [{ acquired: true }] };
+  });
+  return {
+    claimExpiredForDeletion: vi.fn(),
+    completeDeletion: vi.fn(),
+    connect: vi.fn(async () => ({ query: lockQuery, release: lockRelease })),
+    deleteLocalEveSession: vi.fn(async () => deletionPromise),
+    failDeletion: vi.fn(),
+    lockQuery,
+    lockRelease,
+    resolveDeletion,
+    retireAbandonedTasks: vi.fn(),
+  };
+});
+
+vi.mock("../database.js", () => ({
+  database: () => ({ connect: values.connect }),
+}));
+vi.mock("./eve-session-storage.js", () => ({
+  deleteLocalEveSession: values.deleteLocalEveSession,
+}));
+vi.mock("./session-repository.js", () => ({
+  sessionRepository: {
+    claimExpiredForDeletion: values.claimExpiredForDeletion,
+    completeDeletion: values.completeDeletion,
+    failDeletion: values.failDeletion,
+    retireAbandonedTasks: values.retireAbandonedTasks,
+  },
+}));
+
+import { deleteExpiredSessions } from "./session-retention.js";
+
+describe("deleteExpiredSessions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    values.claimExpiredForDeletion
+      .mockResolvedValueOnce({
+        eveSessionId: "wrun_01KXB392VJ8YY13JMJ9YZAF5QR",
+        id: "application-session-1",
+        leaseToken: "lease-1",
+      })
+      .mockResolvedValue(null);
+  });
+
+  it("serializes physical deletion across concurrent retention jobs", async () => {
+    const first = deleteExpiredSessions();
+    await vi.waitFor(() => expect(values.deleteLocalEveSession).toHaveBeenCalledTimes(1));
+
+    await expect(deleteExpiredSessions()).resolves.toBe(0);
+    expect(values.claimExpiredForDeletion).toHaveBeenCalledTimes(1);
+    expect(values.lockRelease).toHaveBeenCalledWith(false);
+
+    values.resolveDeletion();
+    await expect(first).resolves.toBe(1);
+    expect(values.completeDeletion).toHaveBeenCalledWith(
+      "application-session-1",
+      "lease-1",
+    );
+    expect(values.lockRelease).toHaveBeenLastCalledWith(true);
+  });
+});

--- a/agent/lib/sessions/session-retention.ts
+++ b/agent/lib/sessions/session-retention.ts
@@ -2,17 +2,39 @@
  * Eve 0.32.0 session retention job boundary.
  *
  * Export:
- * - `deleteExpiredSessions`: leases and physically deletes retired Eve sessions.
+ * - `deleteExpiredSessions`: globally serializes, leases, and physically deletes retired Eve sessions.
  */
 import { resolve } from "node:path";
 
 import { isAppError } from "../app-error.js";
+import { database } from "../database.js";
 import { deleteLocalEveSession } from "./eve-session-storage.js";
 import { sessionRepository } from "./session-repository.js";
 
+const SESSION_RETENTION_ADVISORY_LOCK_KEY = "osinara-eve-session-retention";
 const WORKFLOW_DATA_ROOT = resolve(".eve", ".workflow-data");
 
 export async function deleteExpiredSessions(): Promise<number> {
+  // Per-session leases allow parallel workers, but world-local hook indexes are shared across runs.
+  // Hold one dedicated connection for the complete physical sweep and destroy it to release the lock
+  // even when filesystem cleanup throws before PostgreSQL can be contacted again.
+  const lockClient = await database().connect();
+  let acquired = false;
+  try {
+    const lock = await lockClient.query<{ acquired: boolean }>(
+      "SELECT pg_try_advisory_lock(hashtextextended($1, 0)) AS acquired",
+      [SESSION_RETENTION_ADVISORY_LOCK_KEY],
+    );
+    acquired = lock.rows[0]?.acquired === true;
+    if (!acquired) return 0;
+
+    return await deleteExpiredSessionsUnderLock();
+  } finally {
+    lockClient.release(acquired);
+  }
+}
+
+async function deleteExpiredSessionsUnderLock(): Promise<number> {
   // The existing minute lifecycle hook bounds abandoned task rows before physical Eve deletion.
   await sessionRepository.retireAbandonedTasks(new Date());
   let deleted = 0;


### PR DESCRIPTION
## Summary
- serialize physical world-local session deletion with a PostgreSQL advisory lock
- let concurrent minute jobs exit before claiming another session
- release the session-level lock by destroying its dedicated connection on every outcome

## Incident evidence
- concurrent cleanup of different runs raced while scanning the shared Eve hook index
- one job observed an index entry removed by another and failed closed
- the affected partial deletion was retried idempotently with the agent schedule stopped

## Verification
- targeted retention/storage tests: 7 passed
- production-equivalent Docker Compose gate: 311 test files, 1741 tests
- typecheck and `eve build` passed