### PR TITLE
Release v0.15.9

### DIFF
--- a/docs/releases/v0.15.9.md
+++ b/docs/releases/v0.15.9.md
@@ -1,0 +1,34 @@
+# Osinara v0.15.9
+
+Patch-релиз повторяет не установленный в production `v0.15.8`, устраняет неограниченное накопление
+terminal Eve stream data и сохраняет исправление local Workflow queue timeout.
+
+## Eve stream retention
+
+- Eve `0.32.0` сохраняет cumulative reasoning и message text в каждом appended stream event; 48
+  production streams создали 562 445 chunk-файлов и заняли 6,71 ГБ за четыре дня.
+- Retired application sessions теперь хранят физический Eve run graph 24 часа вместо 90 дней.
+- Active sessions, pending/HITL operations, retention holds и ещё не terminal runs не удаляются.
+- Migration `073` сокращает существующие deadlines, сохраняет holds и обновляет Telegram trust-zone
+  retirement trigger; каждое сокращение записывается в audit.
+- Physical deletion остаётся за version-pinned Eve `0.32.0` adapter: он удаляет exact run, events,
+  steps, waits, hooks, locks и streams только под application deletion lease.
+- Весь physical sweep сериализован PostgreSQL advisory lock, потому что разные runs используют общий
+  hook index и не могут безопасно удаляться параллельно.
+
+## Остальные исправления
+
+- Разрозненные настройки общения заменены одним revisioned communication prompt на Telegram-чат с
+  операциями `get`, `append`, `replace` и `clear`.
+- Scheduled prompt read требует совпадающий `scheduledRunId` активного caller и не объединяет identity
+  разных principals.
+- Default body и headers timeout local Workflow transport увеличен с 30 секунд до 5 минут, чтобы
+  self-delivery не обрывалась раньше четырёхминутного replay window.
+- Migration `072` fail-closed восстанавливает только проверенный side-effect-free memory-review
+  incident `7609-7659`, не ротируя активную canonical Telegram session.
+
+## Эксплуатационная проверка
+
+- До release старые terminal sessions очищены существующим lease-based adapter: workflow volume
+  уменьшен с 6,7 до 1,8 ГБ, production agent остался healthy, Telegram ingress backlog равен нулю.
+- Production-equivalent Docker Compose gate: 311 test files, 1741 tests, typecheck и `eve build`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.8",
+  "version": "0.15.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.15.8",
+      "version": "0.15.9",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.8",
+  "version": "0.15.9",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- publish a new immutable patch after the terminally failed `v0.15.8` deployment proposal
- include bounded 24-hour terminal Eve stream retention and serialized physical cleanup
- retain chat communication prompts, local Workflow timeout, and exact memory-review recovery

## Production evidence
- old terminal cleanup reduced Eve workflow storage from 6.7 GB to 1.8 GB
- free disk increased to 18 GB and now satisfies backup preflight
- production agent is healthy and Telegram ingress backlog is zero

## Verification
- production-equivalent Docker Compose gate: 311 test files, 1741 tests
- typecheck and `eve build` passed
- no existing release or tag uses `v0.15.9`