### PR TITLE
Hotfix v0.16.1: load production controller modules

### DIFF
--- a/docs/releases/v0.16.1.md
+++ b/docs/releases/v0.16.1.md
@@ -1,0 +1,21 @@
+# Osinara v0.16.1
+
+Patch-релиз исправляет загрузку root-owned production controller перед миграцией на Codex.
+Application runtime, модель `gpt-5.6-luna`, OAuth volume и Compose graph не меняются относительно
+`v0.16.0`.
+
+## Production Controller
+
+- Release downloader и one-time bridge больше не объявляют один readonly asset constant под
+  одинаковым именем при последовательном `source` модулей.
+- Добавлен regression test, который загружает `common`, `database`, `release`, `bridge` и `backup`
+  в точном production-порядке и отклоняет любые глобальные collisions.
+- Ошибка `v0.16.0` происходила до claim approved proposal, остановки сервисов, миграции и изменения
+  данных. Текущая production версия оставалась healthy, а предложение сохранило статус `approved`.
+
+## Проверка
+
+- `bash -n` для entrypoint и всех deployment modules.
+- Runtime source-order test для полного controller module set.
+- Полный Vitest suite: 246 файлов passed, 82 skipped; 1603 теста passed, 277 skipped.
+- TypeScript typecheck.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "type": "module",
   "imports": {

--- a/production-release-contract.test.ts
+++ b/production-release-contract.test.ts
@@ -9,6 +9,7 @@
  * - Root-owned systemd polling units and required production environment documentation.
  * - The exact production jq security predicate accepts only the intended resolved Compose surface.
  */
+import { execFileSync } from "node:child_process";
 import { X509Certificate } from "node:crypto";
 import { readdirSync, readFileSync } from "node:fs";
 
@@ -321,6 +322,17 @@ describe("release workflow contract", () => {
 });
 
 describe("server deployment contract", () => {
+  it("loads every controller module in production order without global collisions", () => {
+    expect(() => execFileSync("bash", ["-c", [
+      "set -euo pipefail",
+      "source scripts/production-deploy/common.sh",
+      "source scripts/production-deploy/database.sh",
+      "source scripts/production-deploy/release.sh",
+      "source scripts/production-deploy/bridge.sh",
+      "source scripts/production-deploy/backup.sh",
+    ].join("; ")], { cwd: projectRoot })).not.toThrow();
+  });
+
   it("is locked, source-independent, digest-strict, and backup-first", () => {
     const { combined: script, files } = readDeployScripts();
 

--- a/scripts/production-deploy/bridge.sh
+++ b/scripts/production-deploy/bridge.sh
@@ -10,7 +10,7 @@ readonly V0160_BRIDGE_TARGET_VERSION="0.16.0"
 readonly V0160_UPDATE_SOURCE_MODEL_CONFIG_SHA256="3ebc69be3aec08cae7a08ce4024b6b8d8a00a797819a787aed391b8ee30937dd"
 readonly V0160_INITIAL_SOURCE_MODEL_CONFIG_SHA256="4125a909ad3a2cfab08df5158538d210e2bcb753b3faa3a79f7be8a81bcf55c8"
 readonly V0160_CODEX_MODEL_CONFIG_SHA256="68b349485a474c4426adb7f98b541d812fb6edaa7617010a0e8e942d94fa16b7"
-readonly V0160_CODEX_MODEL_CONFIG_ASSET="codex-subscription-model-providers.json"
+readonly V0160_BRIDGE_CODEX_MODEL_CONFIG_ASSET="codex-subscription-model-providers.json"
 readonly CODEX_AUTH_SEED="${BASE_DIR}/codex-auth.json"
 readonly CODEX_AUTH_VOLUME="osinara-production-cli-proxy-auth"
 
@@ -164,7 +164,7 @@ validate_v0160_environment() {
 }
 
 validate_v0160_codex_inputs() {
-  local released_config="${WORK_DIR}/${V0160_CODEX_MODEL_CONFIG_ASSET}"
+  local released_config="${WORK_DIR}/${V0160_BRIDGE_CODEX_MODEL_CONFIG_ASSET}"
   require_metadata "$CODEX_AUTH_SEED" "0:0:600"
   require_metadata "$AGENT_MODEL_PROVIDER_CONFIG" "0:0:644"
   [[ -f "$released_config" && ! -L "$released_config" ]] ||
@@ -196,7 +196,7 @@ validate_v0160_codex_inputs() {
 }
 
 install_v0160_environment_and_config() {
-  local released_config="${WORK_DIR}/${V0160_CODEX_MODEL_CONFIG_ASSET}"
+  local released_config="${WORK_DIR}/${V0160_BRIDGE_CODEX_MODEL_CONFIG_ASSET}"
   local environment_temp config_temp line
   environment_temp="$(mktemp "${WORK_DIR}/server-env.XXXXXX")"
   config_temp="$(mktemp "${WORK_DIR}/agent-model-providers.XXXXXX")"


### PR DESCRIPTION
## Summary
- remove the readonly constant collision between release.sh and bridge.sh
- add a regression test that sources every controller module in exact production order
- publish v0.16.1 because v0.16.0 is already immutable

## Production impact
The installed controller failed while sourcing modules, before proposal claim, service stop, migration, or state changes. v0.15.14 remains healthy and the v0.16.0 proposal remains approved. After this canonical hotfix is installed, that approved v0.16.0 cutover can continue safely.

## Verification
- npm run typecheck
- npm test: 246 passed, 82 skipped; 1603 tests passed, 277 skipped
- bash -n for all controller modules
- production-order module source regression test