### PR TITLE
Fix v0.16.0 bridge production source contract

### DIFF
--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -137,7 +137,8 @@ OAuth remains inside `osinara-production-cli-proxy-auth` and is writable only by
 so refreshed access and refresh tokens survive container replacement.
 
 The one-time v0.16.0 bridge accepts only exact v0.15.14 source state. Before migration it validates
-the root-owned OAuth seed, the exact hashed DeepSeek config, the existing credential relationship, and
+the root-owned OAuth seed, the exact production NeuralDeep `qwen3.8-27b` config hash, the required
+model/proxy assignments and retained DeepSeek rollback credential, and
 the attested Codex config. Backup preflight creates the candidate-only auth volume; after writers are
 stopped and durable state is archived, the controller crosses `MIGRATION_STARTED`, seeds the empty
 volume, atomically installs the new model config, and replaces only `MODEL_API_KEY` with the existing

--- a/docs/releases/v0.16.0.md
+++ b/docs/releases/v0.16.0.md
@@ -1,6 +1,6 @@
 # Osinara v0.16.0
 
-Релиз переводит production agent с прямого DeepSeek transport на подписочный OpenAI Codex через
+Релиз переводит production agent с текущего NeuralDeep `qwen3.8-27b` transport на подписочный OpenAI Codex через
 изолированный CLIProxyAPI, исправляет доставку scheduled Telegram turns и обновляет production
 controller для безопасной миграции OAuth-состояния.
 
@@ -28,8 +28,9 @@ controller для безопасной миграции OAuth-состояния
 ## Production Cutover
 
 - Добавлен одноразовый bridge только для перехода с точной `v0.15.14` на `v0.16.0`.
-- Controller проверяет attested Codex model config, root-owned OAuth seed, исходный DeepSeek config и
-  непротиворечивость текущих секретов до изменения runtime state.
+- Controller проверяет attested Codex model config, root-owned OAuth seed, точный hash текущего
+  NeuralDeep config, обязательные model/proxy assignments и сохранённый DeepSeek rollback credential
+  до изменения runtime state.
 - OAuth volume создаётся backup preflight как candidate-only и удаляется при безопасном
   pre-migration failure.
 - Root-controller `--initial 0.16.0` создаёт отсутствующий OAuth volume отдельно, фиксирует его root

--- a/production-codex-bridge.test.ts
+++ b/production-codex-bridge.test.ts
@@ -7,6 +7,7 @@
  * - Provisioning starts only after current data is backed up and the migration boundary is crossed.
  * - Promotion requires one real medium-reasoning Luna completion through the candidate gateway.
  */
+import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -16,6 +17,35 @@ import { afterEach, describe, expect, it } from "vitest";
 
 const projectRoot = new URL("./", import.meta.url).pathname;
 const temporaryDirectories: string[] = [];
