### PR TITLE
fix: chunk private timeline participant sync

### DIFF
--- a/agent/lib/telegram-on-message-timeline-selection.test.ts
+++ b/agent/lib/telegram-on-message-timeline-selection.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Private Telegram timeline participant-selection regression tests.
+ *
+ * Constructs covered:
+ * - A full private timeline is synchronized in repository-bounded chunks after the current entry.
+ * - Duplicate trusted entry IDs remain fail-closed even when they cross a chunk boundary.
+ */
+import { expect, it } from "vitest";
+
+import {
+  privateMessage,
+  repositories,
+  telegramContext,
+} from "./telegram-on-message.test-fixtures.js";
+import { createTelegramMessageHandler } from "./telegram-on-message.js";
+
+function timelineEntryId(sequence: number): string {
+  return `00000000-0000-4000-8000-${String(sequence).padStart(12, "0")}`;
+}
+
+function privateRepository(visibleEntryIds: string[]) {
+  const repository = repositories();
+  repository.telegram.findIdentity.mockResolvedValue({
+    familyId: "family-1",
+    role: "owner",
+    userId: "user-1",
+  });
+  repository.groupContext.prepare.mockResolvedValue({
+    cursorSequence: String(visibleEntryIds.length),
+    currentMessageEnvelope: "<current_telegram_message>test</current_telegram_message>",
+    durableMessage: "<current_telegram_message>test</current_telegram_message>",
+    omittedBeforeSequence: null,
+    timelineOmission: null,
+    visibleEntryIds,
+    visibleTimelineEntries: [],
+  });
+  repository.conversations.syncTimelineParticipants.mockImplementation(
+    async (_conversationId, entryIds) => {
+      if (entryIds.length === 0 || entryIds.length > 50 || new Set(entryIds).size !== entryIds.length) {
+        throw new Error("AGENT_CONVERSATION_TIMELINE_SELECTION_INVALID");
+      }
+      return [];
+    },
+  );
+  return repository;
+}
+
+it("chunks a full private timeline after synchronizing the current participant", async () => {
+  const currentEntryId = timelineEntryId(11);
+  const repository = privateRepository(
+    Array.from({ length: 84 }, (_, index) => timelineEntryId(index + 1)),
+  );
+  const handler = createTelegramMessageHandler(repository);
+
+  await expect(handler(telegramContext().context, privateMessage("куку"))).resolves.toBeTruthy();
+
+  expect(repository.conversations.syncTimelineParticipants.mock.calls.map(([, entryIds]) => entryIds.length))
+    .toEqual([1, 50, 33]);
+  const additionalEntryIds = repository.conversations.syncTimelineParticipants.mock.calls
+    .slice(1)
+    .flatMap(([, entryIds]) => entryIds);
+  expect(additionalEntryIds).not.toContain(currentEntryId);
+  expect(new Set(additionalEntryIds).size).toBe(additionalEntryIds.length);
+});
+
+it("rejects duplicate private timeline entries across chunk boundaries", async () => {
+  const visibleEntryIds = Array.from({ length: 52 }, (_, index) => timelineEntryId(index + 1));
+  visibleEntryIds[51] = visibleEntryIds[0]!;
+  const repository = privateRepository(visibleEntryIds);
+  const handler = createTelegramMessageHandler(repository);
+
+  await expect(handler(telegramContext().context, privateMessage("куку")))
+    .rejects.toThrowError(/AGENT_CONVERSATION_TIMELINE_SELECTION_INVALID/u);
+});

--- a/agent/lib/telegram-on-message.ts
+++ b/agent/lib/telegram-on-message.ts
@@ -19,10 +19,11 @@ import type {
 } from "eve/channels/telegram";
 
 import type { StoredTelegramAttachment } from "./attachments/telegram-workspace-attachments.js";
-import { isAppError } from "./app-error.js";
+import { AppError, isAppError } from "./app-error.js";
 import { bindTelegramConversationTimeline } from "./telegram-conversation-timeline.js";
 import { evaluateConversationAccess } from "./family-access.js";
 import { parseInvitationStartCommand } from "./invitation-code.js";
