### PR TITLE
Preserve NeuralDeep session cache

### DIFF
--- a/agent/agent.ts
+++ b/agent/agent.ts
@@ -3,13 +3,15 @@
  *
  * Constructs:
  * - Explicit primary model from the multi-provider registry.
+ * - Step-scoped NeuralDeep session routing for upstream KV-cache reuse.
  * - Context compaction; Eve exposes its native fresh-context child only to root sessions.
  */
-import { defineAgent } from "eve";
+import { defineAgent, defineDynamic } from "eve";
 
 import { AGENT_COMPACTION_THRESHOLD } from "./config.js";
 import { primaryModel } from "./lib/model-registry.js";
 import { modelProviderConfig } from "./lib/model-provider-config.js";
+import { resolveSessionModelSelection } from "./lib/neuraldeep-session-routing.js";
 
 const primaryModelContextWindowTokens =
   modelProviderConfig.agent.models.primary.contextWindowTokens;
@@ -19,6 +21,15 @@ export default defineAgent({
     modelContextWindowTokens: primaryModelContextWindowTokens,
     thresholdPercent: AGENT_COMPACTION_THRESHOLD,
   },
-  model: primaryModel,
+  model: defineDynamic({
+    fallback: primaryModel,
+    events: {
+      "step.started": (_event, ctx) => resolveSessionModelSelection({
+        model: primaryModel,
+        providerId: modelProviderConfig.provider,
+        sessionId: ctx.session.id,
+      }),
+    },
+  }),
   modelContextWindowTokens: primaryModelContextWindowTokens,
 });

--- a/agent/lib/neuraldeep-model-transport.test.ts
+++ b/agent/lib/neuraldeep-model-transport.test.ts
@@ -3,7 +3,7 @@
  *
  * Constructs covered:
  * - `createConfiguredLanguageModel`: targets NeuralDeep's exact chat-completions endpoint.
- * - NeuralDeep receives Bearer authentication and the audited Qwen request output limit.
+ * - NeuralDeep receives Bearer authentication, session-sticky routing, and the audited output limit.
  * - Undocumented provider-specific reasoning controls are omitted from request payloads.
  */
 import type { LanguageModelV4CallOptions } from "@ai-sdk/provider";
@@ -40,6 +40,7 @@ describe("NeuralDeep model transport", () => {
 
     await model.doGenerate({
       prompt: [{ content: [{ text: "Проверка", type: "text" }], role: "user" }],
+      providerOptions: { neuraldeep: { user: "session_01CACHE" } },
     } as LanguageModelV4CallOptions);
 
     expect(fetch).toHaveBeenCalledWith(
@@ -49,7 +50,11 @@ describe("NeuralDeep model transport", () => {
         method: "POST",
       }),
     );
-    expect(body).toMatchObject({ max_tokens: 16_384, model: "qwen3.8-27b" });
+    expect(body).toMatchObject({
+      max_tokens: 16_384,
+      model: "qwen3.8-27b",
+      user: "session_01CACHE",
+    });
     expect(body).not.toHaveProperty("reasoning_effort");
     expect(body).not.toHaveProperty("thinking");
   });

--- a/agent/lib/neuraldeep-session-routing.test.ts
+++ b/agent/lib/neuraldeep-session-routing.test.ts
@@ -1,0 +1,38 @@
+/**
+ * NeuralDeep session-sticky model routing tests.
+ *
+ * Constructs covered:
+ * - `resolveSessionModelSelection`: adds the Eve session identity only to NeuralDeep requests.
+ * - Non-NeuralDeep providers retain their static model selection without provider options.
+ */
+import type { LanguageModel } from "ai";
+import { describe, expect, it } from "vitest";
+
+import { resolveSessionModelSelection } from "./neuraldeep-session-routing.js";
+
+const model = { modelId: "test-model", provider: "test-provider" } as LanguageModel;
+
+describe("resolveSessionModelSelection", () => {
+  it("uses the opaque Eve session ID for NeuralDeep sticky routing", () => {
+    expect(resolveSessionModelSelection({
+      model,
+      providerId: "neuraldeep",
+      sessionId: "session_01CACHE",
+    })).toEqual({
+      model,
+      modelOptions: {
+        providerOptions: {
+          neuraldeep: { user: "session_01CACHE" },
+        },
+      },
+    });
+  });
+
+  it("does not add NeuralDeep provider options to another provider", () => {
+    expect(resolveSessionModelSelection({
+      model,
+      providerId: "deepseek",
+      sessionId: "session_01CACHE",
+    })).toBeNull();
+  });
+});

