### PR TITLE
perf(compose): healthcheck раз в 15–30 с вместо 5 с

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,9 +7,9 @@ services:
       POSTGRES_USER: osinara
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U osinara -d osinara"]
-      interval: 5s
+      interval: 15s
       timeout: 3s
-      retries: 20
+      retries: 7
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data
@@ -68,9 +68,9 @@ services:
       WORKFLOW_QUEUE_NAMESPACE: eve6f73696e6172612d66616d696c792d6167656e74
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000/eve/v1/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
-      interval: 5s
+      interval: 30s
       timeout: 3s
-      retries: 72
+      retries: 12
     restart: unless-stopped
     networks:
       - default
@@ -114,9 +114,9 @@ services:
         condition: service_completed_successfully
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:8080/health').then(r=>{if(!r.ok)process.exit(1)})"]
-      interval: 5s
+      interval: 30s
       timeout: 3s
-      retries: 20
+      retries: 4
     environment:
       SANDBOX_RUNTIME_IMAGE: osinara-sandbox-runtime:local
     networks:
@@ -141,9 +141,9 @@ services:
       - ALL
     healthcheck:
       test: ["CMD", "node", "-e", "require('node:net').connect(3128,'127.0.0.1').on('connect',function(){this.destroy();process.exit(0)}).on('error',()=>process.exit(1))"]
-      interval: 5s
+      interval: 30s
       timeout: 3s
-      retries: 20
+      retries: 4
     networks:
       - default
       - sandbox-egress
@@ -178,9 +178,9 @@ services:
       OMP_NUM_THREADS: "2"
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://localhost/health"]
-      interval: 5s
+      interval: 15s
       timeout: 5s
-      retries: 120
+      retries: 40
     restart: unless-stopped
     volumes:
       - memory-embedding-model-e5:/data
@@ -208,9 +208,9 @@ services:
     network_mode: none
     healthcheck:
       test: ["CMD", "node", "-e", "const fs=require('node:fs'),p='/tmp/osinara-memory-extraction-worker-ready';if(!fs.existsSync(p)||Date.now()-fs.statSync(p).mtimeMs<30000)process.exit(1)"]
-      interval: 5s
+      interval: 30s
       timeout: 3s
-      retries: 120
+      retries: 20
     restart: unless-stopped
 
   telegram-ingress-worker:


### PR DESCRIPTION
Независимый маленький PR от `develop`.

Четыре из семи healthcheck запускают процесс `node` каждые 5 секунд; на одном vCPU это 48 запусков в минуту ради сервисов, которые падают редко. Интервалы: 30 с для проверок через node, 15 с для `pg_isready`, `curl` и `wget`; `retries` пересчитаны так, что бюджет старта каждого сервиса не изменился (agent 72×5 с → 12×30 с, memory-embedding 120×5 с → 40×15 с и т. д.).

Только `compose.yaml`; `compose.installation.json` установщика при желании можно привести к тем же значениям.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01931GW46FUdEt9v7Lk8MyEq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Изменения

- Увеличены интервалы healthcheck в `compose.yaml`:
  - `node` — до 30 секунд;
  - `pg_isready`, `curl` и `wget` — до 15 секунд.
- Скорректированы значения `retries` для сохранения прежнего бюджета запуска сервисов.
- Аналогичные значения применены в `compose.installation.json`.
- Таймауты проверок не изменены.

Изменения сокращают количество запусков процессов на одновэкапном хосте.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->