+import { CONVERSATION_TIMELINE_SELECTION_MAX_ENTRIES } from "./memory-config.js";
 import { handleTelegramEnrollmentBoundary } from "./telegram-enrollment-boundary.js";
 import { groupCanonicalContinuationToken } from "./sessions/group-canonical-token.js";
 import {
@@ -396,10 +397,30 @@ export function createTelegramMessageHandler(repositories: TelegramMessageReposi
         })
       : preparedGroupTurnContext;
     if (!group) {
-      await repositories.conversations.syncTimelineParticipants(
-        conversation.id,
-        groupTurnContext.visibleEntryIds,
+      // The current participant was synchronized before context preparation. Remaining private
+      // history can exceed the repository's bounded selection contract, so synchronize it in order.
+      if (
+        groupTurnContext.visibleEntryIds.length === 0 ||
+        new Set(groupTurnContext.visibleEntryIds).size !== groupTurnContext.visibleEntryIds.length
+      ) {
+        throw new AppError(
+          "AGENT_CONVERSATION_TIMELINE_SELECTION_INVALID",
+          "Набор записей разговора пуст или содержит повторы",
+        );
+      }
+      const additionalEntryIds = groupTurnContext.visibleEntryIds.filter(
+        (entryId) => entryId !== inboundTimeline.entryId,
       );
+      for (
+        let offset = 0;
+        offset < additionalEntryIds.length;
+        offset += CONVERSATION_TIMELINE_SELECTION_MAX_ENTRIES
+      ) {
+        await repositories.conversations.syncTimelineParticipants(
+          conversation.id,
+          additionalEntryIds.slice(offset, offset + CONVERSATION_TIMELINE_SELECTION_MAX_ENTRIES),
+        );
+      }
     }
     const turnResult = buildTelegramTurnResult({
       access,

--- a/docs/releases/v0.17.1.md
+++ b/docs/releases/v0.17.1.md
@@ -1,0 +1,30 @@
+# Osinara v0.17.1
+
+Patch-релиз восстанавливает ответы в длинных личных Telegram-разговорах после установки `v0.17.0`.
+
+## Причина
+
+- Private turn добавляет текущее сообщение отдельно от видимой истории, а затем синхронизирует
+  Telegram participants по идентификаторам видимых timeline entries.
+- Контекст разговора может содержать больше 50 entries, тогда как один repository selection
+  намеренно ограничен 50 идентификаторами.
+- Handler передавал всю private history одним запросом. На длинном owner-чате это завершало ingress
+  ошибкой `AGENT_CONVERSATION_TIMELINE_SELECTION_INVALID` до запуска модели и оставляло пользователя
+  без ответа.
+
+## Исправление
+
+- Текущий participant по-прежнему синхронизируется отдельно до подготовки контекста.
+- Дополнительная private history сохраняет хронологический порядок, исключает уже обработанный
+  current entry и делится на repository-bounded chunks по 50 идентификаторов.
+- Полная selection до chunking остаётся fail-closed: пустой набор и дубли идентификаторов по-прежнему
+  отклоняются, включая дубли на границе двух chunks.
+- Failed durable updates не переигрываются автоматически. После установки релиза пользователь
+  отправляет новое сообщение, чтобы создать новый turn без риска повторного model call.
+
+## Проверка
+
+- Regression сначала воспроизвёл production failure на private selection из 84 entries.
+- Отдельный тест защищает duplicate entry IDs, расположенные по разные стороны chunk boundary.
+- Полный Docker Compose gate проверяет unit/integration contracts, PostgreSQL migrations, typecheck,
+  Eve build и production tool surface перед публикацией immutable release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "osinara-family-agent",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "hasInstallScript": true,
       "dependencies": {
         "@ai-sdk/anthropic": "4.0.37",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osinara-family-agent",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "type": "module",
   "imports": {


### PR DESCRIPTION
## Summary

- chunk additional private timeline participant synchronization into the repository limit of 50 entries
- avoid synchronizing the already processed current entry twice
- preserve fail-closed rejection for empty and duplicate trusted selections, including cross-chunk duplicates
- prepare patch release `v0.17.1`

## Production evidence

- production update `57061835` failed before model execution with `AGENT_CONVERSATION_TIMELINE_SELECTION_INVALID`
- the affected private owner turn exposed more entries than the repository accepts in one selection
- durable ingress correctly terminalized the update after one dispatch attempt and did not retry it

## Verification

- regression test failed against the previous one-shot synchronization path
- cross-chunk duplicate regression also failed before the global invariant check
- full Docker Compose gate passed: 2012 tests passed, 3 skipped
- TypeScript typecheck and Eve build passed inside the same gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Синхронизация участников приватной timeline теперь выполняется чанками до 50 записей.
- Текущая запись исключается из повторной синхронизации.
- Пустые и дублирующиеся доверенные выборки отклоняются с ошибкой `AGENT_CONVERSATION_TIMELINE_SELECTION_INVALID`.
- Добавлена проверка дублей между чанками.
- Добавлены регрессионные тесты для chunking и дубликатов.
- Версия пакета обновлена до `0.17.1`.

## Проверки

- Docker Compose: 2012 тестов пройдено, 3 пропущено.
- TypeScript typecheck пройден.
- Сборка Eve пройдена.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->