### PR TITLE
Bind queue recovery to successor turn

### DIFF
--- a/agent/lib/memory-review/memory-review-local-queue-recovery-migration.integration.test.ts
+++ b/agent/lib/memory-review/memory-review-local-queue-recovery-migration.integration.test.ts
@@ -5,6 +5,7 @@
  * - Only the exact side-effect-free production batch is converted to a recoverable background batch.
  * - The active canonical chat session remains untouched.
  * - The retained source expands to 50 exact user entries without duplicating a completed successor.
+ * - Only a mutation from the successor turn blocks recovery; later turns in its session remain valid.
  * - Changed incident identity or overlapping source ownership aborts the migration atomically.
  */
 import { readFile, readdir } from "node:fs/promises";
@@ -184,6 +185,22 @@ describeWithDatabase("072 local Workflow queue recovery", () => {
             SET diagnostic_code = 'AGENT_MEMORY_REVIEW_INTERACTIVE_START_AMBIGUOUS'
           WHERE id = $1`,
         [INCIDENT_BATCH_ID],
+      );
+
+      // The durable session continued after the inspected successor. Only an operation from its exact
+      // turn proves a side effect; a later ordinary turn must not permanently block incident repair.
+      await client.query(
+        `INSERT INTO memory_mutation_operations
+           (family_id, operation_key, mutation_kind, input_hash, eve_session_id, eve_turn_id)
+         VALUES ($1, 'successor-turn-operation', 'create', $2, $3, 'turn_0'),
+                ($1, 'later-session-operation', 'create', $2, $3, 'turn_15')`,
+        [family.rows[0]!.id, "a".repeat(64), SUCCESSOR_EVE_SESSION_ID],
+      );
+      await expect(client.query(migration)).rejects.toThrow(
+        "AGENT_MEMORY_REVIEW_LOCAL_QUEUE_RECOVERY_SIDE_EFFECT_FOUND",
+      );
+      await client.query(
+        "DELETE FROM memory_mutation_operations WHERE operation_key = 'successor-turn-operation'",
       );
 
       await client.query(migration);

--- a/agent/lib/memory-review/memory-review-local-queue-recovery-migration.integration.test.ts
+++ b/agent/lib/memory-review/memory-review-local-queue-recovery-migration.integration.test.ts
@@ -5,7 +5,8 @@
  * - Only the exact side-effect-free production batch is converted to a recoverable background batch.
  * - The active canonical chat session remains untouched.
  * - The retained source expands to 50 exact user entries without duplicating a completed successor.
- * - Only a mutation from the successor turn blocks recovery; later turns in its session remain valid.
+ * - Only a same-family mutation from the successor turn blocks recovery.
+ * - Later turns and operations owned by another family do not block the incident repair.
  * - Changed incident identity or overlapping source ownership aborts the migration atomically.
  */
 import { readFile, readdir } from "node:fs/promises";
@@ -73,6 +74,9 @@ describeWithDatabase("072 local Workflow queue recovery", () => {
       // Reconstruct the inspected production trust zone and the 50 exact user sources.
       const family = await client.query<{ id: string }>(
         "INSERT INTO families (name) VALUES ('Local queue recovery') RETURNING id",
+      );
+      const otherFamily = await client.query<{ id: string }>(
+        "INSERT INTO families (name) VALUES ('Unrelated family') RETURNING id",
       );
       const owner = await client.query<{ id: string }>(
         `INSERT INTO users (telegram_user_id, display_name)
@@ -196,11 +200,19 @@ describeWithDatabase("072 local Workflow queue recovery", () => {
                 ($1, 'later-session-operation', 'create', $2, $3, 'turn_15')`,
         [family.rows[0]!.id, "a".repeat(64), SUCCESSOR_EVE_SESSION_ID],
       );
+      await client.query(
+        `INSERT INTO memory_mutation_operations
+           (family_id, operation_key, mutation_kind, input_hash, eve_session_id, eve_turn_id)
+         VALUES ($1, 'cross-family-turn-operation', 'create', $2, $3, 'turn_0')`,
+        [otherFamily.rows[0]!.id, "b".repeat(64), SUCCESSOR_EVE_SESSION_ID],
+      );
       await expect(client.query(migration)).rejects.toThrow(
         "AGENT_MEMORY_REVIEW_LOCAL_QUEUE_RECOVERY_SIDE_EFFECT_FOUND",
       );
       await client.query(
-        "DELETE FROM memory_mutation_operations WHERE operation_key = 'successor-turn-operation'",
+        `DELETE FROM memory_mutation_operations
+          WHERE family_id = $1 AND operation_key = 'successor-turn-operation'`,
+        [family.rows[0]!.id],
       );
 
       await client.query(migration);

--- a/migrations/072_memory_review_local_queue_recovery.sql
+++ b/migrations/072_memory_review_local_queue_recovery.sql
@@ -91,7 +91,9 @@ BEGIN
   IF EXISTS (
     SELECT 1 FROM memory_turn_source_sets WHERE memory_review_batch_id = incident_batch_id
   ) OR EXISTS (
-    SELECT 1 FROM memory_mutation_operations WHERE eve_session_id = successor_eve_session_id
+    SELECT 1 FROM memory_mutation_operations
+     WHERE eve_session_id = successor_eve_session_id
+       AND eve_turn_id = successor.eve_turn_id
   ) OR EXISTS (
     SELECT 1 FROM claim_evidence
      WHERE origin_conversation_id = incident.conversation_id

--- a/migrations/072_memory_review_local_queue_recovery.sql
+++ b/migrations/072_memory_review_local_queue_recovery.sql
@@ -92,7 +92,10 @@ BEGIN
     SELECT 1 FROM memory_turn_source_sets WHERE memory_review_batch_id = incident_batch_id
   ) OR EXISTS (
     SELECT 1 FROM memory_mutation_operations
-     WHERE eve_session_id = successor_eve_session_id
+     WHERE family_id = (
+             SELECT family_id FROM conversation_sessions WHERE id = application_session_id
+           )
+       AND eve_session_id = successor_eve_session_id
        AND eve_turn_id = successor.eve_turn_id
   ) OR EXISTS (
     SELECT 1 FROM claim_evidence


### PR DESCRIPTION
## Summary
- scope migration 072 side-effect detection to the exact completed successor turn
- keep later mutations from the same durable Eve session from blocking recovery
- cover exact-turn blocking and later-turn acceptance in the database integration test

## Verification
- targeted migration integration test
- full Docker Compose gate: 311 files, 1741 tests, typecheck, Eve build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Обновлена миграция `072_memory_review_local_queue_recovery.sql`.
- Проверка побочных эффектов теперь учитывает `eve_session_id` и точный `eve_turn_id` завершённого successor-батча.
- Более поздние мутации той же Eve-сессии больше не блокируют восстановление очереди.
- Добавлено интеграционное покрытие для блокировки точным ходом и успешного восстановления при более позднем ходе.

## Проверка

- Целевой интеграционный тест миграции.
- Полная проверка Docker Compose: 311 файлов, 1 741 тест, typecheck и сборка Eve.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->