### PR TITLE
fix: keep Telegram failures out of shared chats

### DIFF
--- a/agent/channels/telegram.ts
+++ b/agent/channels/telegram.ts
@@ -48,6 +48,7 @@ import {
 import { proactiveDeliveryRepository } from "../lib/proactive-deliveries/proactive-delivery-repository.js";
 import { telegramGroupJournalRepository } from "../lib/telegram-group-journal-repository.js";
 import { postTelegramMessageWithoutContinuationChange } from "../lib/telegram-stable-delivery.js";
+import { shouldNotifyTelegramFailure } from "../lib/telegram-failure-notification.js";
 import { AppError } from "../lib/app-error.js";
 import { conversationTimelineRepository } from "../lib/conversation-timeline-repository.js";
 import { setTelegramMessageReaction } from "../lib/telegram-message-reaction.js";
@@ -278,6 +279,8 @@ export default telegramChannel({
           );
         }
       }
+      // Terminal diagnostics are private-only even when the failed turn belonged to a shared chat.
+      notifyFailure = notifyFailure && shouldNotifyTelegramFailure(channel);
       // A final send that started may already be visible; never append a second failure message.
       const finalDeliveryMayBeVisible = notifyFailure &&
         await telegramFinalDeliveryRepository.shouldSuppressFailureMessage(

--- a/agent/lib/telegram-failure-continuation.integration.test.ts
+++ b/agent/lib/telegram-failure-continuation.integration.test.ts
@@ -84,7 +84,7 @@ describe("Eve Telegram failure continuation", () => {
     });
     const channel = {
       continuation: { token: "-1001::166" },
-      state: { chatId: "-1001", messageThreadId: null },
+      state: { chatId: "649624756", chatType: "private", messageThreadId: null },
       telegram: {
         request,
       },
@@ -105,6 +105,28 @@ describe("Eve Telegram failure continuation", () => {
       request.mock.invocationCallOrder[0]!,
     );
     expect(channel.continuation.token).toBe("-1001::166");
+  });
+
+  it("records a group session failure without publishing it to the group", async () => {
+    const recordSessionFailedByContinuationToken = vi.fn().mockResolvedValue("recorded");
+    const request = vi.fn();
+
+    await handleTelegramSessionFailure(
+      { code: "AGENT_SESSION_FAILED", message: "failed", sessionId: "wrun_group" },
+      {
+        continuation: { token: "-1001::166" },
+        state: { chatId: "-1001", chatType: "supergroup", messageThreadId: null },
+        telegram: { request },
+      } as never,
+      { recordSessionFailedByContinuationToken },
+      { failRunByIdentityForNotification: vi.fn() },
+    );
+
+    expect(recordSessionFailedByContinuationToken).toHaveBeenCalledWith(
+      "-1001::166",
+      "wrun_group",
+    );
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("does not notify or rotate when the terminal event belongs to a stale Eve root", async () => {

--- a/agent/lib/telegram-failure-notification.test.ts
+++ b/agent/lib/telegram-failure-notification.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Telegram terminal failure notification privacy tests.
+ *
+ * Constructs covered:
+ * - `shouldNotifyTelegramFailure`: permits private chats and fails closed for every shared target.
+ */
+import { describe, expect, it } from "vitest";
+
+import { shouldNotifyTelegramFailure } from "./telegram-failure-notification.js";
+
+describe("Telegram failure notification privacy", () => {
+  it.each([
+    ["private", true],
+    ["group", false],
+    ["supergroup", false],
+    ["channel", false],
+    [null, false],
+  ] as const)("maps chat type %s to notification=%s", (chatType, expected) => {
+    expect(shouldNotifyTelegramFailure({ state: { chatType } } as never)).toBe(expected);
+  });
+});

--- a/agent/lib/telegram-failure-notification.ts
+++ b/agent/lib/telegram-failure-notification.ts
@@ -1,0 +1,14 @@
+/**
+ * Telegram terminal failure notification privacy policy.
+ *
+ * Exports:
+ * - `shouldNotifyTelegramFailure`: permits failure details only in a verified private chat.
+ */
+import type { TelegramEventContext } from "eve/channels/telegram";
+
+export function shouldNotifyTelegramFailure(
+  channel: Pick<TelegramEventContext, "state">,
+): boolean {
+  // Missing or shared chat metadata fails closed because terminal errors may expose internals.
+  return channel.state.chatType === "private";
+}

--- a/agent/lib/telegram-on-message-group-routing.test.ts
+++ b/agent/lib/telegram-on-message-group-routing.test.ts
@@ -112,7 +112,7 @@ describe("createTelegramMessageHandler group routing", () => {
       telegramMessageId: "88",
       telegramUserId: "telegram-202",
     });
-    expect(sendMessage).toHaveBeenCalledWith(expect.stringContaining("AGENT_APPROVAL_FORBIDDEN"));
+    expect(sendMessage).not.toHaveBeenCalled();
     expect(repository.session.prepareTurn).not.toHaveBeenCalled();
 
     // Existing topics retain the referenced bot message's thread instead of the incoming value.

--- a/agent/lib/telegram-on-message.ts
+++ b/agent/lib/telegram-on-message.ts
@@ -281,7 +281,7 @@ export function createTelegramMessageHandler(repositories: TelegramMessageReposi
         const error = replyAuthorization === "forbidden"
           ? "AGENT_APPROVAL_FORBIDDEN: Подтвердить действие может только пользователь, который его запросил."
           : "AGENT_APPROVAL_EXPIRED: Это подтверждение уже использовано или больше не действует.";
-        await ctx.telegram.sendMessage(error);
+        if (message.chat.type === "private") await ctx.telegram.sendMessage(error);
         return null;
       }
       // DB authorization, not a pre-rotation route snapshot, decides whether this is synthetic HITL.

--- a/agent/lib/telegram-scheduled-target-binding.test.ts
+++ b/agent/lib/telegram-scheduled-target-binding.test.ts
@@ -112,7 +112,7 @@ function mismatchedChannel() {
 
 function matchingChannel() {
   return {
-    state: {},
+    state: { chatType: "supergroup" },
     telegram: {
       chatId: "-100111",
       messageThreadId: 77,
@@ -200,5 +200,26 @@ describe("scheduled Telegram target binding", () => {
       "eve-session-1",
     );
     expect(dependencies.releaseMemoryTurnSources).toHaveBeenCalledWith(context);
+  });
+
+  it("terminalizes a matching group run without publishing a failure message", async () => {
+    const handler = dependencies.channelConfig?.events?.["turn.failed"];
+
+    await handler(
+      { code: "AGENT_MODEL_FAILED" },
+      matchingChannel(),
+      context,
+    );
+
+    expect(dependencies.failRunForNotification).toHaveBeenCalledOnce();
+    expect(dependencies.postStableMessage).not.toHaveBeenCalled();
+    expect(dependencies.recordTurnFailed).toHaveBeenCalledWith(
+      "application-session-1",
+      "eve-session-1",
+    );
+    expect(dependencies.clearApprovals).toHaveBeenCalledWith(
+      "application-session-1",
+      "eve-session-1",
+    );
   });
 });

--- a/agent/lib/telegram-session-failure.ts
+++ b/agent/lib/telegram-session-failure.ts
@@ -3,7 +3,7 @@
  *
  * Export:
  * - `isHookConflictFailure`: identifies Eve's expected competing-root ownership rejection.
- * - `handleTelegramSessionFailure`: ignores ownership conflicts or records and reports a real failure.
+ * - `handleTelegramSessionFailure`: records failures and reports them only to private chats.
  */
 import type { TelegramEventContext } from "eve/channels/telegram";
 
@@ -14,6 +14,7 @@ import type { sessionRepository } from "./sessions/session-repository.js";
 import { scheduledRunIdFromContinuationToken } from "./agent-schedules/scheduled-session.js";
 import type { agentScheduleDispatchRepository } from "./agent-schedules/agent-schedule-dispatch-repository.js";
 import { postTelegramMessageWithoutContinuationChange } from "./telegram-stable-delivery.js";
+import { shouldNotifyTelegramFailure } from "./telegram-failure-notification.js";
 
 interface SessionFailureData {
   code: string;
@@ -74,5 +75,6 @@ export async function handleTelegramSessionFailure(
   ) as SessionEventResult;
   if (result === "stale") return;
   if (!notifyScheduledFailure) return;
+  if (!shouldNotifyTelegramFailure(channel)) return;
   await postTelegramMessageWithoutContinuationChange(channel, formatTelegramSessionFailure(data));
 }


### PR DESCRIPTION
## Summary
- send terminal turn and session failure diagnostics only to private Telegram chats
- suppress text HITL refusal errors in groups while keeping private callback alerts
- preserve session rotation, scheduled-run terminalization, approval cleanup, and failure recording

## Verification
- targeted privacy and Telegram routing tests
- `npm run typecheck`
- `docker compose -f compose.test.yaml up --build --abort-on-container-exit --exit-code-from tests`

Deployment intentionally deferred.