### PR TITLE
fix: make every approval window consistent and non-contradictory

### DIFF
--- a/agent/lib/telegram-hitl/approval-consequences.ts
+++ b/agent/lib/telegram-hitl/approval-consequences.ts
@@ -1,0 +1,33 @@
+/**
+ * Consequence wording shared by approval composition and settlement.
+ *
+ * Exports:
+ * - `DEFAULT_CONSEQUENCE`, `GOOGLE_WORKSPACE_CONSEQUENCE`, `SCHEDULE_CONSEQUENCES`.
+ * - `allApprovalConsequences`: every sentence a settled prompt may need stripped.
+ *
+ * Key constructs:
+ * - Pure text only. The settlement path — including the background timeout sweep — must not pull a
+ *   PostgreSQL repository in just to learn how a sentence is worded.
+ */
+export const DEFAULT_CONSEQUENCE =
+  "Действие будет выполнено один раз. Автоматического повтора при ошибке не будет.";
+
+export const GOOGLE_WORKSPACE_CONSEQUENCE =
+  "Команда будет выполнена один раз в текущем профиле. Автоматического повтора при ошибке не будет.";
+
+export const SCHEDULE_CONSEQUENCES: Readonly<Record<string, string>> = {
+  create: "Будет создан новый автоматический запуск агента по указанному сценарию.",
+  delete: "Расписание и все его будущие автоматические запуски будут удалены.",
+  pause: "Будущие автоматические запуски остановятся до ручного возобновления.",
+  resume: "Автоматические запуски возобновятся по сохранённому расписанию.",
+  run_now: "Сценарий будет запущен один раз сейчас; обычное расписание не изменится.",
+  update: "Сохранённые параметры расписания будут заменены указанными изменениями.",
+};
+
+export function allApprovalConsequences(): string[] {
+  return [
+    DEFAULT_CONSEQUENCE,
+    GOOGLE_WORKSPACE_CONSEQUENCE,
+    ...Object.values(SCHEDULE_CONSEQUENCES),
+  ];
+}

--- a/agent/lib/telegram-hitl/approval-message.ts
+++ b/agent/lib/telegram-hitl/approval-message.ts
@@ -4,6 +4,7 @@
  * Exports:
  * - `buildApprovalMessage`: fixed order of header, verified facts, agent purpose and consequence.
  * - `genericApprovalFacts`: bounded readable fields for a tool without a reviewed description.
+ * - `approvalFact`, `sanitizeApprovalLine`: sanitized application-derived lines, never shortened.
  * - `googleWorkspaceFacts`: decoded service, command, flags and parameters plus the exact command.
  *
  * Key constructs:
@@ -14,7 +15,8 @@
  */
 import { AppError } from "../app-error.js";
 
-const CONSEQUENCE = "Действие будет выполнено один раз. Автоматического повтора при ошибке не будет.";
+export const DEFAULT_CONSEQUENCE =
+  "Действие будет выполнено один раз. Автоматического повтора при ошибке не будет.";
 const PURPOSE_MAX_CHARACTERS = 300;
 const GENERIC_FACT_LIMIT = 8;
 const GENERIC_VALUE_MAX_CHARACTERS = 180;
@@ -68,7 +70,7 @@ export function buildApprovalMessage(input: ApprovalMessageInput): string {
     header,
     ...(input.facts.length ? [input.facts.join("\n")] : []),
     ...purposeLine(input.reason),
-    input.consequence ?? CONSEQUENCE,
+    input.consequence ?? DEFAULT_CONSEQUENCE,
   ].join("\n\n");
 }
 
@@ -81,6 +83,21 @@ function readableScalar(value: unknown): string | null {
   return text.length <= GENERIC_VALUE_MAX_CHARACTERS
     ? text
     : `${text.slice(0, GENERIC_VALUE_MAX_CHARACTERS - 1).trimEnd()}…`;
+}
+
+/**
+ * Один факт «метка: значение». Значение очищается, но НЕ сокращается: подтверждать нужно полный
+ * текст, а не превью — длинное сообщение разбивается на части при доставке.
+ */
+export function approvalFact(label: string, value: unknown): string[] {
+  if (typeof value !== "string") return [];
+  const text = flatten(value);
+  return text ? [`${flatten(label)}: ${text}`] : [];
+}
+
+/** Очистка уже готовой строки «метка: значение», собранной вызывающим кодом. */
+export function sanitizeApprovalLine(line: string): string {
+  return flatten(line);
 }
 
 export function genericApprovalFacts(input: Record<string, unknown>): string[] {
@@ -173,4 +190,20 @@ export function googleWorkspaceFacts(input: Record<string, unknown>): string[] {
     // A multi-line argument (an email body, for example) is escaped, never allowed to add a line.
     `Точная команда: ${argv.map(visibleEscape).join(" ")}`,
   ];
+}
+
+/**
+ * Removes the trailing consequence once the request is settled: an approved, cancelled or expired
+ * prompt must not keep promising that the action "будет выполнено". Only an exact known sentence is
+ * removed, so a prompt composed by an older release is left untouched instead of being truncated.
+ */
+export function stripApprovalConsequence(
+  prompt: string,
+  consequences: Iterable<string>,
+): string {
+  for (const consequence of consequences) {
+    const suffix = `\n\n${consequence}`;
+    if (prompt.endsWith(suffix)) return prompt.slice(0, -suffix.length);
+  }
+  return prompt;
 }

