### PR TITLE
release: v0.15.12

### DIFF
--- a/docs/releases/v0.15.12.md
+++ b/docs/releases/v0.15.12.md
@@ -1,0 +1,34 @@
+# Osinara v0.15.12
+
+Patch-релиз добавляет verified Telegram channel senders, закрывает публикацию технических ошибок в
+общих чатах и подключает NeuralDeep как третий прямой model provider.
+
+## Telegram channel senders
+
+- `Channel_Bot` и `sender_chat` классифицируются отдельно от Telegram user identity.
+- Channel sender получает отдельную service identity и не может подтверждать HITL, выполнять
+  owner-only операции или наследовать пользовательские tools и skills.
+- Timeline сохраняет channel attribution, а memory provenance привязана к точному вызывающему actor.
+- Migration `075` добавляет actor-bound source identity и обновляет persisted memory contracts.
+
+## Private failure notifications
+
+- Terminal `turn.failed` и `session.failed` отправляются только в Telegram private chats.
+- Группы, supergroups, channels и неизвестный chat type не получают служебных сообщений об ошибках.
+- Текстовые HITL refusals не публикуются в общих чатах; приватный callback alert сохраняется.
+- Failed state, session rotation, scheduled-run terminalization, logs и HITL cleanup выполняются как
+  прежде.
+
+## NeuralDeep
+
+- Добавлен строгий OpenAI-compatible endpoint `https://api.neuraldeep.ru/v1`.
+- Модель `qwen3.8-27b` проверена на text, vision, tool call и continuation после tool result.
+- Используется нативный reasoning модели без неподтверждённого `reasoning_effort`; вариант
+  `qwen3.8-27b-noreason` не выбирается для основного agent loop.
+- Переключение provider остаётся атомарным: preflight, restart, health verification и rollback
+  используют существующий production model-config controller.
+
+## Проверка
+
+- Production-equivalent Docker Compose gate: 318 test files, 1773 tests, typecheck и `eve build`.
+- Live NeuralDeep smoke: catalog, text, vision и двухшаговый tool-call flow.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.11",
+  "version": "0.15.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.15.11",
+      "version": "0.15.12",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.11",
+  "version": "0.15.12",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Release
- Telegram channel sender isolation and actor-bound memory provenance
- private-only terminal failure notifications
- NeuralDeep `qwen3.8-27b` provider

## Verification
- canonical feature PR #98 CI passed
- production-equivalent Docker gate: 318 files, 1773 tests
- version and release-note contract checked locally