### PR TITLE
Release v0.15.10

### DIFF
--- a/docs/releases/v0.15.10.md
+++ b/docs/releases/v0.15.10.md
@@ -1,0 +1,29 @@
+# Osinara v0.15.10
+
+Patch-релиз повторяет не установленный в production `v0.15.9` и исправляет fail-closed проверку
+recovery migration `072`, остановившую предыдущую установку до запуска приложения.
+
+## Memory review recovery
+
+- Migration `072` по-прежнему восстанавливает только exact incident batch `7609-7659` после проверки
+  состояния batch, lane, retained sources, owner alert и отсутствия durable side effects.
+- Side-effect boundary теперь сопоставляет `family_id`, `eve_session_id` и exact `eve_turn_id`
+  завершённого successor batch.
+- Более поздняя операция обычного Telegram turn в той же долговечной Eve session больше не считается
+  side effect ранее завершённого `turn_0`.
+- Операция другой семьи с совпавшей provenance также не может заблокировать recovery.
+- Exact-turn mutation той же семьи продолжает останавливать migration атомарно.
+
+## Остальной payload
+
+- Один revisioned communication prompt на Telegram-чат заменяет разрозненные настройки общения.
+- Local Workflow transport timeout увеличен до пяти минут и покрывает четырёхминутное replay window.
+- Retired terminal Eve run graphs хранятся 24 часа; active, HITL, held и non-terminal sessions не
+  удаляются.
+- Physical retention sweep сериализован PostgreSQL advisory lock для защиты shared Eve hook indexes.
+
+## Эксплуатационная проверка
+
+- После ambiguous `v0.15.9` production был восстановлен из неизменённого `v0.15.7`; additive migration
+  `071` применена, а `072` полностью откатилась своей transaction и отсутствует в migration ledger.
+- Production-equivalent Docker Compose gate: 311 test files, 1741 tests, typecheck и `eve build`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.9",
+  "version": "0.15.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.15.9",
+      "version": "0.15.10",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.9",
+  "version": "0.15.10",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- publish the migration 072 exact-turn and family-boundary correction
- repeat the v0.15.9 payload that did not reach production
- document the ambiguous deployment and safe migration ledger state

## Verification
- fix PR #92 passed the full Docker Compose gate: 311 files, 1741 tests, typecheck, Eve build
- this release PR changes only package metadata and release notes