+const productionSourceConfig = Buffer.from(`{
+  "agent": {
+    "models": {
+      "primary": {
+        "contextWindowTokens": 262144,
+        "id": "qwen3.8-27b",
+        "maxOutputTokens": 16384
+      },
+      "vision": {
+        "id": "qwen3.8-27b",
+        "maxOutputTokens": 16384,
+        "supportsImageInput": true
+      }
+    },
+    "transport": {
+      "baseUrl": "https://api.neuraldeep.ru/v1",
+      "protocol": "openai-chat-completions",
+      "providerName": "neuraldeep",
+      "reasoning": null
+    }
+  },
+  "provider": "neuraldeep",
+  "schemaVersion": 4,
+  "voice": {
+    "enabled": true,
+    "transcriptionModelId": "whisper-large-v3-turbo"
+  }
+}
+`);
 
 function runBridge(directory: string, sourceVersion = "0.15.14", initialMode = false) {
   const current = join(directory, "current");
@@ -28,7 +58,9 @@ function runBridge(directory: string, sourceVersion = "0.15.14", initialMode = f
   writeFileSync(join(current, "osinara-deployment.json"), JSON.stringify({ version: sourceVersion }));
   writeFileSync(
     join(directory, "agent-model-providers.json"),
-    readFileSync(join(projectRoot, "config/agent-model-providers.json")),
+    initialMode
+      ? readFileSync(join(projectRoot, "config/agent-model-providers.json"))
+      : productionSourceConfig,
   );
   writeFileSync(
     join(work, "codex-subscription-model-providers.json"),
@@ -87,7 +119,7 @@ describe("v0.16.0 Codex subscription bridge", () => {
     temporaryDirectories.push(directory);
     writeFileSync(
       join(directory, ".env"),
-      "DEEPSEEK_API_KEY='legacy-key'\nMODEL_API_KEY='legacy-key'\nCLI_PROXY_API_KEY='internal-key'\n",
+      "DEEPSEEK_API_KEY='rollback-key'\nMODEL_API_KEY='active-neuraldeep-key'\nCLI_PROXY_API_KEY='internal-key'\n",
     );
     writeFileSync(join(directory, "codex-auth.json"), JSON.stringify({
       access_token: "access-token",
@@ -107,7 +139,7 @@ describe("v0.16.0 Codex subscription bridge", () => {
       '"type":"codex"',
     );
     expect(readFileSync(join(directory, ".env"), "utf8")).toBe(
-      "DEEPSEEK_API_KEY='legacy-key'\nMODEL_API_KEY='internal-key'\nCLI_PROXY_API_KEY='internal-key'\n",
+      "DEEPSEEK_API_KEY='rollback-key'\nMODEL_API_KEY='internal-key'\nCLI_PROXY_API_KEY='internal-key'\n",
     );
   });
 
@@ -116,7 +148,7 @@ describe("v0.16.0 Codex subscription bridge", () => {
     temporaryDirectories.push(directory);
     writeFileSync(
       join(directory, ".env"),
-      "DEEPSEEK_API_KEY=legacy-key\nMODEL_API_KEY=legacy-key\nCLI_PROXY_API_KEY=internal-key\n",
+      "DEEPSEEK_API_KEY=rollback-key\nMODEL_API_KEY=active-neuraldeep-key\nCLI_PROXY_API_KEY=internal-key\n",
     );
     writeFileSync(join(directory, "codex-auth.json"), JSON.stringify({ type: "codex" }), {
       mode: 0o600,
@@ -127,7 +159,7 @@ describe("v0.16.0 Codex subscription bridge", () => {
     expect(result.status).toBe(1);
     expect(result.stderr).toContain("DEPLOY_V0160_CODEX_AUTH_INVALID");
     expect(readFileSync(join(directory, "agent-model-providers.json"))).toEqual(
-      readFileSync(join(projectRoot, "config/agent-model-providers.json")),
+      productionSourceConfig,
     );
   });
 
@@ -169,7 +201,7 @@ describe("v0.16.0 Codex subscription bridge", () => {
     temporaryDirectories.push(directory);
     writeFileSync(
       join(directory, ".env"),
-      "DEEPSEEK_API_KEY=legacy-key\nMODEL_API_KEY=legacy-key\nCLI_PROXY_API_KEY=internal-key\n",
+      "DEEPSEEK_API_KEY=rollback-key\nMODEL_API_KEY=active-neuraldeep-key\nCLI_PROXY_API_KEY=internal-key\n",
     );
     writeFileSync(join(directory, "codex-auth.json"), JSON.stringify({
       access_token: "access-token",
@@ -213,5 +245,11 @@ describe("v0.16.0 Codex subscription bridge", () => {
 
     expect(bridge).toContain("chown 10001:10001 /auth");
     expect(bridge).toContain("chmod 0700 /auth");
+  });
+
+  it("pins the exact current production NeuralDeep source bytes", () => {
+    expect(createHash("sha256").update(productionSourceConfig).digest("hex")).toBe(
+      "3ebc69be3aec08cae7a08ce4024b6b8d8a00a797819a787aed391b8ee30937dd",
+    );
   });
 });

--- a/scripts/production-deploy/bridge.sh
+++ b/scripts/production-deploy/bridge.sh
@@ -7,7 +7,8 @@ readonly V0152_BRIDGE_TARGET_VERSION="0.15.2"
 readonly V0152_MODEL_CONFIG_SHA256="4125a909ad3a2cfab08df5158538d210e2bcb753b3faa3a79f7be8a81bcf55c8"
 readonly V0160_BRIDGE_SOURCE_VERSION="0.15.14"
 readonly V0160_BRIDGE_TARGET_VERSION="0.16.0"
-readonly V0160_SOURCE_MODEL_CONFIG_SHA256="4125a909ad3a2cfab08df5158538d210e2bcb753b3faa3a79f7be8a81bcf55c8"
+readonly V0160_UPDATE_SOURCE_MODEL_CONFIG_SHA256="3ebc69be3aec08cae7a08ce4024b6b8d8a00a797819a787aed391b8ee30937dd"
+readonly V0160_INITIAL_SOURCE_MODEL_CONFIG_SHA256="4125a909ad3a2cfab08df5158538d210e2bcb753b3faa3a79f7be8a81bcf55c8"
 readonly V0160_CODEX_MODEL_CONFIG_SHA256="68b349485a474c4426adb7f98b541d812fb6edaa7617010a0e8e942d94fa16b7"
 readonly V0160_CODEX_MODEL_CONFIG_ASSET="codex-subscription-model-providers.json"
 readonly CODEX_AUTH_SEED="${BASE_DIR}/codex-auth.json"
@@ -159,9 +160,6 @@ validate_v0160_environment() {
       fail "DEPLOY_V0160_MODEL_KEY_INVALID" \
         "Production update must contain one DeepSeek rollback credential"
     validate_bridge_credential_assignment "$V0160_LEGACY_VALUE"
-    [[ "$V0160_MODEL_VALUE" == "$V0160_LEGACY_VALUE" ]] ||
-      fail "DEPLOY_V0160_MODEL_KEY_CONFLICT" \
-        "Current MODEL_API_KEY does not match the approved v0.15.14 DeepSeek credential"
   fi
 }
 
@@ -176,11 +174,13 @@ validate_v0160_codex_inputs() {
     fail "DEPLOY_V0160_MODEL_CONFIG_HASH_MISMATCH" \
       "Canonical Codex model config does not match the reviewed bytes"
 
-  # The predecessor must still run the exact reviewed DeepSeek bytes before migration starts.
-  printf '%s  %s\n' "$V0160_SOURCE_MODEL_CONFIG_SHA256" "$AGENT_MODEL_PROVIDER_CONFIG" |
+  local source_config_sha256="$V0160_UPDATE_SOURCE_MODEL_CONFIG_SHA256"
+  [[ "$INITIAL_MODE" -eq 0 ]] || source_config_sha256="$V0160_INITIAL_SOURCE_MODEL_CONFIG_SHA256"
+  # Existing production uses reviewed NeuralDeep bytes; explicit initial mode starts from the release default.
+  printf '%s  %s\n' "$source_config_sha256" "$AGENT_MODEL_PROVIDER_CONFIG" |
     sha256sum --check --status - ||
     fail "DEPLOY_V0160_SOURCE_CONFIG_INVALID" \
-      "Current model config is not the expected v0.15.14 DeepSeek route"
+      "Current model config does not match the expected v0.16.0 bridge source"
   jq -e '
     type == "object" and
     keys == ["access_token", "account_id", "expired", "refresh_token", "type"] and


### PR DESCRIPTION
## Summary
- bind the v0.16.0 update bridge to the exact deployed NeuralDeep qwen3.8-27b config hash
- preserve the separate direct-provider source hash used by explicit initial deployment
- validate current MODEL_API_KEY independently from the retained DeepSeek rollback credential
- add exact-byte regression coverage for the deployed production source

## Context
Production preflight found the active v0.15.14 host config was changed through the provider controller after release. The first v0.16.0 workflow was cancelled before tag or release creation.

## Verification
- npm run typecheck
- npm test: 246 passed, 82 skipped; 1602 tests passed, 277 skipped
- targeted production bridge and release contract tests
- bash syntax and git diff checks
- server source config SHA-256: 3ebc69be3aec08cae7a08ce4024b6b8d8a00a797819a787aed391b8ee30937dd