### PR TITLE
fix: allocate session generations monotonically

### DIFF
--- a/agent/lib/sessions/group-canonical-session-repository.integration.test.ts
+++ b/agent/lib/sessions/group-canonical-session-repository.integration.test.ts
@@ -117,6 +117,51 @@ describeWithDatabase("canonical group session repository", () => {
     expect(resumed.id).toBe(canonical.id);
   });
 
+  it("allocates above newer retired generations when an older running task remains", async () => {
+    const f = await fixture();
+    const staleTask = await sessionRepository.prepareTurn(canonicalInput(f, null));
+    await sessionRepository.bindEveSession(staleTask.id, "wrun_stale_task");
+    await sessionRepository.parkSession({
+      applicationSessionId: staleTask.id,
+      pendingRequestId: "request-stale",
+      requesterTelegramUserId: "canonical-owner",
+      requesterUserId: f.userId,
+    });
+    await sessionRepository.resumePendingSession(staleTask.id, "wrun_stale_task");
+
+    const firstReplacement = await sessionRepository.prepareTurn(canonicalInput(f, null));
+    await sessionRepository.requestRotation(firstReplacement.id);
+    const newer = await sessionRepository.prepareTurn(canonicalInput(f, null));
+    await sessionRepository.bindEveSession(newer.id, "wrun_newer_task");
+    await sessionRepository.parkSession({
+      applicationSessionId: newer.id,
+      pendingRequestId: "request-newer",
+      requesterTelegramUserId: "canonical-owner",
+      requesterUserId: f.userId,
+    });
+    await sessionRepository.recordTurnCompleted(newer.id, "wrun_newer_task", false);
+
+    const [recovered, concurrent] = await Promise.all([
+      sessionRepository.prepareTurn(canonicalInput(f, null)),
+      sessionRepository.prepareTurn(canonicalInput(f, null)),
+    ]);
+
+    expect(staleTask.generation).toBe(0);
+    expect(firstReplacement.generation).toBe(1);
+    expect(newer.generation).toBe(2);
+    expect(recovered).toMatchObject({ generation: 3, rotated: true });
+    expect(concurrent.id).toBe(recovered.id);
+    expect(recovered.sandboxSessionId).toBe(staleTask.sandboxSessionId);
+    expect(recovered.continuationToken).toBe(
+      `${canonicalInput(f, null).baseContinuationToken}:osinara:3`,
+    );
+    await expect(database().query(
+      `SELECT 1 FROM conversation_sessions
+        WHERE id = $1 AND kind = 'task' AND task_state = 'running' AND retired_at IS NULL`,
+      [staleTask.id],
+    )).resolves.toMatchObject({ rowCount: 1 });
+  });
+
   it("promotes an OAuth authorization park without inventing a request identity", async () => {
     const f = await fixture();
     const canonical = await sessionRepository.prepareTurn(canonicalInput(f, 77));

--- a/agent/lib/sessions/session-repository.ts
+++ b/agent/lib/sessions/session-repository.ts
@@ -166,10 +166,10 @@ async function createInitialSession(
 async function canonicalReplacementSeed(
   client: PoolClient,
   input: PrepareSessionInput,
-): Promise<{ generation: number; threadId: string } | null> {
+): Promise<{ threadId: string } | null> {
   if (input.kind !== "canonical" || input.groupId === null) return null;
-  const result = await client.query<{ generation: number; thread_id: string }>(
-    `SELECT generation, thread_id
+  const result = await client.query<{ thread_id: string }>(
+    `SELECT thread_id
        FROM conversation_sessions
       WHERE group_id = $1
         AND telegram_forum_topic_id IS NOT DISTINCT FROM $2
@@ -179,7 +179,26 @@ async function canonicalReplacementSeed(
     [input.groupId, input.telegramForumTopicId],
   );
   const row = result.rows[0];
-  return row ? { generation: row.generation + 1, threadId: row.thread_id } : null;
+  return row ? { threadId: row.thread_id } : null;
+}
+
+async function nextThreadGeneration(client: PoolClient, threadId: string): Promise<number> {
+  // Lifecycle selection may intentionally prefer an older active task, but generation remains
+  // monotonic across the complete thread history, including retired rows.
+  const result = await client.query<{ next_generation: number | null }>(
+    `SELECT max(generation) + 1 AS next_generation
+       FROM conversation_sessions
+      WHERE thread_id = $1`,
+    [threadId],
+  );
+  const generation = result.rows[0]?.next_generation;
+  if (generation === null || generation === undefined) {
+    throw new AppError(
+      "AGENT_SESSION_GENERATION_INVALID",
+      "Не удалось определить следующую версию контекста",
+    );
+  }
+  return generation;
 }
 
 async function initialGeneration(client: PoolClient, baseToken: string): Promise<number> {
@@ -204,7 +223,7 @@ async function rotateSession(
     [current.id, input.now, deleteAfter],
   );
 
-  const generation = current.generation + 1;
+  const generation = await nextThreadGeneration(client, current.thread_id);
   const continuationToken = continuationTokenForGeneration(input.baseContinuationToken, generation);
   const result = await client.query<SessionRow>(
     `INSERT INTO conversation_sessions
@@ -277,8 +296,9 @@ export const sessionRepository = {
           );
         }
         const replacement = await canonicalReplacementSeed(client, input);
-        const generation = replacement?.generation ??
-          await initialGeneration(client, input.baseContinuationToken);
+        const generation = replacement
+          ? await nextThreadGeneration(client, replacement.threadId)
+          : await initialGeneration(client, input.baseContinuationToken);
         current = await createInitialSession(client, input, generation, replacement?.threadId);
         if (replacement) {
           await client.query(
@@ -293,7 +313,11 @@ export const sessionRepository = {
       }
       if (current.retired_at !== null) {
         trustZoneRecreated = true;
-        current = await createInitialSession(client, input, current.generation + 1);
+        current = await createInitialSession(
+          client,
+          input,
+          await nextThreadGeneration(client, current.thread_id),
+        );
       }
       assertSameScope(current, input);
 


### PR DESCRIPTION
## Problem

An addressed Telegram group turn can fail before model execution when an older active task remains in the same session thread after a lost terminal event.

`canonicalReplacementSeed` intentionally preferred that active task to preserve the sandbox thread, but also derived the next generation from the selected row. If newer retired generations already existed, the allocator could reuse an occupied continuation token and PostgreSQL rejected the insert with:

```text
duplicate key value violates unique constraint "conversation_sessions_continuation_token_key"
```

The durable ingress update then became terminally failed, while the global health endpoint remained ready.

## Fix

- Keep lifecycle selection of the thread separate from generation allocation.
- Allocate `max(generation) + 1` across the complete thread history, including retired rows.
- Use the same allocator for canonical replacement, ordinary rotation, and retired-route recovery.
- Fail with `AGENT_SESSION_GENERATION_INVALID` if an existing thread has no generation instead of inventing a default.
- Do not add retries, random suffixes, conflict suppression, schema changes, or production data mutation.

The existing group and route advisory locks continue to serialize session creation. The existing `(thread_id, generation)` index supports the aggregate lookup.

## Regression coverage

The integration test reproduces the production lifecycle through repository APIs:

1. An older task remains active in `running` state.
2. Replacement canonical generations advance and retire.
3. No active canonical remains.
4. Two concurrent canonical preparations self-heal to one generation above the complete history.
5. The stale task remains resumable and the replacement preserves its sandbox thread.

The test failed before the fix on the exact continuation-token unique constraint.

## Verification

- Targeted PostgreSQL integration test: 11 passed.
- `npm run typecheck` passed.
- Production-equivalent Docker Compose gate: 333 files passed, 1955 tests passed, 3 skipped.
- `eve build` and tool-surface validation passed.
- Read-only production query confirms the affected thread will allocate generation 14 after deployment.

No production state was changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Генерация сессии теперь использует `max(generation) + 1` по всей истории `thread_id`, включая архивные записи.
- Общий allocator применяется для canonical replacement, обычной ротации и восстановления retired-маршрута.
- При отсутствии generation у существующей thread выбрасывается `AGENT_SESSION_GENERATION_INVALID`.
- Сценарий с устаревшей активной задачей теперь восстанавливает её `sandboxSessionId` и назначает новую generation без дубликатов.
- Concurrent-вызовы `prepareTurn` возвращают одну и ту же восстановленную сессию.
- Добавлены проверки монотонного роста generation, сохранения устаревшей задачи и корректности sandbox-thread.

## Проверка

- Пройдены PostgreSQL integration-тесты.
- Пройдены type checking, Docker Compose test gate, `eve build` и tool-surface validation.
- Выполнен read-only production query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->