### PR TITLE
Release v0.15.13

### DIFF
--- a/docs/releases/v0.15.13.md
+++ b/docs/releases/v0.15.13.md
@@ -1,0 +1,29 @@
+# Osinara v0.15.13
+
+Patch-релиз включает документированную session-sticky маршрутизацию NeuralDeep для повторного
+использования upstream KV-cache в многошаговых и многораундовых диалогах.
+
+## NeuralDeep session cache
+
+- Каждый model step NeuralDeep передаёт непрозрачный Eve session ID в OpenAI-compatible поле
+  `user`, которое NeuralDeep использует для закрепления сессии за одним upstream.
+- Все шаги одного turn и последующие turns текущей Eve-сессии используют одинаковый routing key;
+  штатная session rotation автоматически создаёт новый ключ.
+- Telegram user ID, chat ID, family ID и другие прикладные идентификаторы провайдеру в этом поле не
+  передаются.
+- Для DeepSeek, MiniMax, OpenCode Go и OpenRouter provider options не изменились.
+- Sticky routing повышает вероятность повторного использования KV-cache, но не превращает его в
+  durable cache: NeuralDeep не публикует TTL и не гарантирует cache hit.
+
+## Eve build contract
+
+- Основной direct model выбирается через Eve `step.started`, поскольку только step-scoped resolver
+  может безопасно вернуть live AI SDK model вместе с session-specific provider options.
+- Post-build validator принимает числовые bundler-алиасы `defineDynamic`, сохраняя строгую проверку
+  единственного `step.started` tool resolver и запрет replay-prone scopes.
+
+## Проверка
+
+- Production-equivalent Docker Compose gate: 320 test files, 1778 tests, typecheck и `eve build`.
+- Transport contract подтверждает, что `providerOptions.neuraldeep.user` отправляется корневым полем
+  `user` в JSON запроса `/v1/chat/completions`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.12",
+  "version": "0.15.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.15.12",
+      "version": "0.15.13",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.15.12",
+  "version": "0.15.13",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Release
- publish NeuralDeep session-sticky routing through the documented `user` field
- preserve provider isolation and automatic key rotation with Eve sessions
- include immutable release notes and bump package metadata to `0.15.13`

## Verification
- feature PR #100 passed the production-equivalent Docker Compose suite
- package and lockfile versions both resolve to `0.15.13`
- `git diff --check`