--- a/agent/lib/telegram-hitl/approval-message.ts
+++ b/agent/lib/telegram-hitl/approval-message.ts
@@ -14,9 +14,8 @@
  *   to the one message the owner's authorization depends on.
  */
 import { AppError } from "../app-error.js";
+import { DEFAULT_CONSEQUENCE } from "./approval-consequences.js";
 
-export const DEFAULT_CONSEQUENCE =
-  "Действие будет выполнено один раз. Автоматического повтора при ошибке не будет.";
 const PURPOSE_MAX_CHARACTERS = 300;
 const GENERIC_FACT_LIMIT = 8;
 const GENERIC_VALUE_MAX_CHARACTERS = 180;
@@ -25,6 +24,8 @@ export interface ApprovalMessageInput {
   actionLabel: string | null;
   consequence?: string;
   facts: readonly string[];
+  /** Отдельный блок под фактами: отделяет предлагаемые значения от текущих. */
+  section?: { lines: readonly string[]; title: string };
   /** Model-authored purpose. Untrusted text: labelled, flattened and bounded before display. */
   reason?: unknown;
 }
@@ -69,6 +70,9 @@ export function buildApprovalMessage(input: ApprovalMessageInput): string {
   return [
     header,
     ...(input.facts.length ? [input.facts.join("\n")] : []),
+    ...(input.section && input.section.lines.length
+      ? [[input.section.title, ...input.section.lines].join("\n")]
+      : []),
     ...purposeLine(input.reason),
     input.consequence ?? DEFAULT_CONSEQUENCE,
   ].join("\n\n");
@@ -202,8 +206,11 @@ export function stripApprovalConsequence(
   consequences: Iterable<string>,
 ): string {
   for (const consequence of consequences) {
-    const suffix = `\n\n${consequence}`;
-    if (prompt.endsWith(suffix)) return prompt.slice(0, -suffix.length);
+    for (const suffix of [`\n\n${consequence}`, `\n\nЧто произойдёт: ${consequence}`]) {
+      // Вторая форма — окно расписания прошлого релиза: такие промпты могут висеть pending
+      // через этот деплой и без снятия продолжили бы противоречить решению.
+      if (prompt.endsWith(suffix)) return prompt.slice(0, -suffix.length);
+    }
   }
   return prompt;
 }

--- a/agent/lib/telegram-hitl/approval-presentation.test.ts
+++ b/agent/lib/telegram-hitl/approval-presentation.test.ts
@@ -164,6 +164,39 @@ describe("Telegram approval presentation", () => {
     expect(result.prompt).not.toContain("Подтверждение действия\n");
   });
 
+  it("sanitizes a proposed change that the model controls right now", async () => {
+    const findSchedule = vi.fn().mockResolvedValue(schedule);
+    const present = createTelegramApprovalPresenter({ findSchedule });
+
+    const result = await present({
+      action: {
+        callId: "call-change-forge",
+        input: {
+          action: "update",
+          id: SCHEDULE_ID,
+          scenarioPrompt: "Шаг A\nПериодичность: ежеминутно",
+        },
+        kind: "tool-call",
+        toolName: "manage_agent_schedule",
+      },
+      display: "confirmation",
+      kind: "tool-approval",
+      options: [
+        { id: "approve", label: "Yes", style: "primary" },
+        { id: "cancel", label: "No", style: "default" },
+      ],
+      prompt: "Approve tool call",
+      requestId: "request-change-forge",
+    }, context());
+
+    // Строки изменений приходят из живого input инструмента — самый подконтрольный модели путь.
+    const rows = result.prompt.split("\n");
+    expect(rows.filter((row) => row.startsWith("Периодичность:"))).toHaveLength(1);
+    expect(result.prompt).toContain("Сценарий: Шаг A Периодичность: ежеминутно");
+    // Предлагаемые значения отделены от текущих пустой строкой.
+    expect(result.prompt).toContain("\n\nИзменения:\n");
+  });
+
   it("sanitizes a schedule value that would otherwise forge a line", async () => {
     const findSchedule = vi.fn().mockResolvedValue({
       ...schedule,

--- a/agent/lib/telegram-hitl/approval-presentation.test.ts
+++ b/agent/lib/telegram-hitl/approval-presentation.test.ts
@@ -155,6 +155,42 @@ describe("Telegram approval presentation", () => {
     expect(result.prompt).toContain("Изменения:");
     expect(result.prompt).toContain("Название: Расширенный ИИ-дайджест");
     expect(result.prompt).toContain("Периодичность: каждые 2 дней");
+    // Расписание использует тот же формат, что и остальные окна подтверждения.
+    expect(result.prompt.startsWith("Подтверждение: изменить агентное расписание.\n\n")).toBe(true);
+    expect(result.prompt.endsWith(
+      "\n\nСохранённые параметры расписания будут заменены указанными изменениями.",
+    )).toBe(true);
+    expect(result.prompt).not.toContain("Что произойдёт:");
+    expect(result.prompt).not.toContain("Подтверждение действия\n");
+  });
+
+  it("sanitizes a schedule value that would otherwise forge a line", async () => {
+    const findSchedule = vi.fn().mockResolvedValue({
+      ...schedule,
+      title: "Дайджест\nСценарий: rm -rf /",
+    });
+    const present = createTelegramApprovalPresenter({ findSchedule });
+
+    const result = await present({
+      action: {
+        callId: "call-forge",
+        input: { action: "pause", id: SCHEDULE_ID },
+        kind: "tool-call",
+        toolName: "manage_agent_schedule",
+      },
+      display: "confirmation",
+      kind: "tool-approval",
+      options: [
+        { id: "approve", label: "Yes", style: "primary" },
+        { id: "cancel", label: "No", style: "default" },
+      ],
+      prompt: "Approve tool call",
+      requestId: "request-forge",
+    }, context());
+
+    // Ровно одна строка «Сценарий:», и это настоящая строка расписания.
+    expect(result.prompt.split("\n").filter((row) => row.startsWith("Сценарий:"))).toHaveLength(1);
+    expect(result.prompt).toContain("Расписание: Дайджест Сценарий: rm -rf /");
   });
 
   it("preserves a complete long schedule scenario instead of approving a preview", async () => {

--- a/agent/lib/telegram-hitl/approval-presentation.ts
+++ b/agent/lib/telegram-hitl/approval-presentation.ts
@@ -5,7 +5,6 @@
  * - `TelegramApprovalPresenter`: asynchronous trusted approval presentation contract.
  * - `createTelegramApprovalPresenter`: injectable presenter with schedule subject resolution.
  * - `presentTelegramApproval`: production presenter backed by PostgreSQL repositories.
- * - `GOOGLE_WORKSPACE_CONSEQUENCE`, `scheduleConsequences`: per-tool consequence wording.
  */
 import type { SessionContext } from "eve/context";
 
@@ -25,6 +24,10 @@ import {
   type TelegramInputRequest,
 } from "../telegram-interface.js";
 import {
+  GOOGLE_WORKSPACE_CONSEQUENCE,
+  SCHEDULE_CONSEQUENCES,
+} from "./approval-consequences.js";
+import {
   approvalFact,
   buildApprovalMessage,
   googleWorkspaceFacts,
@@ -40,34 +43,25 @@ export type TelegramApprovalPresenter = (
   ctx: Pick<SessionContext, "session">,
 ) => Promise<TelegramInputRequest>;
 
-export const GOOGLE_WORKSPACE_CONSEQUENCE =
-  "Команда будет выполнена один раз в текущем профиле. Автоматического повтора при ошибке не будет.";
-
-const SCHEDULE_ACTIONS: Readonly<Record<string, { action: string; consequence: string }>> = {
+const SCHEDULE_ACTIONS: Readonly<Record<string, { action: string }>> = {
   create: {
     action: "Создать агентное расписание",
-    consequence: "Будет создан новый автоматический запуск агента по указанному сценарию.",
-  },
+      },
   delete: {
     action: "Удалить агентное расписание",
-    consequence: "Расписание и все его будущие автоматические запуски будут удалены.",
-  },
+      },
   pause: {
     action: "Приостановить агентное расписание",
-    consequence: "Будущие автоматические запуски остановятся до ручного возобновления.",
-  },
+      },
   resume: {
     action: "Возобновить агентное расписание",
-    consequence: "Автоматические запуски возобновятся по сохранённому расписанию.",
-  },
+      },
   run_now: {
     action: "Запустить агентное расписание сейчас",
-    consequence: "Сценарий будет запущен один раз сейчас; обычное расписание не изменится.",
-  },
+      },
   update: {
     action: "Изменить агентное расписание",
-    consequence: "Сохранённые параметры расписания будут заменены указанными изменениями.",
-  },
+      },
 };
 
 function scheduleDate(schedule: AgentScheduleRecord): string {
@@ -131,7 +125,7 @@ function scheduleChanges(input: Record<string, unknown>): string[] {
 }
 
 function schedulePrompt(
-  action: { action: string; consequence: string },
+  actionName: string,
   schedule: AgentScheduleRecord,
   changes: readonly string[],
 ): string {
@@ -139,17 +133,21 @@ function schedulePrompt(
   // проходят ту же очистку, что и остальные факты, поэтому перенос строки в названии или сценарии
   // не может дорисовать строку, выглядящую как строка приложения.
   return buildApprovalMessage({
-    actionLabel: lowerFirst(action.action),
-    consequence: action.consequence,
+    actionLabel: lowerFirst(SCHEDULE_ACTIONS[actionName]!.action),
+    consequence: SCHEDULE_CONSEQUENCES[actionName]!,
     facts: [
       ...approvalFact("Расписание", schedule.title),
       ...approvalFact("Назначение", schedule.userRequest),
       ...approvalFact("Периодичность", describeRecurrence(schedule.recurrence)),
       ...approvalFact("Следующий запуск", `${scheduleDate(schedule)} (${schedule.timezone})`),
       ...approvalFact("Сценарий", schedule.scenarioPrompt),
-      // `scheduleChanges` уже формирует строки «Метка: значение», поэтому им нужна только очистка.
-      ...(changes.length === 0 ? [] : ["Изменения:", ...changes.map(sanitizeApprovalLine)]),
     ],
+    // Отдельным блоком: предлагаемые значения обязаны быть визуально отделены от текущих, иначе
+    // две строки «Сценарий:» — сохранённая и новая — читаются как одна.
+    // `scheduleChanges` уже формирует строки «Метка: значение», поэтому им нужна только очистка.
+    ...(changes.length === 0
+      ? {}
+      : { section: { lines: changes.map(sanitizeApprovalLine), title: "Изменения:" } }),
   });
 }
 
@@ -157,10 +155,6 @@ function lowerFirst(value: string): string {
   return value.charAt(0).toLowerCase() + value.slice(1);
 }
 
-/** Каждая формулировка последствия, которую снимает финализатор решённого запроса. */
-export function scheduleConsequences(): string[] {
-  return Object.values(SCHEDULE_ACTIONS).map((action) => action.consequence);
-}
 
 export function createTelegramApprovalPresenter(
   dependencies: ApprovalPresentationDependencies,
@@ -211,7 +205,7 @@ export function createTelegramApprovalPresenter(
     const changes = actionName === "update" ? scheduleChanges(request.action.input) : [];
     return {
       ...localized,
-      prompt: schedulePrompt(SCHEDULE_ACTIONS[actionName], schedule, changes),
+      prompt: schedulePrompt(actionName, schedule, changes),
     };
   };
 }

--- a/agent/lib/telegram-hitl/approval-presentation.ts
+++ b/agent/lib/telegram-hitl/approval-presentation.ts
@@ -5,6 +5,7 @@
  * - `TelegramApprovalPresenter`: asynchronous trusted approval presentation contract.
  * - `createTelegramApprovalPresenter`: injectable presenter with schedule subject resolution.
  * - `presentTelegramApproval`: production presenter backed by PostgreSQL repositories.
+ * - `GOOGLE_WORKSPACE_CONSEQUENCE`, `scheduleConsequences`: per-tool consequence wording.
  */
 import type { SessionContext } from "eve/context";
 
@@ -23,7 +24,12 @@ import {
   localizeTelegramInputRequest,
   type TelegramInputRequest,
 } from "../telegram-interface.js";
-import { buildApprovalMessage, googleWorkspaceFacts } from "./approval-message.js";
+import {
+  approvalFact,
+  buildApprovalMessage,
+  googleWorkspaceFacts,
+  sanitizeApprovalLine,
+} from "./approval-message.js";
 
 interface ApprovalPresentationDependencies {
   findSchedule(auth: AgentScheduleAuthorization, id: string): Promise<AgentScheduleRecord | null>;
@@ -33,6 +39,9 @@ export type TelegramApprovalPresenter = (
   request: TelegramInputRequest,
   ctx: Pick<SessionContext, "session">,
 ) => Promise<TelegramInputRequest>;
+
+export const GOOGLE_WORKSPACE_CONSEQUENCE =
+  "Команда будет выполнена один раз в текущем профиле. Автоматического повтора при ошибке не будет.";
 
 const SCHEDULE_ACTIONS: Readonly<Record<string, { action: string; consequence: string }>> = {
   create: {
@@ -126,19 +135,31 @@ function schedulePrompt(
   schedule: AgentScheduleRecord,
   changes: readonly string[],
 ): string {
-  return [
-    "Подтверждение действия",
-    "",
-    `Действие: ${action.action}`,
-    `Расписание: ${schedule.title}`,
-    `Назначение: ${schedule.userRequest}`,
-    `Периодичность: ${describeRecurrence(schedule.recurrence)}`,
-    `Следующий запуск: ${scheduleDate(schedule)} (${schedule.timezone})`,
-    `Сценарий: ${schedule.scenarioPrompt}`,
-    ...(changes.length === 0 ? [] : ["", "Изменения:", ...changes]),
-    "",
-    `Что произойдёт: ${action.consequence}`,
-  ].join("\n");
+  // Одна и та же структура во всех окнах: заголовок, факты, последствие. Значения расписания
+  // проходят ту же очистку, что и остальные факты, поэтому перенос строки в названии или сценарии
+  // не может дорисовать строку, выглядящую как строка приложения.
+  return buildApprovalMessage({
+    actionLabel: lowerFirst(action.action),
+    consequence: action.consequence,
+    facts: [
+      ...approvalFact("Расписание", schedule.title),
+      ...approvalFact("Назначение", schedule.userRequest),
+      ...approvalFact("Периодичность", describeRecurrence(schedule.recurrence)),
+      ...approvalFact("Следующий запуск", `${scheduleDate(schedule)} (${schedule.timezone})`),
+      ...approvalFact("Сценарий", schedule.scenarioPrompt),
+      // `scheduleChanges` уже формирует строки «Метка: значение», поэтому им нужна только очистка.
+      ...(changes.length === 0 ? [] : ["Изменения:", ...changes.map(sanitizeApprovalLine)]),
+    ],
+  });
+}
+
+function lowerFirst(value: string): string {
+  return value.charAt(0).toLowerCase() + value.slice(1);
+}
+
+/** Каждая формулировка последствия, которую снимает финализатор решённого запроса. */
+export function scheduleConsequences(): string[] {
+  return Object.values(SCHEDULE_ACTIONS).map((action) => action.consequence);
 }
 
 export function createTelegramApprovalPresenter(
@@ -154,8 +175,7 @@ export function createTelegramApprovalPresenter(
         ...localized,
         prompt: buildApprovalMessage({
           actionLabel: "изменение в Google Workspace",
-          consequence:
-            "Команда будет выполнена один раз в текущем профиле. Автоматического повтора при ошибке не будет.",
+          consequence: GOOGLE_WORKSPACE_CONSEQUENCE,
           facts: googleWorkspaceFacts(request.action.input),
         }),
       };

--- a/agent/lib/telegram-hitl/approval-timeout-prompt.test.ts
+++ b/agent/lib/telegram-hitl/approval-timeout-prompt.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+import { buildApprovalMessage } from "./approval-message.js";
 import {
   createTimedOutPromptFinalizer,
   timedOutPromptEditBody,
@@ -34,6 +35,20 @@ describe("timedOutPromptText", () => {
     expect(text).toContain(CLAIM.promptText);
     expect(text).toContain("Время на подтверждение истекло.");
     expect(text).toContain("Действие не выполнено.");
+  });
+
+  it("does not keep promising an execution next to the expiry", () => {
+    // Сквозная проверка исправляемого бага: реальное собранное окно, а не строка без последствия.
+    const composed = buildApprovalMessage({
+      actionLabel: "исправить запись в памяти",
+      facts: ["Тип памяти: episode"],
+    });
+    expect(composed).toContain("будет выполнено один раз");
+
+    const text = timedOutPromptText(composed);
+    expect(text).not.toContain("будет выполнено один раз");
+    expect(text).toContain("Действие не выполнено.");
+    expect(text).toContain("Тип памяти: episode");
   });
 
   it("truncates an oversized prompt within the Telegram message limit", () => {

--- a/agent/lib/telegram-hitl/approval-timeout-prompt.ts
+++ b/agent/lib/telegram-hitl/approval-timeout-prompt.ts
@@ -12,7 +12,7 @@ import { callTelegramApi } from "eve/channels/telegram";
 import { TELEGRAM_API_REQUEST_TIMEOUT_MS } from "../../config.js";
 import { AppError } from "../app-error.js";
 import type { TimedOutApprovalClaim } from "./approval-timeout.js";
-import { settledPromptText } from "./settled-prompt.js";
+import { boundSettledPrompt, settledPromptText } from "./settled-prompt.js";
 
 const TELEGRAM_MESSAGE_MAX_CHARACTERS = 4_096;
 const TIMEOUT_RESOLUTION = "Время на подтверждение истекло.\nДействие не выполнено.";
@@ -21,9 +21,7 @@ export function timedOutPromptText(promptText: string): string {
   // Запрос закрыт по времени: обещание будущего исполнения снимается вместе с ним.
   const settled = settledPromptText(promptText);
   const promptLimit = TELEGRAM_MESSAGE_MAX_CHARACTERS - TIMEOUT_RESOLUTION.length - 2;
-  const prompt = settled.length <= promptLimit
-    ? settled
-    : `${settled.slice(0, promptLimit - 1).trimEnd()}…`;
+  const prompt = boundSettledPrompt(settled, promptLimit);
   return `${prompt}\n\n${TIMEOUT_RESOLUTION}`;
 }
 

--- a/agent/lib/telegram-hitl/approval-timeout-prompt.ts
+++ b/agent/lib/telegram-hitl/approval-timeout-prompt.ts
@@ -12,15 +12,18 @@ import { callTelegramApi } from "eve/channels/telegram";
 import { TELEGRAM_API_REQUEST_TIMEOUT_MS } from "../../config.js";
 import { AppError } from "../app-error.js";
 import type { TimedOutApprovalClaim } from "./approval-timeout.js";
+import { settledPromptText } from "./settled-prompt.js";
 
 const TELEGRAM_MESSAGE_MAX_CHARACTERS = 4_096;
 const TIMEOUT_RESOLUTION = "Время на подтверждение истекло.\nДействие не выполнено.";
 
 export function timedOutPromptText(promptText: string): string {
+  // Запрос закрыт по времени: обещание будущего исполнения снимается вместе с ним.
+  const settled = settledPromptText(promptText);
   const promptLimit = TELEGRAM_MESSAGE_MAX_CHARACTERS - TIMEOUT_RESOLUTION.length - 2;
-  const prompt = promptText.length <= promptLimit
-    ? promptText
-    : `${promptText.slice(0, promptLimit - 1).trimEnd()}…`;
+  const prompt = settled.length <= promptLimit
+    ? settled
+    : `${settled.slice(0, promptLimit - 1).trimEnd()}…`;
   return `${prompt}\n\n${TIMEOUT_RESOLUTION}`;
 }
 

--- a/agent/lib/telegram-hitl/callback-authorization.test.ts
+++ b/agent/lib/telegram-hitl/callback-authorization.test.ts
@@ -9,6 +9,7 @@
 import type { TelegramContext, TelegramCallbackQuery } from "eve/channels/telegram";
 import { describe, expect, it, vi } from "vitest";
 
+import { buildApprovalMessage } from "./approval-message.js";
 import { createTelegramHitlCallbackAuthorizer } from "./callback-authorization.js";
 
 function callbackQuery(): TelegramCallbackQuery {
@@ -141,5 +142,38 @@ describe("createTelegramHitlCallbackAuthorizer", () => {
       reply_markup: { inline_keyboard: [] },
       text: expect.stringContaining("Отменено"),
     }));
+  });
+
+  it("does not keep promising an execution next to the cancellation", async () => {
+    // Сквозная проверка исправляемого бага: реальное собранное окно, а не строка без последствия.
+    const composed = buildApprovalMessage({
+      actionLabel: "удалить агентное расписание",
+      facts: ["Расписание: Утренний дайджест ИИ"],
+    });
+    expect(composed).toContain("будет выполнено один раз");
+
+    const authorize = createTelegramHitlCallbackAuthorizer({
+      claimCallback: vi.fn().mockResolvedValue({
+        auth: {
+          attributes: { applicationSessionId: "session-1", role: "member" },
+          authenticator: "telegram",
+          principalId: "user-1",
+          principalType: "user" as const,
+        },
+        continuationToken: "-1001:55:88:osinara:2",
+        promptText: composed,
+        selectedOptionId: "cancel",
+        selectedOptionLabel: "Нет, отменить",
+        status: "authorized",
+      }),
+    });
+    const { context, request } = telegramContext();
+
+    await authorize(context, callbackQuery(), "-1001:55:88");
+
+    const [, body] = request.mock.calls.find(([method]) => method === "editMessageText")!;
+    expect((body as { text: string }).text).not.toContain("будет выполнено один раз");
+    expect((body as { text: string }).text).toContain("Действие не будет выполнено.");
+    expect((body as { text: string }).text).toContain("Расписание: Утренний дайджест ИИ");
   });
 });

--- a/agent/lib/telegram-hitl/callback-authorization.ts
+++ b/agent/lib/telegram-hitl/callback-authorization.ts
@@ -17,7 +17,7 @@ import {
   telegramHitlApprovalRepository,
   type TelegramHitlApprovalRepository,
 } from "./approval-repository.js";
-import { settledPromptText } from "./settled-prompt.js";
+import { boundSettledPrompt, settledPromptText } from "./settled-prompt.js";
 
 const CALLBACK_ERRORS = {
   expired:
@@ -41,9 +41,7 @@ function resolvedApprovalText(result: {
   // Решение уже принято: обещание будущего исполнения снимается, иначе текст противоречит сам себе.
   const settled = settledPromptText(result.promptText);
   const promptLimit = TELEGRAM_MESSAGE_MAX_CHARACTERS - resolution.length - 2;
-  const prompt = settled.length <= promptLimit
-    ? settled
-    : `${settled.slice(0, promptLimit - 1).trimEnd()}…`;
+  const prompt = boundSettledPrompt(settled, promptLimit);
   return `${prompt}\n\n${resolution}`;
 }
 

--- a/agent/lib/telegram-hitl/callback-authorization.ts
+++ b/agent/lib/telegram-hitl/callback-authorization.ts
@@ -17,6 +17,7 @@ import {
   telegramHitlApprovalRepository,
   type TelegramHitlApprovalRepository,
 } from "./approval-repository.js";
+import { settledPromptText } from "./settled-prompt.js";
 
 const CALLBACK_ERRORS = {
   expired:
@@ -37,10 +38,12 @@ function resolvedApprovalText(result: {
     : result.selectedOptionId === "cancel"
     ? "Решение: Отменено.\nДействие не будет выполнено."
     : `Выбран ответ: ${result.selectedOptionLabel}`;
+  // Решение уже принято: обещание будущего исполнения снимается, иначе текст противоречит сам себе.
+  const settled = settledPromptText(result.promptText);
   const promptLimit = TELEGRAM_MESSAGE_MAX_CHARACTERS - resolution.length - 2;
-  const prompt = result.promptText.length <= promptLimit
-    ? result.promptText
-    : `${result.promptText.slice(0, promptLimit - 1).trimEnd()}…`;
+  const prompt = settled.length <= promptLimit
+    ? settled
+    : `${settled.slice(0, promptLimit - 1).trimEnd()}…`;
   return `${prompt}\n\n${resolution}`;
 }
 

--- a/agent/lib/telegram-hitl/settled-prompt.test.ts
+++ b/agent/lib/telegram-hitl/settled-prompt.test.ts
@@ -4,12 +4,17 @@
  * Constructs covered:
  * - `settledPromptText`: removes the forward-looking consequence of every composed window.
  * - A prompt from an older release keeps its full text instead of losing its last block.
+ * - `boundSettledPrompt`: fits the Telegram limit without splitting a surrogate pair.
  */
 import { describe, expect, it } from "vitest";
 
-import { buildApprovalMessage, DEFAULT_CONSEQUENCE } from "./approval-message.js";
-import { GOOGLE_WORKSPACE_CONSEQUENCE } from "./approval-presentation.js";
-import { settledPromptText } from "./settled-prompt.js";
+import {
+  DEFAULT_CONSEQUENCE,
+  GOOGLE_WORKSPACE_CONSEQUENCE,
+  SCHEDULE_CONSEQUENCES,
+} from "./approval-consequences.js";
+import { buildApprovalMessage } from "./approval-message.js";
+import { boundSettledPrompt, settledPromptText } from "./settled-prompt.js";
 
 describe("settledPromptText", () => {
   it("removes the default consequence once the request is settled", () => {
@@ -35,18 +40,56 @@ describe("settledPromptText", () => {
     );
   });
 
-  it("removes a schedule consequence", () => {
-    const prompt = buildApprovalMessage({
-      actionLabel: "приостановить агентное расписание",
-      consequence: "Будущие автоматические запуски остановятся до ручного возобновления.",
-      facts: ["Расписание: Утренние новости"],
-    });
-    expect(settledPromptText(prompt)).not.toContain("остановятся до ручного возобновления");
+  it.each(Object.entries(SCHEDULE_CONSEQUENCES))(
+    "removes the %s schedule consequence",
+    (_action, consequence) => {
+      const prompt = buildApprovalMessage({
+        actionLabel: "действие с расписанием",
+        consequence,
+        facts: ["Расписание: Утренние новости"],
+      });
+      expect(settledPromptText(prompt)).toBe(
+        "Подтверждение: действие с расписанием.\n\nРасписание: Утренние новости",
+      );
+    },
+  );
+
+  it("also settles a schedule prompt composed by the previous release", () => {
+    // Такое окно может висеть pending через этот деплой; без снятия оно противоречило бы решению.
+    const legacy = [
+      "Подтверждение действия",
+      "",
+      "Действие: Приостановить агентное расписание",
+      "Расписание: Утренние новости",
+      "",
+      `Что произойдёт: ${SCHEDULE_CONSEQUENCES.pause}`,
+    ].join("\n");
+
+    expect(settledPromptText(legacy)).toBe(
+      "Подтверждение действия\n\nДействие: Приостановить агентное расписание\nРасписание: Утренние новости",
+    );
   });
 
-  it("leaves a prompt composed by an older release intact", () => {
-    // Такие строки могут висеть pending через деплой; отрезать у них последний блок нельзя.
-    const legacy = "Подтвердите действие: удалить файл.\n\nПуть: notes/plan.md";
-    expect(settledPromptText(legacy)).toBe(legacy);
+  it("leaves a prompt with no known consequence intact", () => {
+    // Структурная обрезка последнего блока съела бы у такого промпта параметры.
+    const other = "Подтвердите действие: удалить файл.\n\nПуть: notes/plan.md";
+    expect(settledPromptText(other)).toBe(other);
+  });
+});
+
+describe("boundSettledPrompt", () => {
+  it("keeps a prompt that already fits", () => {
+    expect(boundSettledPrompt("короткий", 100)).toBe("короткий");
+  });
+
+  it("never splits a surrogate pair", () => {
+    const emoji = "🙂".repeat(50);
+    for (let limit = 2; limit <= emoji.length; limit += 1) {
+      const bounded = boundSettledPrompt(emoji, limit);
+      expect(bounded.length).toBeLessThanOrEqual(limit);
+      // Одиночный суррогат Telegram отвергнет, и решённое окно останется со старыми кнопками.
+      expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u
+        .test(bounded)).toBe(false);
+    }
   });
 });

--- a/agent/lib/telegram-hitl/settled-prompt.test.ts
+++ b/agent/lib/telegram-hitl/settled-prompt.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Settled prompt tests.
+ *
+ * Constructs covered:
+ * - `settledPromptText`: removes the forward-looking consequence of every composed window.
+ * - A prompt from an older release keeps its full text instead of losing its last block.
+ */
+import { describe, expect, it } from "vitest";
+
+import { buildApprovalMessage, DEFAULT_CONSEQUENCE } from "./approval-message.js";
+import { GOOGLE_WORKSPACE_CONSEQUENCE } from "./approval-presentation.js";
+import { settledPromptText } from "./settled-prompt.js";
+
+describe("settledPromptText", () => {
+  it("removes the default consequence once the request is settled", () => {
+    const prompt = buildApprovalMessage({
+      actionLabel: "изменить напоминание",
+      facts: ["ID: 1"],
+    });
+    expect(prompt).toContain(DEFAULT_CONSEQUENCE);
+
+    const settled = settledPromptText(prompt);
+    expect(settled).not.toContain("будет выполнено один раз");
+    expect(settled).toBe("Подтверждение: изменить напоминание.\n\nID: 1");
+  });
+
+  it("removes a per-tool consequence too", () => {
+    const prompt = buildApprovalMessage({
+      actionLabel: "изменение в Google Workspace",
+      consequence: GOOGLE_WORKSPACE_CONSEQUENCE,
+      facts: ["Сервис: Gmail"],
+    });
+    expect(settledPromptText(prompt)).toBe(
+      "Подтверждение: изменение в Google Workspace.\n\nСервис: Gmail",
+    );
+  });
+
+  it("removes a schedule consequence", () => {
+    const prompt = buildApprovalMessage({
+      actionLabel: "приостановить агентное расписание",
+      consequence: "Будущие автоматические запуски остановятся до ручного возобновления.",
+      facts: ["Расписание: Утренние новости"],
+    });
+    expect(settledPromptText(prompt)).not.toContain("остановятся до ручного возобновления");
+  });
+
+  it("leaves a prompt composed by an older release intact", () => {
+    // Такие строки могут висеть pending через деплой; отрезать у них последний блок нельзя.
+    const legacy = "Подтвердите действие: удалить файл.\n\nПуть: notes/plan.md";
+    expect(settledPromptText(legacy)).toBe(legacy);
+  });
+});

--- a/agent/lib/telegram-hitl/settled-prompt.ts
+++ b/agent/lib/telegram-hitl/settled-prompt.ts
@@ -1,27 +1,30 @@
 /**
  * Shared removal of the forward-looking consequence from a settled approval prompt.
  *
- * Export:
+ * Exports:
  * - `settledPromptText`: the stored prompt without its "будет выполнено" sentence.
+ * - `boundSettledPrompt`: shortens it to fit beside a resolution without splitting a surrogate pair.
  *
  * Key constructs:
  * - An approved, cancelled or expired prompt must not keep promising a future execution next to the
  *   line that says it will not happen. Only an exact known sentence is removed, so a prompt composed
  *   by an older release is left intact rather than truncated.
  */
-import {
-  DEFAULT_CONSEQUENCE,
-  stripApprovalConsequence,
-} from "./approval-message.js";
-import {
-  GOOGLE_WORKSPACE_CONSEQUENCE,
-  scheduleConsequences,
-} from "./approval-presentation.js";
+import { allApprovalConsequences } from "./approval-consequences.js";
+import { stripApprovalConsequence } from "./approval-message.js";
 
 export function settledPromptText(prompt: string): string {
-  return stripApprovalConsequence(prompt, [
-    DEFAULT_CONSEQUENCE,
-    GOOGLE_WORKSPACE_CONSEQUENCE,
-    ...scheduleConsequences(),
-  ]);
+  return stripApprovalConsequence(prompt, allApprovalConsequences());
+}
+
+/**
+ * Shortens a settled prompt to `limit` characters. A UTF-16 surrogate pair is never split: Telegram
+ * rejects a malformed payload, which would leave the decided prompt showing its old buttons.
+ */
+export function boundSettledPrompt(prompt: string, limit: number): string {
+  if (limit <= 0) return "";
+  if (prompt.length <= limit) return prompt;
+  let end = limit - 1;
+  if (/[\uD800-\uDBFF]/u.test(prompt[end - 1] ?? "")) end -= 1;
+  return `${prompt.slice(0, end).trimEnd()}…`;
 }

--- a/agent/lib/telegram-hitl/settled-prompt.ts
+++ b/agent/lib/telegram-hitl/settled-prompt.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared removal of the forward-looking consequence from a settled approval prompt.
+ *
+ * Export:
+ * - `settledPromptText`: the stored prompt without its "будет выполнено" sentence.
+ *
+ * Key constructs:
+ * - An approved, cancelled or expired prompt must not keep promising a future execution next to the
+ *   line that says it will not happen. Only an exact known sentence is removed, so a prompt composed
+ *   by an older release is left intact rather than truncated.
+ */
+import {
+  DEFAULT_CONSEQUENCE,
+  stripApprovalConsequence,
+} from "./approval-message.js";
+import {
+  GOOGLE_WORKSPACE_CONSEQUENCE,
+  scheduleConsequences,
+} from "./approval-presentation.js";
+
+export function settledPromptText(prompt: string): string {
+  return stripApprovalConsequence(prompt, [
+    DEFAULT_CONSEQUENCE,
+    GOOGLE_WORKSPACE_CONSEQUENCE,
+    ...scheduleConsequences(),
+  ]);
+}

--- a/agent/lib/telegram-interface.test.ts
+++ b/agent/lib/telegram-interface.test.ts
@@ -43,6 +43,36 @@ describe("Telegram interface localization", () => {
     ]);
   });
 
+  it("describes the external group file removal that only exists outside the tools directory", () => {
+    const request = localizeTelegramInputRequest({
+      action: {
+        callId: "call-1",
+        input: { path: "notes/plan.md" },
+        kind: "tool-call" as const,
+        toolName: "remove_group_file",
+      },
+      display: "confirmation" as const,
+      kind: "tool-approval" as const,
+      options: [
+        { id: "approve", label: "Yes" },
+        { id: "cancel", label: "No" },
+      ],
+      prompt: "Approve tool call: remove_group_file",
+      requestId: "request-file",
+    });
+
+    // Единственный разрушительный инструмент внешней группы живёт вне agent/lib/tools/,
+    // поэтому его окно проверяется явно.
+    expect(request.prompt).toBe(
+      "Подтверждение: удалить файл внешней группы.\n\nПуть: notes/plan.md\n\n" +
+        "Действие будет выполнено один раз. Автоматического повтора при ошибке не будет.",
+    );
+    expect(request.options).toEqual([
+      { id: "approve", label: "Да, подтвердить" },
+      { id: "cancel", label: "Нет, отменить" },
+    ]);
+  });
+
   it("leaves a framework session-limit request unrewritten but localizes its buttons", () => {
     const request = localizeTelegramInputRequest({
       action: {


### PR DESCRIPTION
Три хвоста, оставшиеся от ревью PR #112.

## 1. Решённое подтверждение противоречило само себе

После отмены или таймаута сообщение выглядело так:

```
...
Действие будет выполнено один раз. Автоматического повтора при ошибке не будет.

Решение: Отменено.
Действие не будет выполнено.
```

Обещание будущего исполнения теперь снимается при финализации.

Снимается **только точно известная формулировка**. Промпт, собранный прошлым релизом и висящий pending через деплой, остаётся целым — структурная обрезка последнего блока съела бы у него параметры.

## 2. Окно агентного расписания шло особняком

Был собственный формат «Подтверждение действия» / «Что произойдёт». Переведено на общую композицию: заголовок, факты, последствие — как во всех остальных окнах.

## 3. `remove_group_file`

Единственный разрушительный инструмент внешней группы живёт вне `agent/lib/tools/` и не попадает в обзоры инструментов с подтверждением. Его окно закреплено явным тестом.

## Что нашлось по дороге

Первая версия миграции расписаний **сокращала** факты до 180 символов, и существующий тест это отбил: есть требование подтверждать **полный** сценарий, а не превью — длинное сообщение разбивается на части при доставке. Факты расписания теперь очищаются, но не укорачиваются.

Заодно значения расписания получили ту же защиту от подделки строк, что и параметры Google Workspace: перевод строки в названии или сценарии больше не дорисовывает строку, выглядящую как строка приложения. На это есть тест.

## Проверка

- Docker Compose gate: **333 файла, 1943 теста, exit 0** на Eve 0.32.0.
- `npm run build` и валидация tool surface — чисто.