### PR TITLE
hotfix: bound per-turn model steps

### DIFF
--- a/agent/agent.ts
+++ b/agent/agent.ts
@@ -3,15 +3,19 @@
  *
  * Constructs:
  * - Explicit primary model from the multi-provider registry.
- * - Step-scoped NeuralDeep session routing for upstream KV-cache reuse.
+ * - Fail-closed per-turn model step limit and NeuralDeep routing for upstream KV-cache reuse.
  * - Context compaction; Eve exposes its native fresh-context child only to root sessions.
  */
 import { defineAgent, defineDynamic } from "eve";
 
-import { AGENT_COMPACTION_THRESHOLD } from "./config.js";
+import {
+  AGENT_COMPACTION_THRESHOLD,
+  AGENT_MAX_MODEL_STEPS_PER_TURN,
+} from "./config.js";
 import { primaryModel } from "./lib/model-registry.js";
 import { modelProviderConfig } from "./lib/model-provider-config.js";
 import { resolveSessionModelSelection } from "./lib/neuraldeep-session-routing.js";
+import { resolveTurnModelStepLimitSelection } from "./lib/turn-model-step-limit.js";
 
 const primaryModelContextWindowTokens =
   modelProviderConfig.agent.models.primary.contextWindowTokens;
@@ -24,11 +28,21 @@ export default defineAgent({
   model: defineDynamic({
     fallback: primaryModel,
     events: {
-      "step.started": (_event, ctx) => resolveSessionModelSelection({
-        model: primaryModel,
-        providerId: modelProviderConfig.provider,
-        sessionId: ctx.session.id,
-      }),
+      "step.started": (event, ctx) => {
+        // Resolve the guard first: resolver exceptions would let Eve silently use its fallback.
+        const blockedSelection = resolveTurnModelStepLimitSelection({
+          event,
+          maxModelSteps: AGENT_MAX_MODEL_STEPS_PER_TURN,
+          model: primaryModel,
+        });
+        if (blockedSelection !== null) return blockedSelection;
+
+        return resolveSessionModelSelection({
+          model: primaryModel,
+          providerId: modelProviderConfig.provider,
+          sessionId: ctx.session.id,
+        });
+      },
     },
   }),
   modelContextWindowTokens: primaryModelContextWindowTokens,

--- a/agent/config.ts
+++ b/agent/config.ts
@@ -2,7 +2,7 @@
  * Stable application configuration.
  *
  * Exports:
- * - Agent compaction, session lifecycle, attachment, update, and timeout constants.
+ * - Agent compaction, per-turn model safety, session lifecycle, attachment, update, and timeout constants.
  * - Internal service locations and sandbox runner execution limits.
  * - Telegram group journal and proactive delivery model-context limits.
  * - Cross-process advisory-lock namespaces for sensitive workspace state.
@@ -12,6 +12,8 @@
 import { z } from "zod";
 
 export const AGENT_COMPACTION_THRESHOLD = 0.75;
+// The model may perform substantial tool work, but one turn must never consume unbounded calls.
+export const AGENT_MAX_MODEL_STEPS_PER_TURN = 32;
 export const GROQ_TRANSCRIPTION_TIMEOUT_MS = 60_000;
 export const GOOGLE_WORKSPACE_PROFILE_LOCK_HASH_SEED = 2;
 export const GOOGLE_WORKSPACE_COMMAND_TIMEOUT_MS = 60_000;

--- a/agent/lib/turn-model-step-limit.test.ts
+++ b/agent/lib/turn-model-step-limit.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Per-turn model step limit tests.
+ *
+ * Constructs covered:
+ * - `resolveTurnModelStepLimitSelection`: permits calls below the configured boundary.
+ * - Boundary enforcement: returns a fail-closed model instead of triggering Eve fallback.
+ * - Invalid event/config state: blocks the model call with a stable diagnostic error.
+ */
+import type { LanguageModelV4 } from "@ai-sdk/provider";
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveTurnModelStepLimitSelection } from "./turn-model-step-limit.js";
+
+function modelFixture() {
+  return {
+    doGenerate: vi.fn(async () => {
+      throw new Error("Unexpected upstream generate call");
+    }),
+    doStream: vi.fn(async () => {
+      throw new Error("Unexpected upstream stream call");
+    }),
+    modelId: "test-model",
+    provider: "test-provider",
+    specificationVersion: "v4",
+    supportedUrls: {},
+  } satisfies LanguageModelV4;
+}
+
+describe("resolveTurnModelStepLimitSelection", () => {
+  it("allows every model call below the zero-based step boundary", () => {
+    const model = modelFixture();
+
+    expect(resolveTurnModelStepLimitSelection({
+      event: { data: { stepIndex: 31 }, type: "step.started" },
+      maxModelSteps: 32,
+      model,
+    })).toBeNull();
+  });
+
+  it("blocks the model call at the boundary without invoking the upstream", async () => {
+    const model = modelFixture();
+    const selection = resolveTurnModelStepLimitSelection({
+      event: { data: { stepIndex: 32 }, type: "step.started" },
+      maxModelSteps: 32,
+      model,
+    });
+
+    expect(selection).not.toBeNull();
+    await expect(selection!.model.doStream({} as never)).rejects.toThrow(
+      "AGENT_TURN_MODEL_STEP_LIMIT_EXCEEDED",
+    );
+    await expect(selection!.model.doGenerate({} as never)).rejects.toThrow(
+      "AGENT_TURN_MODEL_STEP_LIMIT_EXCEEDED",
+    );
+    expect(model.doStream).not.toHaveBeenCalled();
+    expect(model.doGenerate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { event: {}, maxModelSteps: 32 },
+    { event: { data: { stepIndex: -1 }, type: "step.started" }, maxModelSteps: 32 },
+    { event: { data: { stepIndex: 0 }, type: "step.started" }, maxModelSteps: 0 },
+  ])("fails closed for invalid step state %#", async ({ event, maxModelSteps }) => {
+    const model = modelFixture();
+    const selection = resolveTurnModelStepLimitSelection({ event, maxModelSteps, model });
+
+    expect(selection).not.toBeNull();
+    await expect(selection!.model.doStream({} as never)).rejects.toThrow(
+      "AGENT_TURN_MODEL_STEP_STATE_INVALID",
+    );
+    expect(model.doStream).not.toHaveBeenCalled();
+  });
+});

--- a/agent/lib/turn-model-step-limit.ts
+++ b/agent/lib/turn-model-step-limit.ts
@@ -1,0 +1,82 @@
+/**
+ * Fail-closed per-turn model step enforcement.
+ *
+ * Exports:
+ * - `resolveTurnModelStepLimitSelection`: returns a blocking model at or beyond the limit.
+ *
+ * Key constructs:
+ * - Strict `step.started` validation prevents malformed runtime state from bypassing the guard.
+ * - The blocking model rejects both AI SDK call paths without invoking the upstream provider.
+ */
+import type { LanguageModelV4 } from "@ai-sdk/provider";
+
+import { AppError } from "./app-error.js";
+
+interface TurnModelStepLimitInput {
+  readonly event: unknown;
+  readonly maxModelSteps: number;
+  readonly model: LanguageModelV4;
+}
+
+interface TurnModelStepLimitSelection {
+  readonly model: LanguageModelV4;
+}
+
+type BlockReason = "limit" | "state";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readStepIndex(event: unknown): number | null {
+  if (!isRecord(event) || event.type !== "step.started" || !isRecord(event.data)) return null;
+  const stepIndex = event.data.stepIndex;
+  return typeof stepIndex === "number" && Number.isSafeInteger(stepIndex) && stepIndex >= 0
+    ? stepIndex
+    : null;
+}
+
+function modelStepError(reason: BlockReason): AppError {
+  if (reason === "limit") {
+    return new AppError(
+      "AGENT_TURN_MODEL_STEP_LIMIT_EXCEEDED",
+      "Агент остановил выполнение, потому что запрос потребовал слишком много шагов. Разбейте задачу на части и повторите",
+    );
+  }
+  return new AppError(
+    "AGENT_TURN_MODEL_STEP_STATE_INVALID",
+    "Агент остановил выполнение из-за некорректного состояния шага. Повторите запрос",
+  );
+}
+
+function createBlockingModel(model: LanguageModelV4, reason: BlockReason): LanguageModelV4 {
+  // A valid model object prevents Eve's dynamic resolver from degrading to its fallback model.
+  return {
+    async doGenerate() {
+      throw modelStepError(reason);
+    },
+    async doStream() {
+      throw modelStepError(reason);
+    },
+    modelId: model.modelId,
+    provider: model.provider,
+    specificationVersion: "v4",
+    supportedUrls: model.supportedUrls,
+  };
+}
+
+export function resolveTurnModelStepLimitSelection({
+  event,
+  maxModelSteps,
+  model,
+}: TurnModelStepLimitInput): TurnModelStepLimitSelection | null {
+  const stepIndex = readStepIndex(event);
+  const validLimit = Number.isSafeInteger(maxModelSteps) && maxModelSteps > 0;
+
+  // Invalid runtime coordinates must never disable a production safety boundary.
+  if (stepIndex === null || !validLimit) {
+    return { model: createBlockingModel(model, "state") };
+  }
+  if (stepIndex < maxModelSteps) return null;
+  return { model: createBlockingModel(model, "limit") };
+}

--- a/docs/releases/v0.16.4.md
+++ b/docs/releases/v0.16.4.md
@@ -1,0 +1,27 @@
+# Osinara v0.16.4
+
+Patch-релиз останавливает один agent turn до того, как повторяющиеся model calls превращаются в
+неограниченный цикл и блокируют durable Telegram ingress.
+
+## Model Step Safety
+
+- Один turn ограничен 32 model calls: разрешены zero-based steps с 0 по 31.
+- На следующем step Eve получает валидную fail-closed AI SDK model, которая завершает оба пути
+  вызова стабильной ошибкой `AGENT_TURN_MODEL_STEP_LIMIT_EXCEEDED` без обращения к provider.
+- Blocking model исключает небезопасное поведение Eve 0.32.0, при котором ошибка dynamic resolver
+  логируется, а выполнение продолжается через fallback model.
+- Некорректные step coordinates или конфигурация лимита также блокируют model call с кодом
+  `AGENT_TURN_MODEL_STEP_STATE_INVALID`.
+
+## Production Recovery
+
+- Зависший ingress update терминально закрыт без повторного model call, а canonical session
+  ротирована после подтверждённого неоднозначного side-effect boundary.
+- Telegram backlog полностью обработан после controlled restart; pending и processing updates
+  отсутствуют.
+- Экземпляр sandbox зависшего Eve run удалён после проверки labels и отсутствия полезных процессов.
+
+## Проверка
+
+- Добавлены unit contracts для точной границы, обоих AI SDK call paths и fail-closed invalid state.
+- GitHub Actions Docker Compose test suite и автоматическое code review прошли успешно.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.16.3",
+      "version": "0.16.4",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary
- bound each agent turn to 32 model calls
- fail closed with a valid blocking AI SDK model so Eve 0.32.0 cannot degrade to its dynamic fallback
- reject malformed step coordinates and invalid limit configuration with stable application errors

## Testing
- added targeted boundary and fail-closed unit contracts
- local test/build execution intentionally skipped to avoid loading the operator workstation
- `git diff --check` passed
- remote CI is required before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Добавлен лимит в 32 вызова модели за один ход агента.
- При достижении лимита выполнение блокируется через валидную модель AI SDK.
- Блокирующая модель отклоняет операции `doGenerate` и `doStream` с ошибкой `AGENT_TURN_MODEL_STEP_LIMIT_EXCEEDED`.
- Добавлена строгая проверка состояния `step.started` и конфигурации лимита.
- Некорректные координаты шага и параметры конфигурации блокируют выполнение с ошибкой `AGENT_TURN_MODEL_STEP_STATE_INVALID`.
- Для разрешённых шагов сохранена маршрутизация модели по сессии.
- Добавлена константа `AGENT_MAX_MODEL_STEPS_PER_TURN`.
- Добавлены тесты для граничных значений, блокировки без обращения к upstream-модели и fail-closed поведения.
- `git diff --check` прошёл. Локальные тесты и сборка не запускались. Перед слиянием требуется удалённый CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->