### PR TITLE
feat: add NeuralDeep model provider

### DIFF
--- a/agent/lib/model-provider-config-schema.ts
+++ b/agent/lib/model-provider-config-schema.ts
@@ -15,7 +15,7 @@ import { MODEL_PROVIDER_MAX_OUTPUT_TOKENS } from "./model-provider-limits.js";
 import { getOpenCodeGoProtocol } from "./provider-catalog/opencode-go-models.js";
 
 const modelIdSchema = z.string().trim().min(1).max(200);
-const modelProviderIdSchema = z.enum(["deepseek", "minimax", "opencode-go", "openrouter"]);
+const modelProviderIdSchema = z.enum(["deepseek", "minimax", "neuraldeep", "opencode-go", "openrouter"]);
 const reasoningEffortSchema = z.enum(["max", "xhigh", "high", "medium", "low", "minimal"]);
 const maxOutputTokensSchema = z.number().int().positive().max(MODEL_PROVIDER_MAX_OUTPUT_TOKENS);
 const externalBaseUrlSchema = z.url().superRefine((value, context) => {
@@ -91,6 +91,7 @@ const modelProviderConfigSchema = z.object({
   const expectedBaseUrl = {
     deepseek: "https://api.deepseek.com",
     minimax: "https://api.minimax.io/anthropic/v1",
+    neuraldeep: "https://api.neuraldeep.ru/v1",
     "opencode-go": "https://opencode.ai/zen/go/v1",
     openrouter: "https://openrouter.ai/api/v1",
   }[config.provider];
@@ -115,6 +116,11 @@ const modelProviderConfigSchema = z.object({
   )) {
     context.addIssue({ code: "custom", message: "MiniMax transport mismatch", path: ["agent", "transport"] });
   }
+  if (config.provider === "neuraldeep" && (
+    transport.protocol !== "openai-chat-completions" ||
+    transport.providerName !== "neuraldeep" ||
+    transport.reasoning !== null
+  )) context.addIssue({ code: "custom", message: "NeuralDeep transport mismatch", path: ["agent", "transport"] });
   if (config.provider === "opencode-go") {
     const expectedProtocol = getOpenCodeGoProtocol(config.agent.models.primary.id);
     const anthropicMismatch = transport.protocol === "anthropic-messages" && (

--- a/agent/lib/model-provider-config.test.ts
+++ b/agent/lib/model-provider-config.test.ts
@@ -39,6 +39,31 @@ const validConfig = {
 } as const;
 
 describe("parseModelProviderConfig", () => {
+  it("accepts only the fixed NeuralDeep OpenAI-compatible transport", () => {
+    const neuraldeep = {
+      ...validConfig,
+      agent: {
+        ...validConfig.agent,
+        transport: {
+          baseUrl: "https://api.neuraldeep.ru/v1",
+          protocol: "openai-chat-completions",
+          providerName: "neuraldeep",
+          reasoning: null,
+        },
+      },
+      provider: "neuraldeep",
+    } as const;
+
+    expect(parseModelProviderConfig(neuraldeep)).toEqual(neuraldeep);
+    expect(() => parseModelProviderConfig({
+      ...neuraldeep,
+      agent: {
+        ...neuraldeep.agent,
+        transport: { ...neuraldeep.agent.transport, providerName: "openrouter" },
+      },
+    })).toThrow("AGENT_MODEL_PROVIDER_CONFIG_INVALID");
+  });
+
   it("loads the same active schema that production mounts for the agent", async () => {
     const active = JSON.parse(await readFile("config/agent-model-providers.json", "utf8"));
 

--- a/agent/lib/neuraldeep-model-transport.test.ts
+++ b/agent/lib/neuraldeep-model-transport.test.ts
@@ -1,0 +1,56 @@
+/**
+ * NeuralDeep OpenAI-compatible transport contract tests.
+ *
+ * Constructs covered:
+ * - `createConfiguredLanguageModel`: targets NeuralDeep's exact chat-completions endpoint.
+ * - NeuralDeep receives Bearer authentication and the audited Qwen request output limit.
+ * - Undocumented provider-specific reasoning controls are omitted from request payloads.
+ */
+import type { LanguageModelV4CallOptions } from "@ai-sdk/provider";
+import { describe, expect, it, vi } from "vitest";
+
+import { createConfiguredLanguageModel } from "./model-transport.js";
+
+describe("NeuralDeep model transport", () => {
+  it("uses the standard chat-completions contract without invented reasoning controls", async () => {
+    let body: Record<string, unknown> | undefined;
+    const fetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return new Response(JSON.stringify({
+        choices: [{ finish_reason: "stop", index: 0, message: { content: "Готово.", role: "assistant" } }],
+        created: 1,
+        id: "neuraldeep-completion",
+        model: "qwen3.8-27b",
+        object: "chat.completion",
+        usage: { completion_tokens: 2, prompt_tokens: 3, total_tokens: 5 },
+      }), { headers: { "content-type": "application/json" }, status: 200 });
+    });
+    const model = createConfiguredLanguageModel({
+      apiKey: "neuraldeep-secret",
+      fetch,
+      maxOutputTokens: 16_384,
+      modelId: "qwen3.8-27b",
+      transport: {
+        baseUrl: "https://api.neuraldeep.ru/v1",
+        protocol: "openai-chat-completions",
+        providerName: "neuraldeep",
+        reasoning: null,
+      },
+    });
+
+    await model.doGenerate({
+      prompt: [{ content: [{ text: "Проверка", type: "text" }], role: "user" }],
+    } as LanguageModelV4CallOptions);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.neuraldeep.ru/v1/chat/completions",
+      expect.objectContaining({
+        headers: expect.objectContaining({ authorization: "Bearer neuraldeep-secret" }),
+        method: "POST",
+      }),
+    );
+    expect(body).toMatchObject({ max_tokens: 16_384, model: "qwen3.8-27b" });
+    expect(body).not.toHaveProperty("reasoning_effort");
+    expect(body).not.toHaveProperty("thinking");
+  });
+});

--- a/agent/lib/provider-catalog/model-provider-config-builder.test.ts
+++ b/agent/lib/provider-catalog/model-provider-config-builder.test.ts
@@ -37,6 +37,17 @@ describe("buildModelProviderConfig", () => {
   it.each([
     {
       expected: {
+        baseUrl: "https://api.neuraldeep.ru/v1",
+        protocol: "openai-chat-completions",
+        providerName: "neuraldeep",
+        reasoning: null,
+      },
+      model: catalogModel({ reasoningOptions: [] }),
+      providerId: "neuraldeep",
+      reasoning: null,
+    },
+    {
+      expected: {
         baseUrl: "https://api.deepseek.com",
         protocol: "openai-chat-completions",
         providerName: "deepseek",
@@ -102,7 +113,7 @@ describe("buildModelProviderConfig", () => {
     expected: object;
     model: ProviderCatalogModel;
     providerId: ProviderId;
-    reasoning: ReasoningSelection;
+    reasoning: ReasoningSelection | null;
   }>)("builds the exact $providerId transport", ({ expected, model, providerId, reasoning }) => {
     const config = buildModelProviderConfig(providerId, model, reasoning, false);
 

--- a/agent/lib/provider-catalog/model-provider-config-builder.ts
+++ b/agent/lib/provider-catalog/model-provider-config-builder.ts
@@ -196,6 +196,11 @@ function buildTransport(
       format: "deepseek",
       providerName: "deepseek",
     },
+    neuraldeep: {
+      baseUrl: "https://api.neuraldeep.ru/v1",
+      format: "reasoning-effort",
+      providerName: "neuraldeep",
+    },
     "opencode-go": {
       baseUrl: "https://opencode.ai/zen/go/v1",
       format: "reasoning-effort",

--- a/agent/lib/provider-catalog/neuraldeep-models.ts
+++ b/agent/lib/provider-catalog/neuraldeep-models.ts
@@ -1,0 +1,45 @@
+/**
+ * Maintained NeuralDeep model metadata required by the installer.
+ *
+ * Exports:
+ * - `selectSupportedNeuralDeepModels`: intersects live model IDs with audited runtime metadata.
+ *
+ * Key constructs:
+ * - The allowlist contains only models whose context, tools, vision, and request limit are verified.
+ * - Live `/models` availability remains mandatory, so stale configured entries are never offered.
+ */
+import type { ProviderCatalogModel, ProviderProtocol } from "./provider-catalog-types.js";
+
+interface LiveNeuralDeepModel {
+  readonly id: string;
+  readonly protocol: ProviderProtocol;
+}
+
+const QWEN_3_8_CONTEXT_TOKENS = 262_144;
+const QWEN_3_8_REQUEST_OUTPUT_TOKENS = 16_384;
+
+// NeuralDeep documents this model as 256k, multimodal, tool-capable, and reasoning-enabled.
+// The request output cap matches NeuralDeep's published Qwen coding-agent configuration.
+const SUPPORTED_MODELS: Readonly<Record<string, ProviderCatalogModel>> = {
+  "qwen3.8-27b": {
+    contextWindowTokens: QWEN_3_8_CONTEXT_TOKENS,
+    defaultReasoningOption: null,
+    displayName: "Qwen 3.8 27B",
+    id: "qwen3.8-27b",
+    maxOutputTokens: QWEN_3_8_REQUEST_OUTPUT_TOKENS,
+    protocol: "openai-chat-completions",
+    reasoningOptions: [],
+    supportsImageInput: true,
+    supportsTools: true,
+  },
+};
+
+export function selectSupportedNeuralDeepModels(
+  liveModels: readonly LiveNeuralDeepModel[],
+): ProviderCatalogModel[] {
+  return liveModels.flatMap(({ id, protocol }) => {
+    const model = SUPPORTED_MODELS[id];
+    if (!model || model.protocol !== protocol) return [];
+    return [{ ...model, reasoningOptions: [...model.reasoningOptions] }];
+  });
+}

--- a/agent/lib/provider-catalog/openai-model-list-parser.ts
+++ b/agent/lib/provider-catalog/openai-model-list-parser.ts
@@ -2,7 +2,7 @@
  * OpenAI-compatible ID-only catalog parser.
  *
  * Exports:
- * - `parseOpenAiModelList`: validates DeepSeek, MiniMax, and OpenCode Go `/models` envelopes.
+ * - `parseOpenAiModelList`: validates OpenAI-compatible provider `/models` envelopes.
  * - `OpenAiModelListEntry`: validated model identifier returned by the provider.
  */
 import { z } from "zod";

--- a/agent/lib/provider-catalog/provider-catalog-types.ts
+++ b/agent/lib/provider-catalog/provider-catalog-types.ts
@@ -10,7 +10,7 @@
  * - `ProviderCatalogFetch`: injected Fetch API-compatible dependency.
  * - `FetchProviderCatalogOptions`: explicit catalog request inputs.
  */
-export type ProviderId = "deepseek" | "minimax" | "opencode-go" | "openrouter";
+export type ProviderId = "deepseek" | "minimax" | "neuraldeep" | "opencode-go" | "openrouter";
 
 export type ProviderProtocol = "anthropic-messages" | "openai-chat-completions";
 

--- a/agent/lib/provider-catalog/provider-catalog.test.ts
+++ b/agent/lib/provider-catalog/provider-catalog.test.ts
@@ -4,7 +4,7 @@
  * Constructs covered:
  * - `fetchProviderCatalog`: fetches provider model catalogs through an injected fetch.
  * - Provider authentication, endpoint selection, HTTP handling, and bounded timeout behavior.
- * - DeepSeek and MiniMax OpenAI-list parsing without fabricated capability metadata.
+ * - DeepSeek, MiniMax, and NeuralDeep parsing without fabricated live availability.
  * - Models.dev enrichment, strict live-ID intersection, and installer-ready model filtering.
  * - OpenCode Go's maintained protocol allowlist and exclusion of unknown or unsupported IDs.
  * - Stable `AppError` codes for invalid input and malformed provider responses.
@@ -36,7 +36,7 @@ function createCatalogFetch(responses: Record<string, Response>): ProviderCatalo
 }
 
 describe("fetchProviderCatalog", () => {
-  it.each(["deepseek", "minimax"] as const)(
+  it.each(["deepseek", "minimax", "neuraldeep"] as const)(
     "requires authentication before fetching the %s catalog",
     async (providerId) => {
       const fetch = createFetch(jsonResponse({ object: "list", data: [] }));
@@ -49,6 +49,43 @@ describe("fetchProviderCatalog", () => {
       expect(fetch).not.toHaveBeenCalled();
     },
   );
+
+  it("returns the documented NeuralDeep qwen3.8 model only when it is live", async () => {
+    const fetch = createCatalogFetch({
+      "https://api.neuraldeep.ru/v1/models": jsonResponse({
+        object: "list",
+        data: [
+          { id: "qwen3.8-27b", object: "model", owned_by: "neuraldeep" },
+          { id: "embedding-only", object: "model", owned_by: "neuraldeep" },
+        ],
+      }),
+    });
+
+    const models = await fetchProviderCatalog({
+      apiKey: "neuraldeep-secret",
+      fetch,
+      providerId: "neuraldeep",
+      timeoutMs: REQUEST_TIMEOUT_MS,
+    });
+
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledWith("https://api.neuraldeep.ru/v1/models", {
+      headers: { authorization: "Bearer neuraldeep-secret" },
+      method: "GET",
+      signal: expect.any(AbortSignal),
+    });
+    expect(models).toEqual<ProviderCatalogModel[]>([{
+      contextWindowTokens: 262_144,
+      defaultReasoningOption: null,
+      displayName: "Qwen 3.8 27B",
+      id: "qwen3.8-27b",
+      maxOutputTokens: 16_384,
+      protocol: "openai-chat-completions",
+      reasoningOptions: [],
+      supportsImageInput: true,
+      supportsTools: true,
+    }]);
+  });
 
   it("rejects a blank required API key before fetching", async () => {
     const fetch = createFetch(jsonResponse({ object: "list", data: [] }));

--- a/agent/lib/provider-catalog/provider-catalog.ts
+++ b/agent/lib/provider-catalog/provider-catalog.ts
@@ -15,6 +15,7 @@ import { enrichModelsFromModelsDev } from "./models-dev-parser.js";
 import { parseOpenAiModelList } from "./openai-model-list-parser.js";
 import { parseOpenRouterModels } from "./openrouter-model-parser.js";
 import { getOpenCodeGoProtocol } from "./opencode-go-models.js";
+import { selectSupportedNeuralDeepModels } from "./neuraldeep-models.js";
 import { providerCatalogError } from "./provider-catalog-errors.js";
 import type {
   FetchProviderCatalogOptions,
@@ -53,6 +54,11 @@ const PROVIDER_ENDPOINTS = {
     authentication: "required",
     protocol: "anthropic-messages",
     url: "https://api.minimax.io/v1/models",
+  },
+  neuraldeep: {
+    authentication: "required",
+    protocol: "openai-chat-completions",
+    url: "https://api.neuraldeep.ru/v1/models",
   },
   "opencode-go": {
     authentication: "optional",
@@ -178,6 +184,7 @@ export async function fetchProviderCatalog(
 
     // Validate availability first, then spend only the remaining deadline on metadata enrichment.
     const liveModels = parseLiveProviderResponse(providerId, liveBody);
+    if (providerId === "neuraldeep") return selectSupportedNeuralDeepModels(liveModels);
     const metadataBody = await fetchJsonWithinDeadline(
       fetch,
       MODELS_DEV_URL,

--- a/scripts/provider-installer/configuration.test.ts
+++ b/scripts/provider-installer/configuration.test.ts
@@ -20,6 +20,7 @@ describe("provider installer configuration", () => {
     expect(MODEL_PROVIDER_OPTIONS.map(({ value }) => value)).toEqual([
       "deepseek",
       "minimax",
+      "neuraldeep",
       "opencode-go",
       "openrouter",
     ]);

--- a/scripts/provider-installer/configuration.ts
+++ b/scripts/provider-installer/configuration.ts
@@ -28,6 +28,7 @@ export const ADDRESS_MODE_OPTIONS: readonly PromptOption<AddressMode>[] = [
 export const MODEL_PROVIDER_OPTIONS: readonly PromptOption<ModelProvider>[] = [
   { label: "DeepSeek", value: "deepseek" },
   { label: "MiniMax", value: "minimax" },
+  { label: "NeuralDeep", value: "neuraldeep" },
   { label: "OpenCode Go", value: "opencode-go" },
   { label: "OpenRouter", value: "openrouter" },
 ];

--- a/scripts/provider-installer/contracts.ts
+++ b/scripts/provider-installer/contracts.ts
@@ -6,7 +6,7 @@
  * - Executor input/output contracts separating setup validation from host mutation.
  */
 export type AddressMode = "sslip-io" | "custom-domain";
-export type ModelProvider = "deepseek" | "minimax" | "opencode-go" | "openrouter";
+export type ModelProvider = "deepseek" | "minimax" | "neuraldeep" | "opencode-go" | "openrouter";
 export type ModelProtocol = "anthropic-messages" | "openai-chat-completions";
 export type ReasoningEffort =
   | "max"


### PR DESCRIPTION
## Summary
- add NeuralDeep as a strict OpenAI-compatible provider
- expose the live `qwen3.8-27b` catalog entry with audited tools, vision, context, and output limits
- keep provider-specific reasoning controls disabled and validate text/tool continuation contracts

## Verification
- live `/v1/models`, text, vision, and two-step tool-call smoke against NeuralDeep
- `npm run typecheck`
- `npm test`
- `npm run build`
- `docker compose -f compose.test.yaml up --build --abort-on-container-exit --exit-code-from tests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Что изменено

- Добавлен провайдер `neuraldeep` с OpenAI-совместимым протоколом.
- Настроен endpoint `https://api.neuraldeep.ru/v1`.
- Добавлена модель `qwen3.8-27b` с проверенными лимитами контекста, вывода, vision и tool use.
- Отключены provider-specific reasoning controls.
- Добавлена фильтрация моделей по allowlist и live-каталогу NeuralDeep.
- Обновлены типы, конфигурация установщика и каталог провайдеров.
- Добавлены проверки текстовых запросов, vision, tool continuation и конфигурации транспорта.

## Проверка

- Live smoke-тесты модели, текста, vision и двухшагового tool call.
- Type checking.
- Unit-тесты.
- Сборка.
- Тесты в Docker Compose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->