### PR TITLE
Hotfix v0.16.2: sync candidate model environment

### DIFF
--- a/docs/releases/v0.16.2.md
+++ b/docs/releases/v0.16.2.md
@@ -1,0 +1,29 @@
+# Osinara v0.16.2
+
+Patch-релиз синхронизирует изменённый model bearer key между root deployment process и candidate
+Docker Compose после one-time Codex bridge.
+
+## Model Environment
+
+- После атомарной замены `MODEL_API_KEY` в `/opt/osinara/.env` bridge также обновляет exported
+  `MODEL_API_KEY` текущего systemd process.
+- Quoted dotenv token безопасно преобразуется в runtime value без `eval`; неподдерживаемый синтаксис
+  по-прежнему отклоняется до миграции.
+- Это закрывает приоритет shell environment над `docker compose --env-file`: candidate agent больше
+  не получает прежний NeuralDeep key при первом запуске после Codex cutover.
+- Добавлены regression tests для update и explicit initial deployment с заранее экспортированным
+  устаревшим model key.
+
+## Production Recovery
+
+- `v0.16.0` успешно прошёл backup, migration, CLIProxy upstream smoke и promotion.
+- Первый agent container получил старый process-level key и вернул `MODEL_CALL_FAILED`; данные и
+  OAuth не пострадали.
+- Agent был пересоздан из promoted release с чистым env-file. Internal `/v1/models` и реальный
+  `gpt-5.6-luna` completion после восстановления вернули `200`.
+
+## Проверка
+
+- Production bridge tests для quoted/unquoted dotenv и process environment precedence.
+- Полный controller source-order test и `bash -n`.
+- TypeScript typecheck и полный Vitest suite.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "imports": {

--- a/production-codex-bridge.test.ts
+++ b/production-codex-bridge.test.ts
@@ -100,10 +100,13 @@ function runBridge(directory: string, sourceVersion = "0.15.14", initialMode = f
     APP_IMAGE=test-app-image
     CREATED_CANDIDATE_VOLUMES=()
     INITIAL_MODE=${initialMode ? 1 : 0}
+    PROCESS_MODEL_KEY_PATH=${JSON.stringify(join(directory, "process-model-key"))}
     REQUESTED_VERSION=0.16.0
+    export MODEL_API_KEY=stale-process-model-key
     source scripts/production-deploy/bridge.sh
     prepare_v0160_codex_volume
     provision_v0160_codex_bridge
+    printf %s "$MODEL_API_KEY" > "$PROCESS_MODEL_KEY_PATH"
   `], { cwd: projectRoot, encoding: "utf8" });
 }
 
@@ -141,6 +144,7 @@ describe("v0.16.0 Codex subscription bridge", () => {
     expect(readFileSync(join(directory, ".env"), "utf8")).toBe(
       "DEEPSEEK_API_KEY='rollback-key'\nMODEL_API_KEY='internal-key'\nCLI_PROXY_API_KEY='internal-key'\n",
     );
+    expect(readFileSync(join(directory, "process-model-key"), "utf8")).toBe("internal-key");
   });
 
   it("rejects malformed OAuth before changing model configuration", () => {
@@ -238,6 +242,7 @@ describe("v0.16.0 Codex subscription bridge", () => {
     expect(readFileSync(join(directory, ".env"), "utf8")).toBe(
       "MODEL_API_KEY='internal-key'\nCLI_PROXY_API_KEY='internal-key'\n",
     );
+    expect(readFileSync(join(directory, "process-model-key"), "utf8")).toBe("internal-key");
   });
 
   it("sets secure ownership and mode on the named volume root", () => {

--- a/scripts/production-deploy/bridge.sh
+++ b/scripts/production-deploy/bridge.sh
@@ -195,6 +195,15 @@ validate_v0160_codex_inputs() {
       "Staged Codex OAuth credential is malformed; stage a fresh OpenCode token set"
 }
 
+dotenv_credential_runtime_value() {
+  local value="$1"
+  if [[ "$value" == \'*\' ]]; then
+    value="${value#\'}"
+    value="${value%\'}"
+  fi
+  printf '%s' "$value"
+}
+
 install_v0160_environment_and_config() {
   local released_config="${WORK_DIR}/${V0160_BRIDGE_CODEX_MODEL_CONFIG_ASSET}"
   local environment_temp config_temp line
@@ -213,6 +222,9 @@ install_v0160_environment_and_config() {
   install -o root -g root -m 0644 "$released_config" "$config_temp"
   mv -f "$environment_temp" "$SERVER_ENV"
   mv -f "$config_temp" "$AGENT_MODEL_PROVIDER_CONFIG"
+  # Shell environment outranks `--env-file`; update it before candidate Compose interpolation.
+  MODEL_API_KEY="$(dotenv_credential_runtime_value "$V0160_PROXY_VALUE")"
+  export MODEL_API_KEY
   require_metadata "$SERVER_ENV" "0:0:600"
   require_metadata "$AGENT_MODEL_PROVIDER_CONFIG" "0:0:644"
 }


### PR DESCRIPTION
## Summary
- export the new internal MODEL_API_KEY after the one-time bridge updates the root env file
- safely unwrap the already-validated single-quoted dotenv form without eval
- cover update and initial cutovers where systemd inherited a stale model key

## Production impact
v0.16.0 promotion succeeded, including backup and real CLIProxy upstream smoke. The first agent container inherited the old process-level NeuralDeep key because shell environment outranks --env-file and returned MODEL_CALL_FAILED. The agent was recreated from the promoted release with clean env-file resolution; internal catalog and real Luna completion now return 200.

## Verification
- npm run typecheck
- npm test: 246 passed, 82 skipped; 1603 tests passed, 277 skipped
- production bridge process-environment regressions
- controller source-order test and bash syntax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Обновлена версия пакета с `0.16.1` до `0.16.2`.
- Bridge теперь безопасно извлекает значение `MODEL_API_KEY` из одинарных кавычек без `eval`.
- Bridge экспортирует внутренний ключ после обновления environment-файла.
- Добавлены проверки для обычного и initial-развертывания.
- Проверен сценарий со stale `MODEL_API_KEY` в окружении systemd.
- Это устраняет ошибку `MODEL_CALL_FAILED` при запуске agent container.

## Проверка

- Выполнены type checking и автоматические тесты.
- Проверены регрессии process environment production bridge.
- Проверен порядок операций в controller.
- Выполнена проверка синтаксиса Bash.
- Internal catalog и реальные Luna completion requests вернули HTTP 200.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->