### PR TITLE
hotfix: bound Eve replay session growth

### DIFF
--- a/agent/config.ts
+++ b/agent/config.ts
@@ -18,7 +18,9 @@ export const GOOGLE_WORKSPACE_COMMAND_TIMEOUT_MS = 60_000;
 export const SANDBOX_RUNNER_BASE_URL = "http://sandbox-runner:8080";
 export const SESSION_INACTIVITY_DAYS = 30;
 export const SESSION_GROUP_ROTATION_LOCK_HASH_SEED = 3;
-export const SESSION_MAX_COMPLETED_TURNS = 250;
+// The local Workflow world replays cumulative filesystem artifacts. Rotate with enough headroom
+// below the observed Eve 240-second replay failure at 118 completed production turns.
+export const SESSION_MAX_COMPLETED_TURNS = 50;
 export const SESSION_RETENTION_LEASE_MS = 15 * 60 * 1_000;
 export const SESSION_RETENTION_DAYS = 1;
 export const SESSION_TASK_ABANDONED_DAYS = 7;

--- a/agent/lib/sessions/session-policy.test.ts
+++ b/agent/lib/sessions/session-policy.test.ts
@@ -3,7 +3,7 @@
  *
  * Constructs covered:
  * - `continuationTokenForGeneration`: generation-zero compatibility and isolated successors.
- * - `sessionNeedsRotation`: inactivity, turn-limit, manual, and pending-operation rules.
+ * - `sessionNeedsRotation`: inactivity, replay-safe turn-limit, manual, and pending-operation rules.
  */
 import { describe, expect, it } from "vitest";
 
@@ -20,7 +20,7 @@ describe("session rotation policy", () => {
     expect(continuationTokenForGeneration("101::", 1)).toBe("101:::osinara:1");
   });
 
-  it("rotates after inactivity or the completed-turn limit", () => {
+  it("rotates after inactivity or before the Eve workflow journal becomes replay-unsafe", () => {
     expect(sessionNeedsRotation({
       completedTurns: 1,
       lastActivityAt: new Date("2026-06-12T11:59:59.999Z"),
@@ -29,7 +29,14 @@ describe("session rotation policy", () => {
       rotationRequestedAt: null,
     })).toBe(true);
     expect(sessionNeedsRotation({
-      completedTurns: 250,
+      completedTurns: 49,
+      lastActivityAt: NOW,
+      now: NOW,
+      pendingOperation: false,
+      rotationRequestedAt: null,
+    })).toBe(false);
+    expect(sessionNeedsRotation({
+      completedTurns: 50,
       lastActivityAt: NOW,
       now: NOW,
       pendingOperation: false,
@@ -39,7 +46,7 @@ describe("session rotation policy", () => {
 
   it("defers every rotation reason while a HITL or OAuth operation is pending", () => {
     expect(sessionNeedsRotation({
-      completedTurns: 250,
+      completedTurns: 50,
       lastActivityAt: new Date("2026-01-01T00:00:00.000Z"),
       now: NOW,
       pendingOperation: true,

--- a/docs/releases/v0.16.3.md
+++ b/docs/releases/v0.16.3.md
@@ -1,0 +1,26 @@
+# Osinara v0.16.3
+
+Patch-релиз ограничивает размер durable Eve-сессий до того, как filesystem workflow journal
+перестаёт укладываться в жёсткий replay deadline.
+
+## Session Rotation
+
+- Canonical session теперь ротируется после 50 завершённых turns вместо 250.
+- Pending HITL и OAuth операции по-прежнему закреплены за исходной session до terminal boundary.
+- Порог выбран с запасом по production incident: journal с 118 turns, 1195 workflow events и
+  239 steps превысил максимальную длительность replay Eve в 240 секунд.
+- Добавлен regression test для точной границы: 49 turns сохраняют session, 50 turns создают новую
+  generation.
+
+## Production Recovery
+
+- Зависший ingress update терминально закрыт без автоматического повтора после подтверждённого
+  `REPLAY_TIMEOUT`.
+- Повреждённая canonical session ротирована с сохранением старого durable journal.
+- После controlled restart очередь полностью обработана, новый Telegram turn получил ответ через
+  свежую Eve session, а agent вернулся к нормальной загрузке.
+
+## Проверка
+
+- Targeted session rotation policy test.
+- TypeScript typecheck и полный Vitest suite.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- rotate canonical Eve sessions after 50 completed turns instead of 250
- preserve exact-session pinning while HITL or OAuth is pending
- publish the v0.16.3 incident and recovery notes

## Incident evidence
- production filesystem replay failed at 118 completed turns
- Eve recorded REPLAY_TIMEOUT after its 240-second maximum
- the terminal workflow left Telegram ingress dispatch pending and blocked the global drain

## Verification
- npx vitest run agent/lib/sessions/session-policy.test.ts
- npm run typecheck
- npm test
- npm run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Снижено значение `SESSION_MAX_COMPLETED_TURNS` с `250` до `50`.
- Сессия сохраняется при активном HITL- или OAuth-потоке.
- Обновлены тесты политики ротации для порогов `49` и `50` завершённых ходов.
- Версия пакета обновлена с `0.16.2` до `0.16.3`.
- Добавлены заметки об инциденте и восстановлении v0.16.3.

## Причина

Производственное воспроизведение файловой системы завершилось сбоем после 118 завершённых ходов. Eve зафиксировала `REPLAY_TIMEOUT` после максимального времени выполнения 240 секунд. Терминальный workflow оставил обработку Telegram ingress в состоянии ожидания и заблокировал глобальное опустошение очереди.

## Проверка

- Тесты политики сессий.
- Проверка типов.
- Полный набор тестов.
- Сборка.
- `git diff --check`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->