--- a/agent/lib/neuraldeep-session-routing.ts
+++ b/agent/lib/neuraldeep-session-routing.ts
@@ -1,0 +1,39 @@
+/**
+ * NeuralDeep session-sticky model routing.
+ *
+ * Exports:
+ * - `resolveSessionModelSelection`: binds NeuralDeep requests to one upstream by Eve session ID.
+ */
+import type { AgentModelOptionsDefinition } from "eve";
+import type { LanguageModel } from "ai";
+
+import type { ModelProviderId } from "./model-provider-config.js";
+
+interface SessionModelSelectionInput {
+  readonly model: LanguageModel;
+  readonly providerId: ModelProviderId;
+  readonly sessionId: string;
+}
+
+interface SessionModelSelection {
+  readonly model: LanguageModel;
+  readonly modelOptions: AgentModelOptionsDefinition;
+}
+
+export function resolveSessionModelSelection({
+  model,
+  providerId,
+  sessionId,
+}: SessionModelSelectionInput): SessionModelSelection | null {
+  // NeuralDeep uses this OpenAI-compatible field for sticky upstream routing and KV-cache reuse.
+  if (providerId !== "neuraldeep") return null;
+
+  return {
+    model,
+    modelOptions: {
+      providerOptions: {
+        neuraldeep: { user: sessionId },
+      },
+    },
+  };
+}

--- a/scripts/validate-eve-tool-surface-build.test.ts
+++ b/scripts/validate-eve-tool-surface-build.test.ts
@@ -3,6 +3,7 @@
  *
  * Constructs covered:
  * - Exact step-scoped capabilities region is accepted.
+ * - Bundler-generated aliases for `defineDynamic` preserve the same resolver contract.
  * - Missing, unterminated, and replay-prone resolver regions fail with a stable error code.
  */
 import { describe, expect, it } from "vitest";
@@ -22,6 +23,12 @@ function compiled(event: "session.started" | "step.started" | "turn.started"): s
 describe("compiled Eve dynamic tool surface", () => {
   it("accepts the step-scoped resolver", () => {
     expect(() => validateCompiledDynamicToolSurface(compiled("step.started"))).not.toThrow();
+  });
+
+  it("accepts a bundler-generated defineDynamic alias", () => {
+    const aliasedResolver = compiled("step.started").replace("defineDynamic(", "defineDynamic$1(");
+
+    expect(() => validateCompiledDynamicToolSurface(aliasedResolver)).not.toThrow();
   });
 
   it.each(["session.started", "turn.started"] as const)(

--- a/scripts/validate-eve-tool-surface-build.ts
+++ b/scripts/validate-eve-tool-surface-build.ts
@@ -12,7 +12,7 @@ import { fileURLToPath } from "node:url";
 
 const CAPABILITIES_REGION = "#region agent/tools/capabilities.ts";
 const REGION_END = "//#endregion";
-const DYNAMIC_EVENTS_PATTERN = /defineDynamic\s*\(\s*\{\s*events\s*:\s*\{\s*"([^"]+)"\s*:/gu;
+const DYNAMIC_EVENTS_PATTERN = /defineDynamic(?:\$\d+)?\s*\(\s*\{\s*events\s*:\s*\{\s*"([^"]+)"\s*:/gu;
 const REPLAY_PRONE_EVENT_KEY_PATTERN = /"(?:session|turn)\.started"\s*:/u;
 
 function buildContractError(reason: string): Error {


### PR DESCRIPTION
## Summary
- bind NeuralDeep chat-completion requests to the opaque Eve session ID through the documented `user` field
- keep all non-NeuralDeep providers on the unchanged static fallback
- accept bundler-generated `defineDynamic` aliases in the Eve tool-surface release validator

## Verification
- `npm run typecheck`
- `npm run build`
- `npm test` (1502 passed, 276 integration tests skipped without a database)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Сохранено кэширование сессий NeuralDeep. Chat-completion запросы передают opaque Eve session ID через поле `user`.
- Для остальных провайдеров сохранён статический fallback.
- В агенте добавлена динамическая конфигурация модели через `defineDynamic` и `resolveSessionModelSelection`.
- Валидатор Eve tool surface теперь принимает bundler-алиасы `defineDynamic$<число>`.
- Добавлены тесты маршрутизации сессий NeuralDeep и передачи `session ID` в запрос.

## Проверка

- `npm run typecheck`
- `npm run build`
- `npm test`
- Пройдено 1 502 теста.
- 276 интеграционных тестов пропущены без базы данных.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->